### PR TITLE
FF line wrapper simple optimisation

### DIFF
--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -2,6 +2,8 @@ package org.uniprot.core.flatfile.writer.impl;
 
 import java.util.*;
 
+import static org.uniprot.core.flatfile.writer.impl.FFLineConstant.LINE_LENGTH;
+
 public class FFLineWrapper {
     private static final String[] NOT_WRAPPED = {"->", "-->", "- ", "EC ", "TC ", "ECO:"};
     //	private final static String[] DASHS ={"->", "-->", "- "};
@@ -15,7 +17,7 @@ public class FFLineWrapper {
 
     public static StringBuilder wrap(
             StringBuilder wrapThis, String[] separators, String linePrefix) {
-        return wrap(wrapThis, separators, linePrefix, FFLineConstant.LINE_LENGTH);
+        return wrap(wrapThis, separators, linePrefix, LINE_LENGTH);
     }
 
     public static StringBuilder wrap(
@@ -36,7 +38,7 @@ public class FFLineWrapper {
     }
 
     public static List<String> buildLines(String wrapThis, String separator, String linePrefix) {
-        return buildLines(wrapThis, separator, linePrefix, FFLineConstant.LINE_LENGTH);
+        return buildLines(wrapThis, separator, linePrefix, LINE_LENGTH);
     }
 
     public static List<String> buildLines(
@@ -124,7 +126,7 @@ public class FFLineWrapper {
             count++;
             if (wrapping
                     && ((line.length() + token.length() + separator.length())
-                            >= FFLineConstant.LINE_LENGTH)) {
+                            >= LINE_LENGTH)) {
                 lines.add(line.toString());
                 line = new StringBuilder(linePrefix);
             } else if (count != 1) line.append(space);
@@ -363,7 +365,11 @@ public class FFLineWrapper {
         int spacePos = Integer.MAX_VALUE;
 
         int charFinds = 0;
-        for (int i = index; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
+        int endOfLine = val.length();
+        if (endOfLine > LINE_LENGTH) {
+            endOfLine = LINE_LENGTH;
+        }
+        for (int i = index; i < endOfLine; i++) {
             if (charFinds < 4) {
                 char currentChar = val.charAt(i);
                 if (currentChar == ',' && commaPos == Integer.MAX_VALUE) {

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -8,6 +8,7 @@ public class FFLineWrapper {
     private static final String DASH = "-";
 
     public static StringBuilder wrap(StringBuilder wrapThis, String separator, String linePrefix) {
+
         String[] seps = {separator};
         return wrap(wrapThis, seps, linePrefix);
     }
@@ -356,43 +357,42 @@ public class FFLineWrapper {
     private static String getDigitMap(String val, int index) {
         int nextIndex = -1;
 
-        int printableChars = 126 - 32;
-        int[] charToPosition = new int[printableChars];
-        Arrays.fill(charToPosition, -1);
+        int commaPos = -1;
+        int semiColonPos = -1;
+        int fullStopPos = -1;
+        int spacePos = -1;
+
         for (int i = 0; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
-            if (charToPosition[val.charAt(i) - 32] == -1) {
-                charToPosition[val.charAt(i) - 32] = index + i;
+            char currentChar = val.charAt(i);
+            if (currentChar == ',' && commaPos == -1) {
+                commaPos = index + i;
+            } else if (currentChar == ';' && semiColonPos == -1) {
+                semiColonPos = index + i;
+            } else if (currentChar == '.' && fullStopPos == -1) {
+                fullStopPos = index + i;
+            } else if (currentChar == ' ' && spacePos == -1) {
+                spacePos = index + i;
             }
         }
 
-        //        Map<Character, Integer> characterPositions = new HashMap<>();
-
-        //        for (int i = 0; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
-        //            if (!characterPositions.containsKey(val.charAt(i))) {
-        //                characterPositions.put(val.charAt(i), index + i);
-        //            }
-        //        }
-        if (charToPosition[' ' - 32] != -1) {
-            nextIndex = charToPosition[' ' - 32];
+        if (spacePos != -1) {
+            nextIndex = spacePos;
         }
-        if (charToPosition[',' - 32] != -1) {
-            int nextIndex2 = charToPosition[',' - 32];
+        if (commaPos != -1) {
             if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
+                nextIndex = commaPos;
+            } else nextIndex = Math.min(nextIndex, commaPos);
         }
 
-        if (charToPosition[';' - 32] != -1) {
-            int nextIndex2 = charToPosition[';' - 32];
+        if (semiColonPos != -1) {
             if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
+                nextIndex = semiColonPos;
+            } else nextIndex = Math.min(nextIndex, semiColonPos);
         }
-        if (charToPosition['.' - 32] != -1) {
-            int nextIndex2 = charToPosition['.' - 32];
+        if (fullStopPos != -1) {
             if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
+                nextIndex = fullStopPos;
+            } else nextIndex = Math.min(nextIndex, fullStopPos);
         }
         if (nextIndex == -1) return null;
 

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -1,8 +1,8 @@
 package org.uniprot.core.flatfile.writer.impl;
 
-import java.util.*;
-
 import static org.uniprot.core.flatfile.writer.impl.FFLineConstant.LINE_LENGTH;
+
+import java.util.*;
 
 public class FFLineWrapper {
     private static final String[] NOT_WRAPPED = {"->", "-->", "- ", "EC ", "TC ", "ECO:"};
@@ -125,8 +125,7 @@ public class FFLineWrapper {
         for (String token : tokens) {
             count++;
             if (wrapping
-                    && ((line.length() + token.length() + separator.length())
-                            >= LINE_LENGTH)) {
+                    && ((line.length() + token.length() + separator.length()) >= LINE_LENGTH)) {
                 lines.add(line.toString());
                 line = new StringBuilder(linePrefix);
             } else if (count != 1) line.append(space);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -356,31 +356,40 @@ public class FFLineWrapper {
     private static String getDigitMap(String val, int index) {
         int nextIndex = -1;
 
-        Map<Character, Integer> characterPositions = new HashMap<>();
-
+        int printableChars = 126 - 32;
+        int[] charToPosition = new int[printableChars];
+        Arrays.fill(charToPosition, -1);
         for (int i = 0; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
-            if (!characterPositions.containsKey(val.charAt(i))) {
-                characterPositions.put(val.charAt(i), index + i);
+            if (charToPosition[val.charAt(i) - 32] == -1) {
+                charToPosition[val.charAt(i) - 32] = index + i;
             }
         }
-        if (characterPositions.containsKey(' ')) {
-            nextIndex = characterPositions.get(' ');
+
+        //        Map<Character, Integer> characterPositions = new HashMap<>();
+
+        //        for (int i = 0; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
+        //            if (!characterPositions.containsKey(val.charAt(i))) {
+        //                characterPositions.put(val.charAt(i), index + i);
+        //            }
+        //        }
+        if (charToPosition[' ' - 32] != -1) {
+            nextIndex = charToPosition[' ' - 32];
         }
-        if (characterPositions.containsKey(',')) {
-            int nextIndex2 = characterPositions.get(',');
+        if (charToPosition[',' - 32] != -1) {
+            int nextIndex2 = charToPosition[',' - 32];
             if (nextIndex == -1) {
                 nextIndex = nextIndex2;
             } else nextIndex = Math.min(nextIndex, nextIndex2);
         }
 
-        if (characterPositions.containsKey(';')) {
-            int nextIndex2 = characterPositions.get(';');
+        if (charToPosition[';' - 32] != -1) {
+            int nextIndex2 = charToPosition[';' - 32];
             if (nextIndex == -1) {
                 nextIndex = nextIndex2;
             } else nextIndex = Math.min(nextIndex, nextIndex2);
         }
-        if (characterPositions.containsKey('.')) {
-            int nextIndex2 = characterPositions.get('.');
+        if (charToPosition['.' - 32] != -1) {
+            int nextIndex2 = charToPosition['.' - 32];
             if (nextIndex == -1) {
                 nextIndex = nextIndex2;
             } else nextIndex = Math.min(nextIndex, nextIndex2);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -9,29 +9,6 @@ public class FFLineWrapper {
     //	private final static String[] DASHS ={"->", "-->", "- "};
     private static final String DASH = "-";
 
-    public static StringBuilder wrap(StringBuilder wrapThis, String separator, String linePrefix) {
-
-        String[] seps = {separator};
-        return wrap(wrapThis, seps, linePrefix);
-    }
-
-    public static StringBuilder wrap(
-            StringBuilder wrapThis, String[] separators, String linePrefix) {
-        return wrap(wrapThis, separators, linePrefix, LINE_LENGTH);
-    }
-
-    public static StringBuilder wrap(
-            StringBuilder wrapThis, String[] separators, String linePrefix, int lineLength) {
-        StringBuilder sb = new StringBuilder();
-        boolean isFirst = true;
-        for (String line : buildLines(wrapThis.toString(), separators, linePrefix, lineLength)) {
-            if (!isFirst) sb.append('\n');
-            sb.append(line);
-            isFirst = false;
-        }
-        return sb;
-    }
-
     public static List<String> buildLines(
             StringBuilder wrapThis, String separator, String linePrefix) {
         return buildLines(wrapThis.toString(), separator, linePrefix);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -321,41 +321,6 @@ public class FFLineWrapper {
         return false;
     }
 
-    private static String getDigit(String val, int index) {
-        int nextIndex = -1;
-
-        if (val.indexOf(' ', index) != -1) {
-            nextIndex = val.indexOf(' ', index);
-        }
-        if (val.indexOf(',', index) != -1) {
-            int nextIndex2 = val.indexOf(',', index);
-            if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
-        }
-
-        if (val.indexOf(';', index) != -1) {
-            int nextIndex2 = val.indexOf(';', index);
-            if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
-        }
-        if (val.indexOf('.', index) != -1) {
-            int nextIndex2 = val.indexOf('.', index);
-            if (nextIndex == -1) {
-                nextIndex = nextIndex2;
-            } else nextIndex = Math.min(nextIndex, nextIndex2);
-        }
-        if (nextIndex == -1) return null;
-
-        String sub = val.substring(index + 1, nextIndex);
-        for (int i = 0; i < sub.length(); i++) {
-            char c = sub.charAt(i);
-            if (!Character.isDigit(c)) return null;
-        }
-        return sub;
-    }
-
     private static String getDigitMap(String val, int index) {
         int nextIndex = -1;
 

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/FFLineWrapper.java
@@ -357,39 +357,46 @@ public class FFLineWrapper {
     private static String getDigitMap(String val, int index) {
         int nextIndex = -1;
 
-        int commaPos = -1;
-        int semiColonPos = -1;
-        int fullStopPos = -1;
-        int spacePos = -1;
+        int commaPos = Integer.MAX_VALUE;
+        int semiColonPos = Integer.MAX_VALUE;
+        int fullStopPos = Integer.MAX_VALUE;
+        int spacePos = Integer.MAX_VALUE;
 
-        for (int i = 0; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
-            char currentChar = val.charAt(i);
-            if (currentChar == ',' && commaPos == -1) {
-                commaPos = index + i;
-            } else if (currentChar == ';' && semiColonPos == -1) {
-                semiColonPos = index + i;
-            } else if (currentChar == '.' && fullStopPos == -1) {
-                fullStopPos = index + i;
-            } else if (currentChar == ' ' && spacePos == -1) {
-                spacePos = index + i;
+        int charFinds = 0;
+        for (int i = index; i < val.length() && i < FFLineConstant.LINE_LENGTH; i++) {
+            if (charFinds < 4) {
+                char currentChar = val.charAt(i);
+                if (currentChar == ',' && commaPos == Integer.MAX_VALUE) {
+                    commaPos = i;
+                    charFinds++;
+                } else if (currentChar == ';' && semiColonPos == Integer.MAX_VALUE) {
+                    semiColonPos = i;
+                    charFinds++;
+                } else if (currentChar == '.' && fullStopPos == Integer.MAX_VALUE) {
+                    fullStopPos = i;
+                    charFinds++;
+                } else if (currentChar == ' ' && spacePos == Integer.MAX_VALUE) {
+                    spacePos = i;
+                    charFinds++;
+                }
             }
         }
 
-        if (spacePos != -1) {
+        if (spacePos != Integer.MAX_VALUE) {
             nextIndex = spacePos;
         }
-        if (commaPos != -1) {
+        if (commaPos != Integer.MAX_VALUE) {
             if (nextIndex == -1) {
                 nextIndex = commaPos;
             } else nextIndex = Math.min(nextIndex, commaPos);
         }
 
-        if (semiColonPos != -1) {
+        if (semiColonPos != Integer.MAX_VALUE) {
             if (nextIndex == -1) {
                 nextIndex = semiColonPos;
             } else nextIndex = Math.min(nextIndex, semiColonPos);
         }
-        if (fullStopPos != -1) {
+        if (fullStopPos != Integer.MAX_VALUE) {
             if (nextIndex == -1) {
                 nextIndex = fullStopPos;
             } else nextIndex = Math.min(nextIndex, fullStopPos);

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/integration/FlatfileRoundTripIT.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/integration/FlatfileRoundTripIT.java
@@ -91,7 +91,8 @@ class FlatfileRoundTripIT {
         //                "/entryIT/O93383.txl, false", // line dash issue
         "/entryIT/Q9U299.txl, false",
         "/entryIT/Q401N2.txl, false",
-        "/entryIT/P87498.dat, true"
+        "/entryIT/P87498.dat, true",
+        "/entryIT/A0A663DJA2.dat, true"
     })
     void roundTripTest(String fileName, boolean isPublic) {
         testFile(fileName, isPublic);

--- a/ff-parser/src/test/resources/entryIT/A0A663DJA2.dat
+++ b/ff-parser/src/test/resources/entryIT/A0A663DJA2.dat
@@ -1,0 +1,3568 @@
+ID   A0A663DJA2_SARS2        Unreviewed;        38 AA.
+AC   A0A663DJA2;
+DT   22-APR-2020, integrated into UniProtKB/TrEMBL.
+DT   22-APR-2020, sequence version 1.
+DT   12-AUG-2020, entry version 3.
+DE   SubName: Full=ORF10 proteiin {ECO:0000313|EMBL:QHZ00366.1};
+DE   SubName: Full=ORF10 protein {ECO:0000313|EMBL:QHI42199.1, ECO:0000313|EMBL:QHS34554.1};
+GN   Name=ORF10 {ECO:0000313|EMBL:QHI42199.1};
+GN   Synonyms=orf10 {ECO:0000313|EMBL:QHS34554.1};
+OS   Severe acute respiratory syndrome coronavirus 2 (2019-nCoV) (SARS-CoV-2).
+OC   Viruses; Riboviria; Nidovirales; Cornidovirineae; Coronaviridae;
+OC   Orthocoronavirinae; Betacoronavirus; Sarbecovirus.
+OX   NCBI_TaxID=2697049 {ECO:0000313|EMBL:QHI42199.1, ECO:0000313|Proteomes:UP000464024};
+OH   NCBI_TaxID=9606; Homo sapiens (Human).
+RN   [1] {ECO:0000313|EMBL:QIA98562.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ITA/INMI1/2020 {ECO:0000313|EMBL:QIA98562.1};
+RX   PubMed=32229288;
+RA   Capobianchi M.R., Rueca M., Messina F., Giombini E., Carletti F.,
+RA   Colavita F., Castilletti C., Lalle E., Bordi L., Vairo F., Nicastri E.,
+RA   Ippolito G., Maria Gruber C.E., Bartolini B.;
+RT   "Molecular characterization of SARS-CoV-2 from the first case of COVID-19
+RT   in Italy.";
+RL   Clin. Microbiol. Infect. 0:0-0(2020).
+RN   [2] {ECO:0000313|EMBL:QIB84681.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/NPL/61-TW/2020 {ECO:0000313|EMBL:QIB84681.1};
+RX   PubMed=32057299;
+RA   Bastola A., Sah R., Rodriguez-Morales A.J., Lal B.K., Jha R., Ojha H.C.,
+RA   Shrestha B., Chu D.K.W., Poon L.L.M., Costello A., Morita K., Pandey B.D.;
+RT   "The first 2019 novel coronavirus case in Nepal.";
+RL   Lancet Infect. Dis. 0:0-0(2020).
+RN   [3] {ECO:0000313|EMBL:QHI42199.1, ECO:0000313|Proteomes:UP000464024}
+RP   NUCLEOTIDE SEQUENCE [LARGE SCALE GENOMIC DNA].
+RC   STRAIN=Wuhan-Hu-1 {ECO:0000313|EMBL:QHI42199.1};
+RX   PubMed=32015508; DOI=10.1038/s41586-020-2008-3;
+RA   Wu F., Zhao S., Yu B., Chen Y.M., Wang W., Song Z.G., Hu Y., Tao Z.W.,
+RA   Tian J.H., Pei Y.Y., Yuan M.L., Zhang Y.L., Dai F.H., Liu Y., Wang Q.M.,
+RA   Zheng J.J., Xu L., Holmes E.C., Zhang Y.Z.;
+RT   "A new coronavirus associated with human respiratory disease in China.";
+RL   Nature 579:265-269(2020).
+RN   [4] {ECO:0000313|EMBL:QIX14045.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IME-HZ01/2020
+RC   {ECO:0000313|EMBL:QIX14045.1};
+RX   PubMed=32222421;
+RA   Zhang X.A., Fan H., Qi R.Z., Zheng W., Zheng K., Gong J.H., Fang L.Q.,
+RA   Liu W.;
+RT   "Importing coronavirus disease 2019 (COVID-19) into China after
+RT   international air travel.";
+RL   Travel Med Infect Dis 101620:0-0(2020).
+RN   [5] {ECO:0000313|EMBL:QHR84457.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=Australia/VIC01/2020 {ECO:0000313|EMBL:QHR84457.1};
+RA   Caly L., Seemann T., Schultz M., Druce J., Taiaroa G.;
+RT   "Complete genome sequence of first Australian case of the 2019-nCoV corona
+RT   virus, Australia/VIC01/2020.";
+RL   Submitted (JAN-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [6] {ECO:0000313|EMBL:QHU79182.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=NCoV-FIN-29-Jan-2020 {ECO:0000313|EMBL:QHU79182.1};
+RA   Smura T., Kuivanen S., Broas M., Peltola J., Kallio-Kokko H., Vapalahti O.;
+RT   "2019-nCoV Finland.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [7] {ECO:0000313|EMBL:QHZ00407.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-MA1/2020 {ECO:0000313|EMBL:QHZ00407.1};
+RA   Paden C.R., Zhang J., Queen K., Li Y., Tao Y., Uehara A., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "2019-nCoV Massachusetts.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [8] {ECO:0000313|EMBL:QHU79202.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-WA1-A12/2020 {ECO:0000313|EMBL:QHU79202.1}, and
+RC   2019-nCoV/USA-WA1-F6/2020 {ECO:0000313|EMBL:QHU79212.1};
+RA   Queen K., Tamin A., Harcourt J., Tao Y., Paden C.R., Zhang J., Li Y.,
+RA   Uehara A., Lu X., Kamili S., Gautam R., Wang H., Murray J.R., Gerber S.I.,
+RA   Lindstrom S., Thornburg N., Tong S.;
+RT   "2019-NCoV WA1 culture isolates.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [9] {ECO:0000313|EMBL:QIA20053.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/Yunnan-01/2020
+RC   {ECO:0000313|EMBL:QIA20053.1};
+RA   Fu X., Li D., Sun Y.;
+RT   "A novel coronavirus associated with a respiratory disease in Kunming of
+RT   Yunnan province, China.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [10] {ECO:0000313|EMBL:BCA25652.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/Japan/KY/V-029/2020 {ECO:0000313|EMBL:BCA25652.1};
+RA   Sekizuka T., Matsuyama S., Shirato K., Nao N., Itokawa K., Hashino M.,
+RA   Tanaka R., Yatsu K., Suzuki T., Suzuki M., Hasegawa H., Wakita T.,
+RA   Takeda M., Kuroda M.;
+RT   "Complete genome sequence of Wuhan seafood market pneumonia virus 2019-
+RT   nCoV/Japan/KY/V-029/2020 isolated from a patient in Japan.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [11] {ECO:0000313|EMBL:BCA25662.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/Japan/TY/WK-012/2020 {ECO:0000313|EMBL:BCA25662.1};
+RA   Sekizuka T., Matsuyama S., Shirato K., Nao N., Itokawa K., Hashino M.,
+RA   Tanaka R., Yatsu K., Suzuki T., Suzuki M., Hasegawa H., Wakita T.,
+RA   Takeda M., Kuroda M.;
+RT   "Complete genome sequence of Wuhan seafood market pneumonia virus 2019-
+RT   nCoV/Japan/TY/WK-012/2020 isolated from a patient in Japan.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [12] {ECO:0000313|EMBL:BCA25672.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/Japan/TY/WK-501/2020 {ECO:0000313|EMBL:BCA25672.1};
+RA   Sekizuka T., Matsuyama S., Shirato K., Nao N., Itokawa K., Hashino M.,
+RA   Tanaka R., Yatsu K., Suzuki T., Suzuki M., Hasegawa H., Wakita T.,
+RA   Takeda M., Kuroda M.;
+RT   "Complete genome sequence of Wuhan seafood market pneumonia virus 2019-
+RT   nCoV/Japan/TY/WK-501/2020 isolated from a patient in Japan.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [13] {ECO:0000313|EMBL:BCA25682.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/Japan/TY/WK-521/2020 {ECO:0000313|EMBL:BCA25682.1};
+RA   Sekizuka T., Matsuyama S., Shirato K., Nao N., Itokawa K., Hashino M.,
+RA   Tanaka R., Yatsu K., Suzuki T., Suzuki M., Hasegawa H., Wakita T.,
+RA   Takeda M., Kuroda M.;
+RT   "Complete genome sequence of Wuhan seafood market pneumonia virus 2019-
+RT   nCoV/Japan/TY/WK-521/2020 isolated from a patient in Japan.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [14] {ECO:0000313|EMBL:BCA87369.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/Hu/DP/Kng/19-020 {ECO:0000313|EMBL:BCA87369.1}, and
+RC   SARS-CoV-2/Hu/DP/Kng/19-027 {ECO:0000313|EMBL:BCA87379.1};
+RA   Hishiki T., Suzuki R., Sakuragi J., Usui K., Tanaka Y., Kawai J., Kogo Y.,
+RA   Matsuki Y., An T., Hayashizaki Y., Takasaki T.;
+RT   "Development of SmartAmp system for SARS-CoV-2 using viruses isolated from
+RT   patients in a Cruse Ship.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [15] {ECO:0000313|EMBL:QHZ00366.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=HZ-1 {ECO:0000313|EMBL:QHZ00366.1};
+RA   Yu H., Li J., Yu X., Wang H., Pan J.;
+RT   "Genomic Analysis of First Case of 2019-ncov in Hangzhou, Zhejiang China.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [16] {ECO:0000313|EMBL:QHZ00387.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SNU01 {ECO:0000313|EMBL:QHZ00387.1};
+RA   Park W.B., Kwon N.-J., Choi S.-J., Kang C.K., Choe P.G., Kim J.Y., Yun J.,
+RA   Lee G.-W., Seong M.-W., Kim N., Seo J.-S., Oh M.-D.;
+RT   "Isolation of 2019 novel coronavirus from a patient imported into Korea
+RT   from Wuhan, China.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [17] {ECO:0000313|EMBL:QHZ87600.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CA6/2020 {ECO:0000313|EMBL:QHZ87600.1};
+RA   Zhang J., Queen K., Li Y., Tao Y., Uehara A., Paden C.R., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "nCoV-2019 California.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [18] {ECO:0000313|EMBL:QHZ87590.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-IL2/2020 {ECO:0000313|EMBL:QHZ87590.1};
+RA   Li Y., Zhang J., Queen K., Tao Y., Uehara A., Paden C.R., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "nCoV-2019 Illinois case.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [19] {ECO:0000313|EMBL:QHW06067.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CA5/2020 {ECO:0000313|EMBL:QHW06067.1};
+RA   Tao Y., Queen K., Zhang J., Li Y., Uehara A., Paden C.R., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "Novel coronavirus 2019 California sequence.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [20] {ECO:0000313|EMBL:QHW06047.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CA3/2020 {ECO:0000313|EMBL:QHW06047.1}, and
+RC   2019-nCoV/USA-CA4/2020 {ECO:0000313|EMBL:QHW06057.1};
+RA   Queen K., Zhang J., Li Y., Tao Y., Uehara A., Paden C.R., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "Novel coronavirus 2019 sequences from California.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [21] {ECO:0000313|EMBL:QHZ00397.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-WI1/2020 {ECO:0000313|EMBL:QHZ00397.1};
+RA   Zhang J., Uehara A., Queen K., Li Y., Tao Y., Paden C.R., Lu X., Lynch B.,
+RA   Sakthivel S.K.K., Whitaker B.L., Kamili S., Wang L., Murray J.R.,
+RA   Gerber S.I., Lindstrom S., Tong S.;
+RT   "Novel coronavirus sequence Wisconsin.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [22] {ECO:0000313|EMBL:QID98802.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CA9/2020 {ECO:0000313|EMBL:QID98802.1};
+RA   Queen K., Uehara A., Zhang J., Li Y., Tao Y., Paden C.R., Wang H.,
+RA   Kamili S., Lu X., Lynch B., Sakthivel S.K.K., Whitaker B.L., Wang L.,
+RA   Murray J.R., Padilla J., Lee J., Gerber S.I., Lindstrom S., Tong S.;
+RT   "US case California.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [23] {ECO:0000313|EMBL:QID21056.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CA7/2020 {ECO:0000313|EMBL:QID21056.1},
+RC   2019-nCoV/USA-CA8/2020 {ECO:0000313|EMBL:QID21066.1}, and
+RC   2019-nCoV/USA-TX1/2020 {ECO:0000313|EMBL:QID21076.1};
+RA   Queen K., Uehara A., Zhang J., Li Y., Tao Y., Paden C.R., Wang H.,
+RA   Kamili S., Lu X., Lynch B., Sakthivel S.K.K., Whitaker B.L., Wang L.,
+RA   Murray J.R., Gerber S.I., Lindstrom S., Tong S.;
+RT   "US cases.";
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [24] {ECO:0000313|EMBL:QHS34554.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/IND/29/2020 {ECO:0000313|EMBL:QHS34554.1};
+RA   Yadav P.D., Potdar V., Abraham P.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [25] {ECO:0000313|EMBL:QIG55873.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/HKG/HKU-902a/2020
+RC   {ECO:0000313|EMBL:QIG55873.1}, SARS-CoV-2/human/HKG/HKU-902b/2020
+RC   {ECO:0000313|EMBL:QIG55883.1}, SARS-CoV-2/human/HKG/HKU-903a/2020
+RC   {ECO:0000313|EMBL:QIG55893.1}, SARS-CoV-2/human/HKG/HKU-903b/2020
+RC   {ECO:0000313|EMBL:QIG55903.1}, SARS-CoV-2/human/HKG/HKU-907a/2020
+RC   {ECO:0000313|EMBL:QIG55913.1}, SARS-CoV-2/human/HKG/HKU-907b/2020
+RC   {ECO:0000313|EMBL:QIG55923.1}, SARS-CoV-2/human/HKG/HKU-908a/2020
+RC   {ECO:0000313|EMBL:QIG55933.1}, and SARS-CoV-2/human/HKG/HKU-908b/2020
+RC   {ECO:0000313|EMBL:QIG55943.1};
+RA   To K.K.W., Yuen K.-Y.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [26] {ECO:0000313|EMBL:QIE07469.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IQTC02/2020 {ECO:0000313|EMBL:QIE07469.1};
+RA   Shi Y., Zheng K., Sun J., Huang J., Zhu A., Zhuang Z., Dai J., Chen Z.,
+RA   Sun F., Zhang Z., Li X., Wang Y.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [27] {ECO:0000313|EMBL:QIE07479.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IQTC04/2020 {ECO:0000313|EMBL:QIE07479.1};
+RA   Huang J., Shi Y., Sun J., Zheng K., Zhu A., Sun F., Zhuang Z., Dai J.,
+RA   Zhang Z., Huang S., Wang Y., Li X.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [28] {ECO:0000313|EMBL:QIE07459.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IQTC01/2020 {ECO:0000313|EMBL:QIE07459.1};
+RA   Shi Y., Sun J., Zheng K., Huang J., Zhao J.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [29] {ECO:0000313|EMBL:QIA98603.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/NTU01/TWN/human/2020 {ECO:0000313|EMBL:QIA98603.1},
+RC   and SARS-CoV-2/NTU02/TWN/human/2020 {ECO:0000313|EMBL:QIA98614.1};
+RA   Yeh S.-H., Lin Y.-Y., Lai Y.-Y., Li C.-L., Chang S.-C., Chen P.-J.,
+RA   Chang S.-Y.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [30] {ECO:0000313|EMBL:QIX14045.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IME-HZ01/2020
+RC   {ECO:0000313|EMBL:QIX14045.1};
+RA   Zhang X., Fan H., Liu W.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [31] {ECO:0000313|EMBL:QIA98591.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/IND/166/2020 {ECO:0000313|EMBL:QIA98591.1};
+RA   Potdar V., Choudhary M., Yadav P.D., Shete-Aich A.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [32] {ECO:0000313|EMBL:QIE07489.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/IQTC03/2020 {ECO:0000313|EMBL:QIE07489.1};
+RA   Zheng K., Shi Y., Sun J., Huang J., Zhu A., Sun F., Zhuang Z., Dai J.,
+RA   Chen Z., Huang S., Zhang Z., Li X., Wang Y.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [33] {ECO:0000313|EMBL:QIC53212.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/SWE/01/2020 {ECO:0000313|EMBL:QIC53212.1};
+RA   Bengner M., Palmerus M., Lindsjo O., Lind Karlberg M., Monteil V.,
+RA   Appelberg S., Brave A., Muradrasoli S., Tegmark-Wisell K.;
+RL   Submitted (FEB-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [34] {ECO:0000313|EMBL:QIQ68562.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/HZ-162/2020 {ECO:0000313|EMBL:QIQ68562.1},
+RC   SARS-CoV-2/human/CHN/HZ-178/2020 {ECO:0000313|EMBL:QIQ68572.1},
+RC   SARS-CoV-2/human/CHN/HZ-185/2020 {ECO:0000313|EMBL:QIQ68582.1},
+RC   SARS-CoV-2/human/CHN/HZ-477/2020 {ECO:0000313|EMBL:QIQ68592.1},
+RC   SARS-CoV-2/human/CHN/HZ-48/2020 {ECO:0000313|EMBL:QIQ68612.1},
+RC   SARS-CoV-2/human/CHN/HZ-481/2020 {ECO:0000313|EMBL:QIQ68602.1},
+RC   SARS-CoV-2/human/CHN/HZ-49/2020 {ECO:0000313|EMBL:QIQ68622.1},
+RC   SARS-CoV-2/human/CHN/HZ-551/2020 {ECO:0000313|EMBL:QIQ68632.1},
+RC   SARS-CoV-2/human/CHN/HZ-576/2020 {ECO:0000313|EMBL:QIQ68642.1},
+RC   SARS-CoV-2/human/CHN/HZ-60/2020 {ECO:0000313|EMBL:QIQ68652.1},
+RC   SARS-CoV-2/human/CHN/HZ-62/2020 {ECO:0000313|EMBL:QIQ68662.1},
+RC   SARS-CoV-2/human/CHN/HZ-638/2020 {ECO:0000313|EMBL:QIQ68672.1},
+RC   SARS-CoV-2/human/CHN/HZ-79/2020 {ECO:0000313|EMBL:QIQ68682.1},
+RC   SARS-CoV-2/human/CHN/HZ-90/2020 {ECO:0000313|EMBL:QIQ68692.1}, and
+RC   SARS-CoV-2/human/CHN/HZ-91/2020 {ECO:0000313|EMBL:QIQ68702.1};
+RA   Liu Y., Sun Z., Chen J., Wang X.;
+RT   "A cluster of cases infected with 2019 novel coronavirus during a meeting
+RT   in Hangzhou, China: epidemiological evidence for person to person
+RT   transmission.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [35] {ECO:0000313|EMBL:QIJ96501.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CruiseA-23/2020 {ECO:0000313|EMBL:QIJ96501.1},
+RC   2019-nCoV/USA-CruiseA-24/2020 {ECO:0000313|EMBL:QIJ96511.1},
+RC   2019-nCoV/USA-CruiseA-25/2020 {ECO:0000313|EMBL:QIJ96521.1}, and
+RC   2019-nCoV/USA-CruiseA-26/2020 {ECO:0000313|EMBL:QIJ96531.1};
+RA   Queen K., Uehara A., Tao Y., Paden C.R., Zhang J., Li Y., Wang H.,
+RA   Kamili S., Lu X., Lynch B., Sakthivel S.K.K., Whitaker B.L., Wang L.,
+RA   Murray J.R., Padilla J., Lee J., Gerber S.I., Lindstrom S., Tong S.;
+RT   "additional Cruise A sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [36] {ECO:0000313|EMBL:QIJ96471.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CruiseA-19/2020 {ECO:0000313|EMBL:QIJ96471.1},
+RC   2019-nCoV/USA-CruiseA-21/2020 {ECO:0000313|EMBL:QIJ96481.1}, and
+RC   2019-nCoV/USA-CruiseA-22/2020 {ECO:0000313|EMBL:QIJ96491.1};
+RA   Tao Y., Queen K., Paden C.R., Uehara A., Zhang J., Li Y., Keckler M.S.,
+RA   Laufer Halpin A.S., Wang H., Padilla J., Lee J., Elkins C.A., Gerber S.I.,
+RA   Tong S.;
+RT   "Additional Cruise A sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [37] {ECO:0000313|EMBL:QIQ68704.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ESP/Valencia003/2020
+RC   {ECO:0000313|EMBL:QIQ68704.1}, SARS-CoV-2/human/ESP/Valencia10/2020
+RC   {ECO:0000313|EMBL:QIS30153.1}, and SARS-CoV-2/human/ESP/Valencia9/2020
+RC   {ECO:0000313|EMBL:QIS30143.1};
+RA   Bracho M.A., D'Auria G., Navarro D., de Marco G., Garcia-Gonzalez N.,
+RA   Beamud B., Gonzalez-Candelas F.;
+RT   "Analysis of SARS-CoV-2 genome sequences from Comunitat Valenciana (Spain),
+RT   March 2020.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [38] {ECO:0000313|EMBL:QIQ08798.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ESP/Valencia4/2020
+RC   {ECO:0000313|EMBL:QIQ08808.1}, SARS-CoV-2/human/ESP/Valencia5/2020
+RC   {ECO:0000313|EMBL:QIQ08798.1}, SARS-CoV-2/human/ESP/Valencia6/2020
+RC   {ECO:0000313|EMBL:QIQ08818.1}, SARS-CoV-2/human/ESP/Valencia7/2020
+RC   {ECO:0000313|EMBL:QIQ08828.1}, and SARS-CoV-2/human/ESP/Valencia8/2020
+RC   {ECO:0000313|EMBL:QIQ08838.1};
+RA   Bracho M.A., D'Auria G., Gimeno C., Ocete M.D., De Marco G.,
+RA   Garcia-Gonzalez N., Beamud B., Gonzalez-Candelas F.;
+RT   "Analysis of SARS-CoV-2 genome sequences from Comunitat Valenciana (Spain),
+RT   March 2020.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [39] {ECO:0000313|EMBL:QIG56002.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/BRA/SP02/2020 {ECO:0000313|EMBL:QIG56002.1};
+RA   Amgarten D., Malta F., Ruiz R.M., Petroni R., Santana R.A.F.,
+RA   de Menezes F.G., Mangueira C.L.P., Pinho J.R.R.;
+RT   "Complete genome sequences of SARS-COV-2 isolated in Brazil.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [40] {ECO:0000313|EMBL:QII57176.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CruiseA-10/2020 {ECO:0000313|EMBL:QII57196.1},
+RC   2019-nCoV/USA-CruiseA-11/2020 {ECO:0000313|EMBL:QII57206.1},
+RC   2019-nCoV/USA-CruiseA-12/2020 {ECO:0000313|EMBL:QII57216.1},
+RC   2019-nCoV/USA-CruiseA-7/2020 {ECO:0000313|EMBL:QII57176.1},
+RC   2019-nCoV/USA-CruiseA-8/2020 {ECO:0000313|EMBL:QII57186.1}, and
+RC   2019-nCoV/USA-CruiseA-9/2020 {ECO:0000313|EMBL:QII57226.1};
+RA   Tao Y., Paden C.R., Queen K., Uehara A., Zhang J., Li Y., Wang H.,
+RA   Kamili S., Lu X., Lynch B., Sakthivel S.K.K., Whitaker B.L., Wang L.,
+RA   Murray J.R., Padilla J., Lee J., Gerber S.I., Lindstrom S., Tong S.;
+RT   "Cruise A sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [41] {ECO:0000313|EMBL:QII57296.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CruiseA-1/2020 {ECO:0000313|EMBL:QII57296.1},
+RC   2019-nCoV/USA-CruiseA-2/2020 {ECO:0000313|EMBL:QII57306.1},
+RC   2019-nCoV/USA-CruiseA-3/2020 {ECO:0000313|EMBL:QII57316.1},
+RC   2019-nCoV/USA-CruiseA-4/2020 {ECO:0000313|EMBL:QII57326.1},
+RC   2019-nCoV/USA-CruiseA-5/2020 {ECO:0000313|EMBL:QII57336.1}, and
+RC   2019-nCoV/USA-CruiseA-6/2020 {ECO:0000313|EMBL:QII57346.1};
+RA   Uehara A., Tao Y., Paden C.R., Queen K., Zhang J., Li Y., Keckler M.S.,
+RA   Laufer Halpin A.S., Wang H., Padilla J., Lee J., Elkins C.A., Gerber S.I.,
+RA   Tong S.;
+RT   "Cruise A sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [42] {ECO:0000313|EMBL:QII57236.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=2019-nCoV/USA-CruiseA-13/2020 {ECO:0000313|EMBL:QII57236.1},
+RC   2019-nCoV/USA-CruiseA-14/2020 {ECO:0000313|EMBL:QII57246.1},
+RC   2019-nCoV/USA-CruiseA-15/2020 {ECO:0000313|EMBL:QII57256.1},
+RC   2019-nCoV/USA-CruiseA-16/2020 {ECO:0000313|EMBL:QII57266.1},
+RC   2019-nCoV/USA-CruiseA-17/2020 {ECO:0000313|EMBL:QII57276.1}, and
+RC   2019-nCoV/USA-CruiseA-18/2020 {ECO:0000313|EMBL:QII57286.1};
+RA   Paden C.R., Tao Y., Queen K., Uehara A., Zhang J., Li Y., Wang H.,
+RA   Kamili S., Lu X., Lynch B., Sakthivel S.K.K., Whitaker B.L., Wang L.,
+RA   Murray J.R., Padilla J., Lee J., Gerber S.I., Lindstrom S., Tong S.;
+RT   "Cruise A sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [43] {ECO:0000313|EMBL:QIQ50190.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=FDAARGOS_983 {ECO:0000313|EMBL:QIQ50190.1};
+RA   Thornburg N., Bradford R., Rashid S., Flores B., Parker M., Tallon L.,
+RA   Sadzewicz L., Ott S., Vavikolanu K., Nadendla S., Sichtig H.;
+RT   "FDA dAtabase for Regulatory Grade micrObial Sequences (FDA-ARGOS):
+RT   Supporting development and validation of Infectious Disease Dx tests.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [44] {ECO:0000313|EMBL:QIK02952.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=USA/MN1-MDH1/2020 {ECO:0000313|EMBL:QIK02972.1},
+RC   USA/MN2-MDH2/2020 {ECO:0000313|EMBL:QIK02962.1}, and USA/MN3-MDH3/2020
+RC   {ECO:0000313|EMBL:QIK02952.1};
+RA   Plumb M., Garfin J., Wang X.;
+RT   "Full genome sequences of first three Minnesota, U.S. COVID-19 cases.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [45] {ECO:0000313|EMBL:QIS60297.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/PER/Peru-10/2020
+RC   {ECO:0000313|EMBL:QIS60297.1};
+RA   Padilla-Rojas C.P., Lope-Pari P.N., Vega-Chozo K., Balbuena-Torres J.,
+RA   Caceres-Rey O.A., Bailon-Calderon H., Huaringa-Nunez M., Rojas-Serrano N.;
+RT   "Near-complete genome sequence of 2019 novel coronavirus SARS-CoV-2 causing
+RT   a COVID-19 case in Peru.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [46] {ECO:0000313|EMBL:QII87791.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/WA3-UW1/2020
+RC   {ECO:0000313|EMBL:QII87791.1}, SARS-CoV-2/human/USA/WA4-UW2/2020
+RC   {ECO:0000313|EMBL:QII87803.1}, SARS-CoV-2/human/USA/WA6-UW3/2020
+RC   {ECO:0000313|EMBL:QII87815.1}, SARS-CoV-2/human/USA/WA7-UW4/2020
+RC   {ECO:0000313|EMBL:QII87827.1}, SARS-CoV-2/human/USA/WA8-UW5/2020
+RC   {ECO:0000313|EMBL:QII87839.1}, and SARS-CoV-2/human/USA/WA9-UW6/2020
+RC   {ECO:0000313|EMBL:QII87849.1};
+RA   Roychoudhury P., Greninger A., Jerome K.;
+RT   "SARS-CoV-2 genomes from WA state.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [47] {ECO:0000313|EMBL:BCB97899.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/Hu/DP/Kng/19-031 {ECO:0000313|EMBL:BCB97899.1}, and
+RC   SARS-CoV-2/Hu/Kng/19-437 {ECO:0000313|EMBL:BCB97909.1};
+RA   Hishiki T., Suzuki R., Sakuragi J., Usui K., Tanaka Y., Kawai J., Kogo Y.,
+RA   Matsuki Y., An T., Hayashizaki Y., Takasaki T.;
+RT   "SARS-CoV-2 isolation from COVID-19 patients and asymptomatic individual.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [48] {ECO:0000313|EMBL:BCB15099.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=TKYE6182_2020 {ECO:0000313|EMBL:BCB15099.1};
+RA   Kumagai R., Yoshida I., Nagashima M., Chiba T., Sadamasu K.;
+RT   "The Detection of severe acute respiratory syndrome coronavirus 2 (SARS-
+RT   CoV-2) in Tokyo (February, 2020).";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [49] {ECO:0000313|EMBL:QIK50446.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/VNM/nCoV-19-01S/2020
+RC   {ECO:0000313|EMBL:QIK50446.1};
+RA   Cao T.M., Nguyen H.T., Pham H.T.T., Vu N.P.H., Dao M.H., Huynh L.T.K.,
+RA   Nguyen L.T., Nguyen N.T., Nguyen T.T.N., Nguyen A.H., Luong Q.C.,
+RA   Nguyen T.V., Tran K.C., Pham Q.D., Tran T., Hoang C.Q., Nguyen T.T.,
+RA   Le H.Q., Phung T.M., Vo T.N.A., Nguyen S.N., Pham D.T., Phan L.T.,
+RA   Nguyen T.V.;
+RT   "The first human to human transmission of CoVid-19 case in Viet Nam.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [50] {ECO:0000313|EMBL:QIK50456.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/VNM/nCoV-19-02S/2020
+RC   {ECO:0000313|EMBL:QIK50456.1};
+RA   Nguyen H.T., Cao T.M., Pham H.T.T., Vu N.P.H., Dao M.H., Huynh L.T.K.,
+RA   Nguyen L.T., Nguyen N.T., Nguyen T.T.N., Nguyen A.H., Luong Q.C.,
+RA   Nguyen T.V., Tran K.C., Pham Q.D., Tran T., Hoang C.Q., Nguyen T.T.,
+RA   Le H.Q., Phung T.M., Vo T.N.A., Nguyen S.N., Pham D.T., Nguyen T.V.,
+RA   Phan L.T.;
+RT   "The first imported case of CoVid-19 in Viet Nam.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [51] {ECO:0000313|EMBL:QIS60377.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/WA-NH10/2020
+RC   {ECO:0000313|EMBL:QIS60387.1}, SARS-CoV-2/human/USA/WA-NH11/2020
+RC   {ECO:0000313|EMBL:QIS60397.1}, SARS-CoV-2/human/USA/WA-NH12/2020
+RC   {ECO:0000313|EMBL:QIS60407.1}, SARS-CoV-2/human/USA/WA-NH13/2020
+RC   {ECO:0000313|EMBL:QIS60497.1}, SARS-CoV-2/human/USA/WA-NH14/2020
+RC   {ECO:0000313|EMBL:QIS60417.1}, SARS-CoV-2/human/USA/WA-NH17/2020
+RC   {ECO:0000313|EMBL:QIS60427.1}, SARS-CoV-2/human/USA/WA-NH18/2020
+RC   {ECO:0000313|EMBL:QIS60437.1}, SARS-CoV-2/human/USA/WA-NH19/2020
+RC   {ECO:0000313|EMBL:QIS60447.1}, SARS-CoV-2/human/USA/WA-NH20/2020
+RC   {ECO:0000313|EMBL:QIS60457.1}, SARS-CoV-2/human/USA/WA-NH21/2020
+RC   {ECO:0000313|EMBL:QIS60467.1}, SARS-CoV-2/human/USA/WA-NH22/2020
+RC   {ECO:0000313|EMBL:QIS60477.1}, SARS-CoV-2/human/USA/WA-NH23/2020
+RC   {ECO:0000313|EMBL:QIS60507.1}, SARS-CoV-2/human/USA/WA-NH24/2020
+RC   {ECO:0000313|EMBL:QIS60487.1}, and SARS-CoV-2/human/USA/WA-NH9/2020
+RC   {ECO:0000313|EMBL:QIS60377.1};
+RA   Tao Y., Zhang J., Paden C.R., Queen K., Uehara A., Li Y., Wang H.,
+RA   Jacobs J., Russell D., Hiatt B., Gant J., Tong S.;
+RT   "WA state nursing home sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [52] {ECO:0000313|EMBL:QIS60307.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/WA-NH2/2020 {ECO:0000313|EMBL:QIS60307.1},
+RC   SARS-CoV-2/human/USA/WA-NH3/2020 {ECO:0000313|EMBL:QIS60317.1},
+RC   SARS-CoV-2/human/USA/WA-NH4/2020 {ECO:0000313|EMBL:QIS60327.1},
+RC   SARS-CoV-2/human/USA/WA-NH5/2020 {ECO:0000313|EMBL:QIS60337.1},
+RC   SARS-CoV-2/human/USA/WA-NH6/2020 {ECO:0000313|EMBL:QIS60347.1},
+RC   SARS-CoV-2/human/USA/WA-NH7/2020 {ECO:0000313|EMBL:QIS60357.1}, and
+RC   SARS-CoV-2/human/USA/WA-NH8/2020 {ECO:0000313|EMBL:QIS60367.1};
+RA   Zhang J., Tao Y., Paden C.R., Queen K., Uehara A., Li Y., Wang H.,
+RA   Jacobs J., Russell D., Hiatt B., Gant J., Tong S.;
+RT   "Washington state nursing home sequences.";
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [53] {ECO:0000313|EMBL:QIK50425.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/TWN/CGMH-CGU-01/2020
+RC   {ECO:0000313|EMBL:QIK50425.1};
+RA   Tsao K.-C., Gong Y.-N., Yang S.-L., Liu Y.-C., Huang C.-G., Huang Y.-C.,
+RA   Chen G.-W., Shih S.-R.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [54] {ECO:0000313|EMBL:QIO04375.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/KMS1/2020 {ECO:0000313|EMBL:QIO04375.1};
+RA   Xu X., Liao Y., Wang L., Zhou X., Xie Z., Chen H., Fan S., Liu L.,
+RA   Zheng H., Jiang G., Li Q.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [55] {ECO:0000313|EMBL:QIS30073.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/CZB-RR057-005/2020
+RC   {ECO:0000313|EMBL:QIS30073.1}, SARS-CoV-2/human/USA/CZB-RR057-006/2020
+RC   {ECO:0000313|EMBL:QIS30083.1}, SARS-CoV-2/human/USA/CZB-RR057-007/2020
+RC   {ECO:0000313|EMBL:QIS30093.1}, SARS-CoV-2/human/USA/CZB-RR057-011/2020
+RC   {ECO:0000313|EMBL:QIS30103.1}, SARS-CoV-2/human/USA/CZB-RR057-013/2020
+RC   {ECO:0000313|EMBL:QIS30113.1}, SARS-CoV-2/human/USA/CZB-RR057-014/2020
+RC   {ECO:0000313|EMBL:QIS30123.1}, and
+RC   SARS-CoV-2/human/USA/CZB-RR057-015/2020 {ECO:0000313|EMBL:QIS30133.1};
+RA   Arevalo S., Batson J., Botvinnik O., Castaneda G., Detweiler A.,
+RA   Dynerman D., Hao S., Kamm J., Kistler A., Kumar G.R., Langelier C., Li L.,
+RA   Miller S., Mwakibete L., Neff N., Pisco A., Phelps M., Tan M., Zhao C.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [56] {ECO:0000313|EMBL:QIS60285.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-Cov-2/human/PAK/Manga1/2020 {ECO:0000313|EMBL:QIS60285.1};
+RA   Zainab T., Shamshad S., Noureen A., Malik A., Asad M.J., Rizvi K.A.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [57] {ECO:0000313|EMBL:QIH45031.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/105/2020 {ECO:0000313|EMBL:QIH45031.1},
+RC   SARS-CoV-2/human/CHN/231/2020 {ECO:0000313|EMBL:QIH45041.1},
+RC   SARS-CoV-2/human/CHN/233/2020 {ECO:0000313|EMBL:QIH45051.1}, and
+RC   SARS-CoV-2/human/CHN/235/2020 {ECO:0000313|EMBL:QIH45061.1};
+RA   Li J., Li L., Li Z., Qiu S., Song H., Li P., Li P.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [58] {ECO:0000313|EMBL:QIH55229.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/WA2/2020 {ECO:0000313|EMBL:QIH55229.1};
+RA   Chu H., Boeckh M., Englund J., Famulare M., Lutz B., Nickerson D.,
+RA   Rieder M., Starita L., Thompson M., Shendure J., Bedford T.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [59] {ECO:0000313|EMBL:QIQ68562.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CHN/HZ-162/2020 {ECO:0000313|EMBL:QIQ68562.1},
+RC   SARS-CoV-2/human/CHN/HZ-178/2020 {ECO:0000313|EMBL:QIQ68572.1},
+RC   SARS-CoV-2/human/CHN/HZ-185/2020 {ECO:0000313|EMBL:QIQ68582.1},
+RC   SARS-CoV-2/human/CHN/HZ-477/2020 {ECO:0000313|EMBL:QIQ68592.1},
+RC   SARS-CoV-2/human/CHN/HZ-48/2020 {ECO:0000313|EMBL:QIQ68612.1},
+RC   SARS-CoV-2/human/CHN/HZ-481/2020 {ECO:0000313|EMBL:QIQ68602.1},
+RC   SARS-CoV-2/human/CHN/HZ-49/2020 {ECO:0000313|EMBL:QIQ68622.1},
+RC   SARS-CoV-2/human/CHN/HZ-551/2020 {ECO:0000313|EMBL:QIQ68632.1},
+RC   SARS-CoV-2/human/CHN/HZ-576/2020 {ECO:0000313|EMBL:QIQ68642.1},
+RC   SARS-CoV-2/human/CHN/HZ-60/2020 {ECO:0000313|EMBL:QIQ68652.1},
+RC   SARS-CoV-2/human/CHN/HZ-62/2020 {ECO:0000313|EMBL:QIQ68662.1},
+RC   SARS-CoV-2/human/CHN/HZ-638/2020 {ECO:0000313|EMBL:QIQ68672.1},
+RC   SARS-CoV-2/human/CHN/HZ-79/2020 {ECO:0000313|EMBL:QIQ68682.1},
+RC   SARS-CoV-2/human/CHN/HZ-90/2020 {ECO:0000313|EMBL:QIQ68692.1}, and
+RC   SARS-CoV-2/human/CHN/HZ-91/2020 {ECO:0000313|EMBL:QIQ68702.1};
+RA   Yu H., Li J., Yu X., Wang H., Pan J.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [60] {ECO:0000313|EMBL:QIS30063.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/COL/79256_Antioquia/2020
+RC   {ECO:0000313|EMBL:QIS30063.1};
+RA   Mercado-Reyes M.M., Laiton-Donato K., Alvarez-Diaz D.A., Usme-Ciro J.A.,
+RA   Franco-Munoz C.E., Puerto-Castro G.M., Franco-Sierra N.D., Gonzalez M.A.,
+RA   Cucunuba Z.M., Villabona-Arenas C.J., Villabona-Arenas L., Echeverria S.,
+RA   Florez A.C., Gomez-Rangel S., Rodriguez L.D., Barbosa J., Ospitia E.,
+RA   Ospina-Martinez M.L.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [61] {ECO:0000313|EMBL:QIK50436.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/PC00101P/2020
+RC   {ECO:0000313|EMBL:QIK50436.1};
+RA   Zeller M., Anderson C., Spencer E., Klitting R., Robles-Sikisaka R.,
+RA   Gangavarapu K., Nicholson L., Andersen K.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [62] {ECO:0000313|EMBL:QJC21002.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/HKG/HKU-001a/2020
+RC   {ECO:0000313|EMBL:QJC21002.1};
+RA   Chan J.F.W., Yuen K.-Y.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [63] {ECO:0000313|EMBL:QIS30003.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/Wuhan_YB012504/human/2020/CHN
+RC   {ECO:0000313|EMBL:QIS30051.1},
+RC   SARS-CoV-2/Wuhan_YB012506/human/2020/CHN
+RC   {ECO:0000313|EMBL:QIS30039.1},
+RC   SARS-CoV-2/Wuhan_YB012602/human/2020/CHN
+RC   {ECO:0000313|EMBL:QIS30027.1},
+RC   SARS-CoV-2/Wuhan_YB012605/human/2020/CHN
+RC   {ECO:0000313|EMBL:QIS30015.1}, and
+RC   SARS-CoV-2/Wuhan_YB012611/human/2020/CHN
+RC   {ECO:0000313|EMBL:QIS30003.1};
+RA   Si H., Zhu Y., Lin H., Xie S., Shi Z., Zhou P.;
+RL   Submitted (MAR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [64] {ECO:0000313|EMBL:QIU78716.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ESP/Valencia11/2020
+RC   {ECO:0000313|EMBL:QIU78752.1}, SARS-CoV-2/human/ESP/Valencia12/2020
+RC   {ECO:0000313|EMBL:QIU78740.1}, SARS-CoV-2/human/ESP/Valencia13/2020
+RC   {ECO:0000313|EMBL:QIU78716.1}, SARS-CoV-2/human/ESP/Valencia14/2020
+RC   {ECO:0000313|EMBL:QIU78764.1}, SARS-CoV-2/human/ESP/Valencia15/2020
+RC   {ECO:0000313|EMBL:QIU78776.1}, SARS-CoV-2/human/ESP/Valencia16/2020
+RC   {ECO:0000313|EMBL:QIU78788.1}, SARS-CoV-2/human/ESP/Valencia17/2020
+RC   {ECO:0000313|EMBL:QIU78728.1}, SARS-CoV-2/human/ESP/Valencia18/2020
+RC   {ECO:0000313|EMBL:QIU78799.1}, SARS-CoV-2/human/ESP/Valencia19/2020
+RC   {ECO:0000313|EMBL:QIU78811.1}, SARS-CoV-2/human/ESP/Valencia20/2020
+RC   {ECO:0000313|EMBL:QIU78822.1}, SARS-CoV-2/human/ESP/Valencia22/2020
+RC   {ECO:0000313|EMBL:QIU78832.1}, SARS-CoV-2/human/ESP/Valencia23/2020
+RC   {ECO:0000313|EMBL:QIU78856.1}, SARS-CoV-2/human/ESP/Valencia25/2020
+RC   {ECO:0000313|EMBL:QIU78843.1}, and
+RC   SARS-CoV-2/human/ESP/Valencia26/2020 {ECO:0000313|EMBL:QIU78864.1};
+RA   Bracho M.A., D'Auria G., Ocete M.D., De Marco G., Garcia-Gonzalez N.,
+RA   Beamud B., Concepcion G., Gonzalez-Candelas F.;
+RT   "Analysis of SARS-CoV-2 genome sequences from Comunitat Valenciana
+RT   (Spain).";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [65] {ECO:0000313|EMBL:QIU81907.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS CoV-2/human/USA/UF-1/2020 {ECO:0000313|EMBL:QIU81907.1};
+RA   Elbadry M.A., Subramaniam K., Waltzek T.B., Stephenson C.J., Gibson J.C.,
+RA   Alam M., Morris J.G.Jr., Lednicky J.A.;
+RT   "Genetic analysis of SARS CoV-2 in Gainesville, Florida, 2020.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [66] {ECO:0000313|EMBL:QIZ15006.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/ENV/USA/UF-3/2020 {ECO:0000313|EMBL:QIZ15006.1};
+RA   Shankar S.N., Wu C.-Y., Clugston J.R., Elbadry M.A., Morris J.G.Jr.,
+RA   Lednicky J.A.;
+RT   "Genomic sequence of SARS CoV-2 in breathing air.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [67] {ECO:0000313|EMBL:QJC19500.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/IND/GBRC1/2020 {ECO:0000313|EMBL:QJC19500.1};
+RA   Pandit R., Shah T., Hinsu A., Sabara P., Puvar A., Raval J., Gandhi M.,
+RA   Trivedi P., Pandya M., Kanani A., Verma A., Savaliya N., Kumar R.,
+RA   Kumar D., Saiyed Z., Kinariwala D., Patel D., Aring B., Vaghela G.,
+RA   Barve S., Modi B., Joshi K., Sood N., Shah P., Dixit R., Bagatharia S.,
+RA   Joshi M., Joshi C.;
+RT   "Novel Coronavirus genome sequence and its characterization from the
+RT   patient in Gujarat, India during COVID-19 outbreak.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [68] {ECO:0000313|EMBL:QIV64986.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/UNC_200181/2020
+RC   {ECO:0000313|EMBL:QIV64986.1}, and
+RC   SARS-CoV-2/human/USA/UNC_200189/2020 {ECO:0000313|EMBL:QIV64998.1};
+RA   Bailey A.G., Caro-Vegas C.P., Dittmer D., Eason A.B., Juarez A.,
+RA   Landis J.T., McNamara R.P., Miller M.B., Moorad R., Pluta L.J.,
+RA   Seltzer T.A., Thompson C., Vahrson W., Villamor F.;
+RT   "SARS-COV-2 Sequence in North Carolina Covid 19 Outbreak.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [69] {ECO:0000313|EMBL:QIZ97048.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/AZ-ASU2922/2020
+RC   {ECO:0000313|EMBL:QIZ97048.1}, SARS-CoV-2/human/USA/AZ-ASU2923/2020
+RC   {ECO:0000313|EMBL:QIZ97059.1}, and
+RC   SARS-CoV-2/human/USA/AZ-ASU2936/2020 {ECO:0000313|EMBL:QIZ97071.1};
+RA   Holland L.A., Kaelin E.A., Maqsood R., Estifanos B., Wu L.I., Varsani A.,
+RA   Halden R.U., Hogue B.G., Scotch M., Lim E.S.;
+RT   "Sentinel surveillance in Arizona identifies SARS-CoV-2 isolate with 27
+RT   amino acid in-frame deletion in accessory protein ORF7a.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [70] {ECO:0000313|EMBL:QIU81919.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/UF-2/2020 {ECO:0000313|EMBL:QIU81919.1};
+RA   Elbadry M.A., Subramaniam K., Waltzek T.B., Gibson J.C., Stephenson C.J.,
+RA   Morris J.G.Jr., Lednicky J.A.;
+RT   "Sequence of SARS CoV-2 determined directly from patient specimen.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [71] {ECO:0000313|EMBL:QIV14981.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/UNC_200173/2020
+RC   {ECO:0000313|EMBL:QIV14981.1};
+RA   Bailey A.G., Caro-Vegas C., Thompson C., Dittmer D., Eason A.B., Juarez A.,
+RA   Landis J.T., McNamara R.P., Miller M.B., Moorad R., Pluta L.J.,
+RA   Seltzer T.A., Villamor F., Vahrson W.;
+RT   "Severe Acute Respiratory Syndrome Coronavirus 2 sequence in North Carolina
+RT   Covid19 Outbreak.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [72] {ECO:0000313|EMBL:BCD58762.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=TKYE6968_2020 {ECO:0000313|EMBL:BCD58762.1};
+RA   Kumagai R., Yoshida I., Asakura H., Nagashima M., Chiba T., Sadamasu K.;
+RT   "The Detection of severe acute respiratory syndrome coronavirus 2(SARS-CoV-
+RT   2) in Tokyo (February, 2020).";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [73] {ECO:0000313|EMBL:BCD57652.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=TKYE6947_2020 {ECO:0000313|EMBL:BCD57652.1};
+RA   Kumagai R., Yoshida I., Asakura H., Nagashima M., Chiba T., Sadamasu K.;
+RT   "The Detection of severe acute respiratory syndrome coronavirus 2(SARS-CoV-
+RT   2) in Tokyo (March, 2020).";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [74] {ECO:0000313|EMBL:QIZ15546.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ZAF/R03006/2020 {ECO:0000313|EMBL:QIZ15546.1};
+RA   Allam M., Ismail A., Khumalo Z.T.H., Kwenda S., van Heusden P., Cloete R.,
+RA   Wibmer C.K., Mohale T., Subramoney K., Mtshali P.S., Mnyameni F.,
+RA   Walaza S., Ngubane W., Govender N., Motaze N.V., Bhiman J.N.;
+RT   "Whole-Genome Sequence of the Severe Acute Respiratory Syndrome Coronavirus
+RT   2 (SARS-CoV-2) obtained from a South African Coronavirus Disease 2019
+RT   (COVID-19) Patient.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [75] {ECO:0000313|EMBL:QJD23282.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/NY-PV08109/2020
+RC   {ECO:0000313|EMBL:QJD23642.1}, SARS-CoV-2/human/USA/NY-PV08120/2020
+RC   {ECO:0000313|EMBL:QJD24182.1}, SARS-CoV-2/human/USA/NY-PV08121/2020
+RC   {ECO:0000313|EMBL:QJD23426.1}, SARS-CoV-2/human/USA/NY-PV08122/2020
+RC   {ECO:0000313|EMBL:QJD24014.1}, SARS-CoV-2/human/USA/NY-PV08123/2020
+RC   {ECO:0000313|EMBL:QJD24338.1}, SARS-CoV-2/human/USA/NY-PV08124/2020
+RC   {ECO:0000313|EMBL:QJD23378.1}, SARS-CoV-2/human/USA/NY-PV08125/2020
+RC   {ECO:0000313|EMBL:QJD24290.1}, SARS-CoV-2/human/USA/NY-PV08127/2020
+RC   {ECO:0000313|EMBL:QJD23558.1}, SARS-CoV-2/human/USA/NY-PV08133/2020
+RC   {ECO:0000313|EMBL:QJD24228.1}, SARS-CoV-2/human/USA/NY-PV08135/2020
+RC   {ECO:0000313|EMBL:QJD23702.1}, SARS-CoV-2/human/USA/NY-PV08136/2020
+RC   {ECO:0000313|EMBL:QJD24146.1}, SARS-CoV-2/human/USA/NY-PV08137/2020
+RC   {ECO:0000313|EMBL:QJD23533.1}, SARS-CoV-2/human/USA/NY-PV08138/2020
+RC   {ECO:0000313|EMBL:QJD23882.1}, SARS-CoV-2/human/USA/NY-PV08139/2020
+RC   {ECO:0000313|EMBL:QJD23292.1}, SARS-CoV-2/human/USA/NY-PV08140/2020
+RC   {ECO:0000313|EMBL:QJD23388.1}, SARS-CoV-2/human/USA/NY-PV08143/2020
+RC   {ECO:0000313|EMBL:QJD24266.1}, SARS-CoV-2/human/USA/NY-PV08146/2020
+RC   {ECO:0000313|EMBL:QJD23498.1}, SARS-CoV-2/human/USA/NY-PV08148/2020
+RC   {ECO:0000313|EMBL:QJD23594.1}, SARS-CoV-2/human/USA/NY-PV08149/2020
+RC   {ECO:0000313|EMBL:QJD23798.1}, SARS-CoV-2/human/USA/NY-PV08150/2020
+RC   {ECO:0000313|EMBL:QJD24170.1}, SARS-CoV-2/human/USA/NY-PV08400/2020
+RC   {ECO:0000313|EMBL:QJD23713.1}, SARS-CoV-2/human/USA/NY-PV08401/2020
+RC   {ECO:0000313|EMBL:QJD23462.1}, SARS-CoV-2/human/USA/NY-PV08402/2020
+RC   {ECO:0000313|EMBL:QJD24002.1}, SARS-CoV-2/human/USA/NY-PV08403/2020
+RC   {ECO:0000313|EMBL:QJD23618.1}, SARS-CoV-2/human/USA/NY-PV08404/2020
+RC   {ECO:0000313|EMBL:QJD23784.1}, SARS-CoV-2/human/USA/NY-PV08405/2020
+RC   {ECO:0000313|EMBL:QJD23856.1}, SARS-CoV-2/human/USA/NY-PV08410/2020
+RC   {ECO:0000313|EMBL:QJD24108.1}, SARS-CoV-2/human/USA/NY-PV08412/2020
+RC   {ECO:0000313|EMBL:QJD23654.1}, SARS-CoV-2/human/USA/NY-PV08413/2020
+RC   {ECO:0000313|EMBL:QJD23846.1}, SARS-CoV-2/human/USA/NY-PV08414/2020
+RC   {ECO:0000313|EMBL:QJD24324.1}, SARS-CoV-2/human/USA/NY-PV08415/2020
+RC   {ECO:0000313|EMBL:QJD24050.1}, SARS-CoV-2/human/USA/NY-PV08416/2020
+RC   {ECO:0000313|EMBL:QJD24194.1}, SARS-CoV-2/human/USA/NY-PV08417/2020
+RC   {ECO:0000313|EMBL:QJD23916.1}, SARS-CoV-2/human/USA/NY-PV08419/2020
+RC   {ECO:0000313|EMBL:QJD24024.1}, SARS-CoV-2/human/USA/NY-PV08420/2020
+RC   {ECO:0000313|EMBL:QJD23568.1}, SARS-CoV-2/human/USA/NY-PV08425/2020
+RC   {ECO:0000313|EMBL:QJD23906.1}, SARS-CoV-2/human/USA/NY-PV08426/2020
+RC   {ECO:0000313|EMBL:QJD23330.1}, SARS-CoV-2/human/USA/NY-PV08427/2020
+RC   {ECO:0000313|EMBL:QJD24254.1}, SARS-CoV-2/human/USA/NY-PV08428/2020
+RC   {ECO:0000313|EMBL:QJD23870.1}, SARS-CoV-2/human/USA/NY-PV08429/2020
+RC   {ECO:0000313|EMBL:QJD24314.1}, SARS-CoV-2/human/USA/NY-PV08432/2020
+RC   {ECO:0000313|EMBL:QJD23306.1}, SARS-CoV-2/human/USA/NY-PV08434/2020
+RC   {ECO:0000313|EMBL:QJD23630.1}, SARS-CoV-2/human/USA/NY-PV08435/2020
+RC   {ECO:0000313|EMBL:QJD24206.1}, SARS-CoV-2/human/USA/NY-PV08436/2020
+RC   {ECO:0000313|EMBL:QJD23342.1}, SARS-CoV-2/human/USA/NY-PV08438/2020
+RC   {ECO:0000313|EMBL:QJD23471.1}, SARS-CoV-2/human/USA/NY-PV08441/2020
+RC   {ECO:0000313|EMBL:QJD23486.1}, SARS-CoV-2/human/USA/NY-PV08443/2020
+RC   {ECO:0000313|EMBL:QJD24302.1}, SARS-CoV-2/human/USA/NY-PV08444/2020
+RC   {ECO:0000313|EMBL:QJD24122.1}, SARS-CoV-2/human/USA/NY-PV08445/2020
+RC   {ECO:0000313|EMBL:QJD23582.1}, SARS-CoV-2/human/USA/NY-PV08446/2020
+RC   {ECO:0000313|EMBL:QJD23762.1}, SARS-CoV-2/human/USA/NY-PV08447/2020
+RC   {ECO:0000313|EMBL:QJD24278.1}, SARS-CoV-2/human/USA/NY-PV08448/2020
+RC   {ECO:0000313|EMBL:QJD23822.1}, SARS-CoV-2/human/USA/NY-PV08449/2020
+RC   {ECO:0000313|EMBL:QJD24134.1}, SARS-CoV-2/human/USA/NY-PV08450/2020
+RC   {ECO:0000313|EMBL:QJD23942.1}, SARS-CoV-2/human/USA/NY-PV08452/2020
+RC   {ECO:0000313|EMBL:QJD24074.1}, SARS-CoV-2/human/USA/NY-PV08453/2020
+RC   {ECO:0000313|EMBL:QJD23690.1}, SARS-CoV-2/human/USA/NY-PV08455/2020
+RC   {ECO:0000313|EMBL:QJD24098.1}, SARS-CoV-2/human/USA/NY-PV08456/2020
+RC   {ECO:0000313|EMBL:QJD23366.1}, SARS-CoV-2/human/USA/NY-PV08459/2020
+RC   {ECO:0000313|EMBL:QJD24062.1}, SARS-CoV-2/human/USA/NY-PV08461/2020
+RC   {ECO:0000313|EMBL:QJD23930.1}, SARS-CoV-2/human/USA/NY-PV08462/2020
+RC   {ECO:0000313|EMBL:QJD23738.1}, SARS-CoV-2/human/USA/NY-PV08463/2020
+RC   {ECO:0000313|EMBL:QJD23438.1}, SARS-CoV-2/human/USA/NY-PV08464/2020
+RC   {ECO:0000313|EMBL:QJD23282.1}, SARS-CoV-2/human/USA/NY-PV08466/2020
+RC   {ECO:0000313|EMBL:QJD24350.1}, SARS-CoV-2/human/USA/NY-PV08468/2020
+RC   {ECO:0000313|EMBL:QJD23606.1}, SARS-CoV-2/human/USA/NY-PV08469/2020
+RC   {ECO:0000313|EMBL:QJD23750.1}, SARS-CoV-2/human/USA/NY-PV08471/2020
+RC   {ECO:0000313|EMBL:QJD23666.1}, SARS-CoV-2/human/USA/NY-PV08472/2020
+RC   {ECO:0000313|EMBL:QJD23978.1}, SARS-CoV-2/human/USA/NY-PV08473/2020
+RC   {ECO:0000313|EMBL:QJD23810.1}, SARS-CoV-2/human/USA/NY-PV08474/2020
+RC   {ECO:0000313|EMBL:QJD23834.1}, SARS-CoV-2/human/USA/NY-PV08476/2020
+RC   {ECO:0000313|EMBL:QJD23953.1}, SARS-CoV-2/human/USA/NY-PV08477/2020
+RC   {ECO:0000313|EMBL:QJD23990.1}, SARS-CoV-2/human/USA/NY-PV08478/2020
+RC   {ECO:0000313|EMBL:QJD23318.1}, SARS-CoV-2/human/USA/NY-PV08481/2020
+RC   {ECO:0000313|EMBL:QJD23894.1}, SARS-CoV-2/human/USA/NY-PV08485/2020
+RC   {ECO:0000313|EMBL:QJD23726.1}, SARS-CoV-2/human/USA/NY-PV08486/2020
+RC   {ECO:0000313|EMBL:QJD23354.1}, SARS-CoV-2/human/USA/NY-PV08487/2020
+RC   {ECO:0000313|EMBL:QJD24086.1}, SARS-CoV-2/human/USA/NY-PV08489/2020
+RC   {ECO:0000313|EMBL:QJD24218.1}, SARS-CoV-2/human/USA/NY-PV08490/2020
+RC   {ECO:0000313|EMBL:QJD23402.1}, SARS-CoV-2/human/USA/NY-PV08491/2020
+RC   {ECO:0000313|EMBL:QJD23774.1}, SARS-CoV-2/human/USA/NY-PV08492/2020
+RC   {ECO:0000313|EMBL:QJD23450.1}, SARS-CoV-2/human/USA/NY-PV08493/2020
+RC   {ECO:0000313|EMBL:QJD24242.1}, SARS-CoV-2/human/USA/NY-PV08494/2020
+RC   {ECO:0000313|EMBL:QJD23546.1}, SARS-CoV-2/human/USA/NY-PV08495/2020
+RC   {ECO:0000313|EMBL:QJD23678.1}, SARS-CoV-2/human/USA/NY-PV08496/2020
+RC   {ECO:0000313|EMBL:QJD24038.1}, SARS-CoV-2/human/USA/NY-PV08498/2020
+RC   {ECO:0000313|EMBL:QJD23966.1}, SARS-CoV-2/human/USA/NY-PV08500/2020
+RC   {ECO:0000313|EMBL:QJD23510.1}, SARS-CoV-2/human/USA/NY-PV09000/2020
+RC   {ECO:0000313|EMBL:QJD23522.1}, SARS-CoV-2/human/USA/NY1-PV08001/2020
+RC   {ECO:0000313|EMBL:QJD24158.1}, and
+RC   SARS-CoV-2/human/USA/NY2-PV08100/2020 {ECO:0000313|EMBL:QJD23414.1};
+RA   Gonzalez-Reiche A.S., Hernandez M., Sullivan M., Ciferri B., Alshammary H.,
+RA   Obla A., Fabre S., Kleiner G., Polanco J., Khan Z., Alburquerque B.,
+RA   van de Guchte A., Dutta J., Francoeur N., Salom Melo B., Oussenko I.,
+RA   Deikus G., Soto J., Sridhar S.H., Wang Y.C., Twyman K., Kasarskis A.,
+RA   Altman D.R., Smith M., Sebra R., Aberg J., Krammer F., Garcia-Sastre A.,
+RA   Luksza M., Patel G., Paniz-Mondolfi A., Gitman M., Sordillo E.M., Simon V.,
+RA   van Bakel H.;
+RT   "Whole-genome sequencing of COVID-19 clinical isolates.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [76] {ECO:0000313|EMBL:QJD24362.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/NJ-PV09072/2020
+RC   {ECO:0000313|EMBL:QJD24506.1}, SARS-CoV-2/human/USA/NY-PV09006/2020
+RC   {ECO:0000313|EMBL:QJD25298.1}, SARS-CoV-2/human/USA/NY-PV09019/2020
+RC   {ECO:0000313|EMBL:QJD24386.1}, SARS-CoV-2/human/USA/NY-PV09020/2020
+RC   {ECO:0000313|EMBL:QJD25562.1}, SARS-CoV-2/human/USA/NY-PV09021/2020
+RC   {ECO:0000313|EMBL:QJD25646.1}, SARS-CoV-2/human/USA/NY-PV09023/2020
+RC   {ECO:0000313|EMBL:QJD25034.1}, SARS-CoV-2/human/USA/NY-PV09025/2020
+RC   {ECO:0000313|EMBL:QJD25730.1}, SARS-CoV-2/human/USA/NY-PV09028/2020
+RC   {ECO:0000313|EMBL:QJD25202.1}, SARS-CoV-2/human/USA/NY-PV09029/2020
+RC   {ECO:0000313|EMBL:QJD25538.1}, SARS-CoV-2/human/USA/NY-PV09030/2020
+RC   {ECO:0000313|EMBL:QJD25476.1}, SARS-CoV-2/human/USA/NY-PV09032/2020
+RC   {ECO:0000313|EMBL:QJD24878.1}, SARS-CoV-2/human/USA/NY-PV09037/2020
+RC   {ECO:0000313|EMBL:QJD25106.1}, SARS-CoV-2/human/USA/NY-PV09039/2020
+RC   {ECO:0000313|EMBL:QJD24674.1}, SARS-CoV-2/human/USA/NY-PV09041/2020
+RC   {ECO:0000313|EMBL:QJD24734.1}, SARS-CoV-2/human/USA/NY-PV09043/2020
+RC   {ECO:0000313|EMBL:QJD25118.1}, SARS-CoV-2/human/USA/NY-PV09044/2020
+RC   {ECO:0000313|EMBL:QJD25058.1}, SARS-CoV-2/human/USA/NY-PV09045/2020
+RC   {ECO:0000313|EMBL:QJD25310.1}, SARS-CoV-2/human/USA/NY-PV09046/2020
+RC   {ECO:0000313|EMBL:QJD25586.1}, SARS-CoV-2/human/USA/NY-PV09047/2020
+RC   {ECO:0000313|EMBL:QJD25597.1}, SARS-CoV-2/human/USA/NY-PV09050/2020
+RC   {ECO:0000313|EMBL:QJD25680.1}, SARS-CoV-2/human/USA/NY-PV09056/2020
+RC   {ECO:0000313|EMBL:QJD24854.1}, SARS-CoV-2/human/USA/NY-PV09057/2020
+RC   {ECO:0000313|EMBL:QJD25418.1}, SARS-CoV-2/human/USA/NY-PV09060/2020
+RC   {ECO:0000313|EMBL:QJD24530.1}, SARS-CoV-2/human/USA/NY-PV09061/2020
+RC   {ECO:0000313|EMBL:QJD24962.1}, SARS-CoV-2/human/USA/NY-PV09063/2020
+RC   {ECO:0000313|EMBL:QJD24986.1}, SARS-CoV-2/human/USA/NY-PV09064/2020
+RC   {ECO:0000313|EMBL:QJD24926.1}, SARS-CoV-2/human/USA/NY-PV09067/2020
+RC   {ECO:0000313|EMBL:QJD25070.1}, SARS-CoV-2/human/USA/NY-PV09068/2020
+RC   {ECO:0000313|EMBL:QJD25382.1}, SARS-CoV-2/human/USA/NY-PV09069/2020
+RC   {ECO:0000313|EMBL:QJD25022.1}, SARS-CoV-2/human/USA/NY-PV09071/2020
+RC   {ECO:0000313|EMBL:QJD24602.1}, SARS-CoV-2/human/USA/NY-PV09073/2020
+RC   {ECO:0000313|EMBL:QJD25634.1}, SARS-CoV-2/human/USA/NY-PV09075/2020
+RC   {ECO:0000313|EMBL:QJD24698.1}, SARS-CoV-2/human/USA/NY-PV09076/2020
+RC   {ECO:0000313|EMBL:QJD25344.1}, SARS-CoV-2/human/USA/NY-PV09077/2020
+RC   {ECO:0000313|EMBL:QJD24662.1}, SARS-CoV-2/human/USA/NY-PV09079/2020
+RC   {ECO:0000313|EMBL:QJD24518.1}, SARS-CoV-2/human/USA/NY-PV09080/2020
+RC   {ECO:0000313|EMBL:QJD25212.1}, SARS-CoV-2/human/USA/NY-PV09083/2020
+RC   {ECO:0000313|EMBL:QJD25190.1}, SARS-CoV-2/human/USA/NY-PV09087/2020
+RC   {ECO:0000313|EMBL:QJD24422.1}, SARS-CoV-2/human/USA/NY-PV09088/2020
+RC   {ECO:0000313|EMBL:QJD25274.1}, SARS-CoV-2/human/USA/NY-PV09090/2020
+RC   {ECO:0000313|EMBL:QJD25622.1}, SARS-CoV-2/human/USA/NY-PV09092/2020
+RC   {ECO:0000313|EMBL:QJD25154.1}, SARS-CoV-2/human/USA/NY-PV09097/2020
+RC   {ECO:0000313|EMBL:QJD24830.1}, SARS-CoV-2/human/USA/NY-PV09098/2020
+RC   {ECO:0000313|EMBL:QJD25178.1}, SARS-CoV-2/human/USA/NY-PV09099/2020
+RC   {ECO:0000313|EMBL:QJD24794.1}, SARS-CoV-2/human/USA/NY-PV09102/2020
+RC   {ECO:0000313|EMBL:QJD25466.1}, SARS-CoV-2/human/USA/NY-PV09103/2020
+RC   {ECO:0000313|EMBL:QJD24434.1}, SARS-CoV-2/human/USA/NY-PV09115/2020
+RC   {ECO:0000313|EMBL:QJD25670.1}, SARS-CoV-2/human/USA/NY-PV09116/2020
+RC   {ECO:0000313|EMBL:QJD24890.1}, SARS-CoV-2/human/USA/NY-PV09118/2020
+RC   {ECO:0000313|EMBL:QJD24766.1}, SARS-CoV-2/human/USA/NY-PV09119/2020
+RC   {ECO:0000313|EMBL:QJD24578.1}, SARS-CoV-2/human/USA/NY-PV09120/2020
+RC   {ECO:0000313|EMBL:QJD24638.1}, SARS-CoV-2/human/USA/NY-PV09121/2020
+RC   {ECO:0000313|EMBL:QJD24445.1}, SARS-CoV-2/human/USA/NY-PV09122/2020
+RC   {ECO:0000313|EMBL:QJD24746.1}, SARS-CoV-2/human/USA/NY-PV09123/2020
+RC   {ECO:0000313|EMBL:QJD25082.1}, SARS-CoV-2/human/USA/NY-PV09125/2020
+RC   {ECO:0000313|EMBL:QJD25226.1}, SARS-CoV-2/human/USA/NY-PV09126/2020
+RC   {ECO:0000313|EMBL:QJD25550.1}, SARS-CoV-2/human/USA/NY-PV09127/2020
+RC   {ECO:0000313|EMBL:QJD25694.1}, SARS-CoV-2/human/USA/NY-PV09128/2020
+RC   {ECO:0000313|EMBL:QJD24614.1}, SARS-CoV-2/human/USA/NY-PV09129/2020
+RC   {ECO:0000313|EMBL:QJD24782.1}, SARS-CoV-2/human/USA/NY-PV09130/2020
+RC   {ECO:0000313|EMBL:QJD25430.1}, SARS-CoV-2/human/USA/NY-PV09132/2020
+RC   {ECO:0000313|EMBL:QJD24806.1}, SARS-CoV-2/human/USA/NY-PV09134/2020
+RC   {ECO:0000313|EMBL:QJD25010.1}, SARS-CoV-2/human/USA/NY-PV09135/2020
+RC   {ECO:0000313|EMBL:QJD25250.1}, SARS-CoV-2/human/USA/NY-PV09137/2020
+RC   {ECO:0000313|EMBL:QJD25658.1}, SARS-CoV-2/human/USA/NY-PV09138/2020
+RC   {ECO:0000313|EMBL:QJD24974.1}, SARS-CoV-2/human/USA/NY-PV09139/2020
+RC   {ECO:0000313|EMBL:QJD25358.1}, SARS-CoV-2/human/USA/NY-PV09140/2020
+RC   {ECO:0000313|EMBL:QJD24842.1}, SARS-CoV-2/human/USA/NY-PV09141/2020
+RC   {ECO:0000313|EMBL:QJD24540.1}, SARS-CoV-2/human/USA/NY-PV09142/2020
+RC   {ECO:0000313|EMBL:QJD24554.1}, SARS-CoV-2/human/USA/NY-PV09143/2020
+RC   {ECO:0000313|EMBL:QJD24362.1}, SARS-CoV-2/human/USA/NY-PV09144/2020
+RC   {ECO:0000313|EMBL:QJD24686.1}, SARS-CoV-2/human/USA/NY-PV09145/2020
+RC   {ECO:0000313|EMBL:QJD24410.1}, SARS-CoV-2/human/USA/NY-PV09147/2020
+RC   {ECO:0000313|EMBL:QJD25130.1}, SARS-CoV-2/human/USA/NY-PV09149/2020
+RC   {ECO:0000313|EMBL:QJD24648.1}, SARS-CoV-2/human/USA/NY-PV09151/2020
+RC   {ECO:0000313|EMBL:QJD25574.1}, SARS-CoV-2/human/USA/NY-PV09152/2020
+RC   {ECO:0000313|EMBL:QJD24626.1}, SARS-CoV-2/human/USA/NY-PV09153/2020
+RC   {ECO:0000313|EMBL:QJD24470.1}, SARS-CoV-2/human/USA/NY-PV09154/2020
+RC   {ECO:0000313|EMBL:QJD24374.1}, SARS-CoV-2/human/USA/NY-PV09156/2020
+RC   {ECO:0000313|EMBL:QJD24758.1}, SARS-CoV-2/human/USA/NY-PV09157/2020
+RC   {ECO:0000313|EMBL:QJD25046.1}, SARS-CoV-2/human/USA/NY-PV09158/2020
+RC   {ECO:0000313|EMBL:QJD25718.1}, SARS-CoV-2/human/USA/NY-PV09161/2020
+RC   {ECO:0000313|EMBL:QJD25440.1}, SARS-CoV-2/human/USA/NY-PV09163/2020
+RC   {ECO:0000313|EMBL:QJD24818.1}, SARS-CoV-2/human/USA/NY-PV09164/2020
+RC   {ECO:0000313|EMBL:QJD24482.1}, SARS-CoV-2/human/USA/NY-PV09165/2020
+RC   {ECO:0000313|EMBL:QJD25406.1}, SARS-CoV-2/human/USA/NY-PV09168/2020
+RC   {ECO:0000313|EMBL:QJD25610.1}, SARS-CoV-2/human/USA/NY-PV09169/2020
+RC   {ECO:0000313|EMBL:QJD25454.1}, SARS-CoV-2/human/USA/NY-PV09170/2020
+RC   {ECO:0000313|EMBL:QJD25094.1}, SARS-CoV-2/human/USA/NY-PV09171/2020
+RC   {ECO:0000313|EMBL:QJD25322.1}, SARS-CoV-2/human/USA/NY-PV09172/2020
+RC   {ECO:0000313|EMBL:QJD25370.1}, SARS-CoV-2/human/USA/NY-PV09176/2020
+RC   {ECO:0000313|EMBL:QJD24722.1}, SARS-CoV-2/human/USA/NY-PV09177/2020
+RC   {ECO:0000313|EMBL:QJD25394.1}, SARS-CoV-2/human/USA/NY-PV09178/2020
+RC   {ECO:0000313|EMBL:QJD25754.1}, SARS-CoV-2/human/USA/NY-PV09179/2020
+RC   {ECO:0000313|EMBL:QJD24866.1}, SARS-CoV-2/human/USA/NY-PV09180/2020
+RC   {ECO:0000313|EMBL:QJD24902.1}, SARS-CoV-2/human/USA/NY-PV09181/2020
+RC   {ECO:0000313|EMBL:QJD25262.1}, SARS-CoV-2/human/USA/NY-PV09182/2020
+RC   {ECO:0000313|EMBL:QJD24590.1}, SARS-CoV-2/human/USA/NY-PV09183/2020
+RC   {ECO:0000313|EMBL:QJD25286.1}, SARS-CoV-2/human/USA/NY-PV09186/2020
+RC   {ECO:0000313|EMBL:QJD25526.1}, SARS-CoV-2/human/USA/NY-PV09187/2020
+RC   {ECO:0000313|EMBL:QJD25490.1}, SARS-CoV-2/human/USA/NY-PV09188/2020
+RC   {ECO:0000313|EMBL:QJD24457.1}, SARS-CoV-2/human/USA/NY-PV09189/2020
+RC   {ECO:0000313|EMBL:QJD25766.1}, SARS-CoV-2/human/USA/NY-PV09190/2020
+RC   {ECO:0000313|EMBL:QJD25142.1}, SARS-CoV-2/human/USA/NY-PV09192/2020
+RC   {ECO:0000313|EMBL:QJD24950.1}, SARS-CoV-2/human/USA/NY-PV09193/2020
+RC   {ECO:0000313|EMBL:QJD24710.1}, SARS-CoV-2/human/USA/NY-PV09194/2020
+RC   {ECO:0000313|EMBL:QJD25238.1}, SARS-CoV-2/human/USA/NY-PV09195/2020
+RC   {ECO:0000313|EMBL:QJD24494.1}, SARS-CoV-2/human/USA/NY-PV09197/2020
+RC   {ECO:0000313|EMBL:QJD25166.1}, SARS-CoV-2/human/USA/NY-PV09198/2020
+RC   {ECO:0000313|EMBL:QJD25742.1}, SARS-CoV-2/human/USA/NY-PV09199/2020
+RC   {ECO:0000313|EMBL:QJD24938.1}, SARS-CoV-2/human/USA/NY-PV09200/2020
+RC   {ECO:0000313|EMBL:QJD25334.1}, SARS-CoV-2/human/USA/NY-PV09301/2020
+RC   {ECO:0000313|EMBL:QJD24566.1}, SARS-CoV-2/human/USA/NY-PV09303/2020
+RC   {ECO:0000313|EMBL:QJD24914.1}, SARS-CoV-2/human/USA/NY-PV09304/2020
+RC   {ECO:0000313|EMBL:QJD25706.1}, SARS-CoV-2/human/USA/NY-PV09305/2020
+RC   {ECO:0000313|EMBL:QJD24398.1}, SARS-CoV-2/human/USA/NY-PV09307/2020
+RC   {ECO:0000313|EMBL:QJD24998.1}, SARS-CoV-2/human/USA/NY-PV09308/2020
+RC   {ECO:0000313|EMBL:QJD25502.1}, and
+RC   SARS-CoV-2/human/USA/NY-PV09309/2020 {ECO:0000313|EMBL:QJD25514.1};
+RA   Gonzalez-Reiche A.S., Sullivan M., Obla A., Patel G., Sordillo E.,
+RA   Gitman M., Paniz-Mondolfi A., Hernandez M., Fabre S., Polanco J., Khan Z.,
+RA   Albuquerque B., Dutta J., Soto J., Sridhar S.H., Wang Y.C., Smith M.,
+RA   Sebra R., Miorin L., Liu W., Albrecht R., Aberg J., Krammer F.,
+RA   Garcia-Sastre A., Simon V., van Bakel H.;
+RT   "Whole-genome sequencing of COVID-19 clinical isolates.";
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [77] {ECO:0000313|EMBL:QIT06888.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/CA_2602/2020
+RC   {ECO:0000313|EMBL:QIT06900.1}, SARS-CoV-2/human/USA/GA_2741/2020
+RC   {ECO:0000313|EMBL:QIT06924.1}, SARS-CoV-2/human/USA/GA_2742/2020
+RC   {ECO:0000313|EMBL:QIT06936.1}, SARS-CoV-2/human/USA/OR_2656/2020
+RC   {ECO:0000313|EMBL:QIT06948.1}, SARS-CoV-2/human/USA/RI_0520/2020
+RC   {ECO:0000313|EMBL:QIT06888.1}, and SARS-CoV-2/human/USA/WA_5030/2020
+RC   {ECO:0000313|EMBL:QIT06912.1};
+RA   Tao Y., Zhang J., Queen K., Uehara A., Paden C.R., Li Y., Wang H.,
+RA   Padilla J., Lee J., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [78] {ECO:0000313|EMBL:QIZ16518.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/TUR/ERAGEM-001/2020
+RC   {ECO:0000313|EMBL:QIZ16518.1};
+RA   Pavel S.T.I., Yetiskin H., Aydin G., Holyavkin C., Uygut M.A., Dursun Z.B.,
+RA   Celik I., Iseri A., Ozdarendeli A.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [79] {ECO:0000313|EMBL:QIV64974.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/UNC_200191/2020
+RC   {ECO:0000313|EMBL:QIV64974.1};
+RA   Bailey A.G., Caro-Vegas C., Dittmer D., Eason A.B., Juarez A., Landis J.T.,
+RA   McNamara R.P., Miller M.B., Moorad R., Pluta L.J., Seltzer T.A.,
+RA   Thompson C., Vahrson W., Villamor F.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [80] {ECO:0000313|EMBL:QIX13684.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/VA-DCLS-0001/2020
+RC   {ECO:0000313|EMBL:QIX13684.1}, SARS-CoV-2/human/USA/VA-DCLS-0002/2020
+RC   {ECO:0000313|EMBL:QIX13696.1}, SARS-CoV-2/human/USA/VA-DCLS-0003/2020
+RC   {ECO:0000313|EMBL:QIX13708.1}, SARS-CoV-2/human/USA/VA-DCLS-0004/2020
+RC   {ECO:0000313|EMBL:QIX13720.1}, SARS-CoV-2/human/USA/VA-DCLS-0005/2020
+RC   {ECO:0000313|EMBL:QIX13732.1}, SARS-CoV-2/human/USA/VA-DCLS-0006/2020
+RC   {ECO:0000313|EMBL:QIX13743.1}, SARS-CoV-2/human/USA/VA-DCLS-0007/2020
+RC   {ECO:0000313|EMBL:QIX13756.1}, SARS-CoV-2/human/USA/VA-DCLS-0008/2020
+RC   {ECO:0000313|EMBL:QIX13768.1}, SARS-CoV-2/human/USA/VA-DCLS-0009/2020
+RC   {ECO:0000313|EMBL:QIX13780.1}, SARS-CoV-2/human/USA/VA-DCLS-0010/2020
+RC   {ECO:0000313|EMBL:QIX13792.1}, SARS-CoV-2/human/USA/VA-DCLS-0011/2020
+RC   {ECO:0000313|EMBL:QIX13804.1}, SARS-CoV-2/human/USA/VA-DCLS-0012/2020
+RC   {ECO:0000313|EMBL:QIX13816.1}, SARS-CoV-2/human/USA/VA-DCLS-0016/2020
+RC   {ECO:0000313|EMBL:QIX13828.1}, SARS-CoV-2/human/USA/VA-DCLS-0017/2020
+RC   {ECO:0000313|EMBL:QIX13840.1}, SARS-CoV-2/human/USA/VA-DCLS-0018/2020
+RC   {ECO:0000313|EMBL:QIX13852.1}, SARS-CoV-2/human/USA/VA-DCLS-0019/2020
+RC   {ECO:0000313|EMBL:QIX13864.1}, SARS-CoV-2/human/USA/VA-DCLS-0020/2020
+RC   {ECO:0000313|EMBL:QIX13876.1}, SARS-CoV-2/human/USA/VA-DCLS-0021/2020
+RC   {ECO:0000313|EMBL:QIX13888.1}, SARS-CoV-2/human/USA/VA-DCLS-0024/2020
+RC   {ECO:0000313|EMBL:QIX13900.1}, SARS-CoV-2/human/USA/VA-DCLS-0031/2020
+RC   {ECO:0000313|EMBL:QIX13912.1}, SARS-CoV-2/human/USA/VA-DCLS-0033/2020
+RC   {ECO:0000313|EMBL:QIX13924.1}, SARS-CoV-2/human/USA/VA-DCLS-0034/2020
+RC   {ECO:0000313|EMBL:QIX13936.1}, SARS-CoV-2/human/USA/VA-DCLS-0036/2020
+RC   {ECO:0000313|EMBL:QIX13948.1}, SARS-CoV-2/human/USA/VA-DCLS-0038/2020
+RC   {ECO:0000313|EMBL:QIX13960.1}, SARS-CoV-2/human/USA/VA-DCLS-0039/2020
+RC   {ECO:0000313|EMBL:QIX13972.1}, SARS-CoV-2/human/USA/VA-DCLS-0040/2020
+RC   {ECO:0000313|EMBL:QIX13984.1}, SARS-CoV-2/human/USA/VA-DCLS-0041/2020
+RC   {ECO:0000313|EMBL:QJA41994.1}, SARS-CoV-2/human/USA/VA-DCLS-0042/2020
+RC   {ECO:0000313|EMBL:QIX13996.1}, SARS-CoV-2/human/USA/VA-DCLS-0043/2020
+RC   {ECO:0000313|EMBL:QIX14008.1}, SARS-CoV-2/human/USA/VA-DCLS-0044/2020
+RC   {ECO:0000313|EMBL:QIX14020.1}, SARS-CoV-2/human/USA/VA-DCLS-0045/2020
+RC   {ECO:0000313|EMBL:QIX14032.1}, SARS-CoV-2/human/USA/VA-DCLS-0046/2020
+RC   {ECO:0000313|EMBL:QIX14044.1}, SARS-CoV-2/human/USA/VA-DCLS-0047/2020
+RC   {ECO:0000313|EMBL:QJA42006.1}, SARS-CoV-2/human/USA/VA-DCLS-0048/2020
+RC   {ECO:0000313|EMBL:QJA42018.1}, SARS-CoV-2/human/USA/VA-DCLS-0049/2020
+RC   {ECO:0000313|EMBL:QJA42030.1}, SARS-CoV-2/human/USA/VA-DCLS-0050/2020
+RC   {ECO:0000313|EMBL:QJA42042.1}, SARS-CoV-2/human/USA/VA-DCLS-0051/2020
+RC   {ECO:0000313|EMBL:QJA42054.1}, SARS-CoV-2/human/USA/VA-DCLS-0052/2020
+RC   {ECO:0000313|EMBL:QJA42066.1}, SARS-CoV-2/human/USA/VA-DCLS-0053/2020
+RC   {ECO:0000313|EMBL:QJA42078.1}, SARS-CoV-2/human/USA/VA-DCLS-0054/2020
+RC   {ECO:0000313|EMBL:QJA42090.1}, SARS-CoV-2/human/USA/VA-DCLS-0055/2020
+RC   {ECO:0000313|EMBL:QJA42102.1}, SARS-CoV-2/human/USA/VA-DCLS-0056/2020
+RC   {ECO:0000313|EMBL:QJA42114.1}, SARS-CoV-2/human/USA/VA-DCLS-0057/2020
+RC   {ECO:0000313|EMBL:QJA42126.1}, SARS-CoV-2/human/USA/VA-DCLS-0058/2020
+RC   {ECO:0000313|EMBL:QJA42138.1}, SARS-CoV-2/human/USA/VA-DCLS-0059/2020
+RC   {ECO:0000313|EMBL:QJA42150.1}, SARS-CoV-2/human/USA/VA-DCLS-0060/2020
+RC   {ECO:0000313|EMBL:QJA42162.1}, SARS-CoV-2/human/USA/VA-DCLS-0061/2020
+RC   {ECO:0000313|EMBL:QJA42174.1}, SARS-CoV-2/human/USA/VA-DCLS-0063/2020
+RC   {ECO:0000313|EMBL:QJA42186.1}, SARS-CoV-2/human/USA/VA-DCLS-0064/2020
+RC   {ECO:0000313|EMBL:QJA42198.1}, SARS-CoV-2/human/USA/VA-DCLS-0065/2020
+RC   {ECO:0000313|EMBL:QJA42210.1}, SARS-CoV-2/human/USA/VA-DCLS-0066/2020
+RC   {ECO:0000313|EMBL:QJA42222.1}, SARS-CoV-2/human/USA/VA-DCLS-0067/2020
+RC   {ECO:0000313|EMBL:QJA42234.1}, and
+RC   SARS-CoV-2/human/USA/VA-DCLS-0068/2020 {ECO:0000313|EMBL:QJA42246.1};
+RA   Fink L.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [81] {ECO:0000313|EMBL:QIX12204.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/IRN/HGRC-1.1-IPI-8206/2020
+RC   {ECO:0000313|EMBL:QIX12204.1};
+RG   Rapid Response Team of Infection Diseases;
+RG   Pasteur Institute of Iran;
+RA   Zeinali S., Khosravi M.A., Abbasalipour Bashash M., Mostafavi Jabbari S.,
+RA   Firoozi M., Pourtavakoli S., Khateri E., Zeinali R., Hoseini F.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [82] {ECO:0000313|EMBL:QIT06996.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ISR/ISR_JP0320/2020
+RC   {ECO:0000313|EMBL:QIT06996.1};
+RA   Cohen-Gihon I., Israeli O., Shifman O., Stein D., Melamed S., Paran N.,
+RA   Israely T., Achdout H., Yahalom Ronen Y., Tamir H., Politi B., Cherry L.,
+RA   Vitner E., Weiss S., Laskar O., Mandelboim M., Erster O., Regev-Yochay G.,
+RA   Segal G., Yitzhaki S., Shapira S.C., Beth-Din A., Zvi A.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [83] {ECO:0000313|EMBL:QJA41662.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/USA-WA_0418/2020
+RC   {ECO:0000313|EMBL:QJA41722.1}, SARS-CoV-2/human/USA/USA-WA_0427/2020
+RC   {ECO:0000313|EMBL:QJA41686.1}, SARS-CoV-2/human/USA/USA-WA_0428/2020
+RC   {ECO:0000313|EMBL:QJA41674.1}, SARS-CoV-2/human/USA/USA-WA_0434/2020
+RC   {ECO:0000313|EMBL:QJA41698.1}, SARS-CoV-2/human/USA/USA-WA_0442/2020
+RC   {ECO:0000313|EMBL:QJA41710.1}, and
+RC   SARS-CoV-2/human/USA/USA-WA_0480/2020 {ECO:0000313|EMBL:QJA41662.1};
+RA   Zhang J., Tao Y., Paden C.R., Queen K., Uehara A., Li Y., Wang H.,
+RA   Jacobs J., Russell D., Hiatt B., Gant J., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [84] {ECO:0000313|EMBL:QIU80934.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/CT-UW-1365/2020
+RC   {ECO:0000313|EMBL:QIZ14878.1}, SARS-CoV-2/human/USA/CT-UW-3845/2020
+RC   {ECO:0000313|EMBL:QJC20100.1}, SARS-CoV-2/human/USA/CT-UW-4238/2020
+RC   {ECO:0000313|EMBL:QJC19596.1}, SARS-CoV-2/human/USA/CT-UW-4244/2020
+RC   {ECO:0000313|EMBL:QJC19620.1}, SARS-CoV-2/human/USA/CT-UW-4251/2020
+RC   {ECO:0000313|EMBL:QJC19632.1}, SARS-CoV-2/human/USA/CT-UW-4341/2020
+RC   {ECO:0000313|EMBL:QJC19860.1}, SARS-CoV-2/human/USA/CT-UW-4344/2020
+RC   {ECO:0000313|EMBL:QJA17249.1}, SARS-CoV-2/human/USA/CT-UW-4346/2020
+RC   {ECO:0000313|EMBL:QJA17261.1}, SARS-CoV-2/human/USA/CT-UW-4347/2020
+RC   {ECO:0000313|EMBL:QJA17273.1}, SARS-CoV-2/human/USA/CT-UW-4366/2020
+RC   {ECO:0000313|EMBL:QJA17309.1}, SARS-CoV-2/human/USA/CT-UW-4372/2020
+RC   {ECO:0000313|EMBL:QJA17321.1}, SARS-CoV-2/human/USA/CT-UW238/2020
+RC   {ECO:0000313|EMBL:QIQ68492.1}, SARS-CoV-2/human/USA/CT-UW250/2020
+RC   {ECO:0000313|EMBL:QIS30233.1}, SARS-CoV-2/human/USA/CT-UW256/2020
+RC   {ECO:0000313|EMBL:QIS30293.1}, SARS-CoV-2/human/USA/CT-UW303/2020
+RC   {ECO:0000313|EMBL:QIS60579.1}, SARS-CoV-2/human/USA/CT-UW327/2020
+RC   {ECO:0000313|EMBL:QIS60831.1}, SARS-CoV-2/human/USA/CT-UW329/2020
+RC   {ECO:0000313|EMBL:QIS61503.1}, SARS-CoV-2/human/USA/CT-UW331/2020
+RC   {ECO:0000313|EMBL:QIS60879.1}, SARS-CoV-2/human/USA/ID-UW-1925/2020
+RC   {ECO:0000313|EMBL:QIZ13584.1}, SARS-CoV-2/human/USA/ID-UW-1934/2020
+RC   {ECO:0000313|EMBL:QIZ13596.1}, SARS-CoV-2/human/USA/ID-UW-1935/2020
+RC   {ECO:0000313|EMBL:QIZ13558.1}, SARS-CoV-2/human/USA/ID-UW-1938/2020
+RC   {ECO:0000313|EMBL:QIZ13548.1}, SARS-CoV-2/human/USA/ID-UW-1939/2020
+RC   {ECO:0000313|EMBL:QIZ13568.1}, SARS-CoV-2/human/USA/ID-UW-2127/2020
+RC   {ECO:0000313|EMBL:QJA16469.1}, SARS-CoV-2/human/USA/ID-UW-2134/2020
+RC   {ECO:0000313|EMBL:QJA16637.1}, SARS-CoV-2/human/USA/ID-UW-2159/2020
+RC   {ECO:0000313|EMBL:QJA16803.1}, SARS-CoV-2/human/USA/ID-UW-2160/2020
+RC   {ECO:0000313|EMBL:QJA16769.1}, SARS-CoV-2/human/USA/ID-UW-2173/2020
+RC   {ECO:0000313|EMBL:QJA17189.1}, SARS-CoV-2/human/USA/ID-UW-2174/2020
+RC   {ECO:0000313|EMBL:QJA17129.1}, SARS-CoV-2/human/USA/ID-UW-2195/2020
+RC   {ECO:0000313|EMBL:QJA17201.1}, SARS-CoV-2/human/USA/ID-UW-2198/2020
+RC   {ECO:0000313|EMBL:QJA17117.1}, SARS-CoV-2/human/USA/ID-UW-2255/2020
+RC   {ECO:0000313|EMBL:QJA17225.1}, SARS-CoV-2/human/USA/ID-UW-3888/2020
+RC   {ECO:0000313|EMBL:QJC20220.1}, SARS-CoV-2/human/USA/ID-UW-3892/2020
+RC   {ECO:0000313|EMBL:QJC20292.1}, SARS-CoV-2/human/USA/ID-UW-4100/2020
+RC   {ECO:0000313|EMBL:QJC20723.1}, SARS-CoV-2/human/USA/ID-UW-4239/2020
+RC   {ECO:0000313|EMBL:QJC19608.1}, SARS-CoV-2/human/USA/ID-UW-4266/2020
+RC   {ECO:0000313|EMBL:QJC19644.1}, SARS-CoV-2/human/USA/ID-UW-4355/2020
+RC   {ECO:0000313|EMBL:QJA17284.1}, SARS-CoV-2/human/USA/ID-UW-4357/2020
+RC   {ECO:0000313|EMBL:QJA17297.1}, SARS-CoV-2/human/USA/ID-UW-4375/2020
+RC   {ECO:0000313|EMBL:QJA17333.1}, SARS-CoV-2/human/USA/ID-UW-4378/2020
+RC   {ECO:0000313|EMBL:QJA17345.1}, SARS-CoV-2/human/USA/ID-UW-4380/2020
+RC   {ECO:0000313|EMBL:QJA17357.1}, SARS-CoV-2/human/USA/ID-UW-4396/2020
+RC   {ECO:0000313|EMBL:QJA17381.1}, SARS-CoV-2/human/USA/ID-UW-4400/2020
+RC   {ECO:0000313|EMBL:QJA17393.1}, SARS-CoV-2/human/USA/ID-UW-4424/2020
+RC   {ECO:0000313|EMBL:QJA17440.1}, SARS-CoV-2/human/USA/ID-UW-4427/2020
+RC   {ECO:0000313|EMBL:QJA17453.1}, SARS-CoV-2/human/USA/ID-UW-4433/2020
+RC   {ECO:0000313|EMBL:QJA17465.1}, SARS-CoV-2/human/USA/ID-UW-4448/2020
+RC   {ECO:0000313|EMBL:QJA17477.1}, SARS-CoV-2/human/USA/ID-UW-4461/2020
+RC   {ECO:0000313|EMBL:QJA17489.1}, SARS-CoV-2/human/USA/ID-UW-4462/2020
+RC   {ECO:0000313|EMBL:QJC20232.1}, SARS-CoV-2/human/USA/ID-UW-4486/2020
+RC   {ECO:0000313|EMBL:QJC20244.1}, SARS-CoV-2/human/USA/IL-UW-1311/2020
+RC   {ECO:0000313|EMBL:QIZ14866.1}, SARS-CoV-2/human/USA/IL-UW348/2020
+RC   {ECO:0000313|EMBL:QIS61083.1}, SARS-CoV-2/human/USA/IL-UW349/2020
+RC   {ECO:0000313|EMBL:QIS61095.1}, SARS-CoV-2/human/USA/IL-UW353/2020
+RC   {ECO:0000313|EMBL:QIS61143.1}, SARS-CoV-2/human/USA/IL-UW381/2020
+RC   {ECO:0000313|EMBL:QIS61465.1}, SARS-CoV-2/human/USA/MN-UW266/2020
+RC   {ECO:0000313|EMBL:QIS30393.1}, SARS-CoV-2/human/USA/MN-UW326/2020
+RC   {ECO:0000313|EMBL:QIS60819.1}, SARS-CoV-2/human/USA/MN-UW335/2020
+RC   {ECO:0000313|EMBL:QIS60927.1}, SARS-CoV-2/human/USA/OR-UW-1849/2020
+RC   {ECO:0000313|EMBL:QIZ13188.1}, SARS-CoV-2/human/USA/OR-UW-1851/2020
+RC   {ECO:0000313|EMBL:QIZ13176.1}, SARS-CoV-2/human/USA/OR-UW-1885/2020
+RC   {ECO:0000313|EMBL:QIZ13428.1}, SARS-CoV-2/human/USA/OR-UW-1887/2020
+RC   {ECO:0000313|EMBL:QIZ13440.1}, SARS-CoV-2/human/USA/OR-UW-1937/2020
+RC   {ECO:0000313|EMBL:QIZ13379.1}, SARS-CoV-2/human/USA/OR-UW-4300/2020
+RC   {ECO:0000313|EMBL:QJC19716.1}, SARS-CoV-2/human/USA/OR-UW-4388/2020
+RC   {ECO:0000313|EMBL:QJA17369.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1402/2020
+RC   {ECO:0000313|EMBL:QIZ14948.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1403/2020
+RC   {ECO:0000313|EMBL:QIU81186.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1773/2020
+RC   {ECO:0000313|EMBL:QIZ14770.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1791/2020
+RC   {ECO:0000313|EMBL:QIZ13714.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1816/2020
+RC   {ECO:0000313|EMBL:QIZ13942.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1817/2020
+RC   {ECO:0000313|EMBL:QIZ13930.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1818/2020
+RC   {ECO:0000313|EMBL:QIZ13918.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1832/2020
+RC   {ECO:0000313|EMBL:QIZ13786.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-1834/2020
+RC   {ECO:0000313|EMBL:QIZ13903.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-2069/2020
+RC   {ECO:0000313|EMBL:QJA16457.1},
+RC   SARS-CoV-2/human/USA/UNKNOWN-UW-2139/2020
+RC   {ECO:0000313|EMBL:QJA16625.1}, SARS-CoV-2/human/USA/WA-UW-1268/2020
+RC   {ECO:0000313|EMBL:QIU81222.1}, SARS-CoV-2/human/USA/WA-UW-1269/2020
+RC   {ECO:0000313|EMBL:QIU81042.1}, SARS-CoV-2/human/USA/WA-UW-1271/2020
+RC   {ECO:0000313|EMBL:QIU80958.1}, SARS-CoV-2/human/USA/WA-UW-1279/2020
+RC   {ECO:0000313|EMBL:QIU81090.1}, SARS-CoV-2/human/USA/WA-UW-1287/2020
+RC   {ECO:0000313|EMBL:QIU81030.1}, SARS-CoV-2/human/USA/WA-UW-1294/2020
+RC   {ECO:0000313|EMBL:QIZ14938.1}, SARS-CoV-2/human/USA/WA-UW-1296/2020
+RC   {ECO:0000313|EMBL:QIU81258.1}, SARS-CoV-2/human/USA/WA-UW-1297/2020
+RC   {ECO:0000313|EMBL:QIU81270.1}, SARS-CoV-2/human/USA/WA-UW-1300/2020
+RC   {ECO:0000313|EMBL:QIU81210.1}, SARS-CoV-2/human/USA/WA-UW-1302/2020
+RC   {ECO:0000313|EMBL:QIU81006.1}, SARS-CoV-2/human/USA/WA-UW-1304/2020
+RC   {ECO:0000313|EMBL:QIU80970.1}, SARS-CoV-2/human/USA/WA-UW-1306/2020
+RC   {ECO:0000313|EMBL:QIU81114.1}, SARS-CoV-2/human/USA/WA-UW-1308/2020
+RC   {ECO:0000313|EMBL:QIU81078.1}, SARS-CoV-2/human/USA/WA-UW-1309/2020
+RC   {ECO:0000313|EMBL:QIU81126.1}, SARS-CoV-2/human/USA/WA-UW-1314/2020
+RC   {ECO:0000313|EMBL:QIU81294.1}, SARS-CoV-2/human/USA/WA-UW-1315/2020
+RC   {ECO:0000313|EMBL:QIU80982.1}, SARS-CoV-2/human/USA/WA-UW-1319/2020
+RC   {ECO:0000313|EMBL:QIU81066.1}, SARS-CoV-2/human/USA/WA-UW-1320/2020
+RC   {ECO:0000313|EMBL:QIU81054.1}, SARS-CoV-2/human/USA/WA-UW-1322/2020
+RC   {ECO:0000313|EMBL:QIU81330.1}, SARS-CoV-2/human/USA/WA-UW-1327/2020
+RC   {ECO:0000313|EMBL:QIU81102.1}, SARS-CoV-2/human/USA/WA-UW-1329/2020
+RC   {ECO:0000313|EMBL:QIU80994.1}, SARS-CoV-2/human/USA/WA-UW-1334/2020
+RC   {ECO:0000313|EMBL:QIU81342.1}, SARS-CoV-2/human/USA/WA-UW-1338/2020
+RC   {ECO:0000313|EMBL:QIU81234.1}, SARS-CoV-2/human/USA/WA-UW-1341/2020
+RC   {ECO:0000313|EMBL:QIZ14926.1}, SARS-CoV-2/human/USA/WA-UW-1342/2020
+RC   {ECO:0000313|EMBL:QIZ14914.1}, SARS-CoV-2/human/USA/WA-UW-1346/2020
+RC   {ECO:0000313|EMBL:QIU81354.1}, SARS-CoV-2/human/USA/WA-UW-1347/2020
+RC   {ECO:0000313|EMBL:QIU81306.1}, SARS-CoV-2/human/USA/WA-UW-1349/2020
+RC   {ECO:0000313|EMBL:QIU81390.1}, SARS-CoV-2/human/USA/WA-UW-1353/2020
+RC   {ECO:0000313|EMBL:QIU81246.1}, SARS-CoV-2/human/USA/WA-UW-1362/2020
+RC   {ECO:0000313|EMBL:QIZ14888.1}, SARS-CoV-2/human/USA/WA-UW-1417/2020
+RC   {ECO:0000313|EMBL:QIU81174.1}, SARS-CoV-2/human/USA/WA-UW-1422/2020
+RC   {ECO:0000313|EMBL:QIZ14986.1}, SARS-CoV-2/human/USA/WA-UW-1425/2020
+RC   {ECO:0000313|EMBL:QIU81738.1}, SARS-CoV-2/human/USA/WA-UW-1426/2020
+RC   {ECO:0000313|EMBL:QIU81498.1}, SARS-CoV-2/human/USA/WA-UW-1433/2020
+RC   {ECO:0000313|EMBL:QIU81726.1}, SARS-CoV-2/human/USA/WA-UW-1435/2020
+RC   {ECO:0000313|EMBL:QIU81666.1}, SARS-CoV-2/human/USA/WA-UW-1436/2020
+RC   {ECO:0000313|EMBL:QIZ14974.1}, SARS-CoV-2/human/USA/WA-UW-1440/2020
+RC   {ECO:0000313|EMBL:QIU81690.1}, SARS-CoV-2/human/USA/WA-UW-1441/2020
+RC   {ECO:0000313|EMBL:QIU81678.1}, SARS-CoV-2/human/USA/WA-UW-1446/2020
+RC   {ECO:0000313|EMBL:QIU81510.1}, SARS-CoV-2/human/USA/WA-UW-1448/2020
+RC   {ECO:0000313|EMBL:QIU81486.1}, SARS-CoV-2/human/USA/WA-UW-1470/2020
+RC   {ECO:0000313|EMBL:QIU81702.1}, SARS-CoV-2/human/USA/WA-UW-1471/2020
+RC   {ECO:0000313|EMBL:QIU81714.1}, SARS-CoV-2/human/USA/WA-UW-1472/2020
+RC   {ECO:0000313|EMBL:QIZ14902.1}, SARS-CoV-2/human/USA/WA-UW-1478/2020
+RC   {ECO:0000313|EMBL:QIZ14962.1}, SARS-CoV-2/human/USA/WA-UW-1538/2020
+RC   {ECO:0000313|EMBL:QIZ14818.1}, SARS-CoV-2/human/USA/WA-UW-1552/2020
+RC   {ECO:0000313|EMBL:QIU81570.1}, SARS-CoV-2/human/USA/WA-UW-1561/2020
+RC   {ECO:0000313|EMBL:QIU81522.1}, SARS-CoV-2/human/USA/WA-UW-1562/2020
+RC   {ECO:0000313|EMBL:QIU81654.1}, SARS-CoV-2/human/USA/WA-UW-1567/2020
+RC   {ECO:0000313|EMBL:QIU81414.1}, SARS-CoV-2/human/USA/WA-UW-1569/2020
+RC   {ECO:0000313|EMBL:QIU81642.1}, SARS-CoV-2/human/USA/WA-UW-1570/2020
+RC   {ECO:0000313|EMBL:QIU81630.1}, SARS-CoV-2/human/USA/WA-UW-1572/2020
+RC   {ECO:0000313|EMBL:QIZ14842.1}, SARS-CoV-2/human/USA/WA-UW-1574/2020
+RC   {ECO:0000313|EMBL:QIU81618.1}, SARS-CoV-2/human/USA/WA-UW-1575/2020
+RC   {ECO:0000313|EMBL:QIZ14854.1}, SARS-CoV-2/human/USA/WA-UW-1576/2020
+RC   {ECO:0000313|EMBL:QIU81606.1}, SARS-CoV-2/human/USA/WA-UW-1578/2020
+RC   {ECO:0000313|EMBL:QIU81582.1}, SARS-CoV-2/human/USA/WA-UW-1581/2020
+RC   {ECO:0000313|EMBL:QIU81450.1}, SARS-CoV-2/human/USA/WA-UW-1583/2020
+RC   {ECO:0000313|EMBL:QIU81438.1}, SARS-CoV-2/human/USA/WA-UW-1586/2020
+RC   {ECO:0000313|EMBL:QIU81546.1}, SARS-CoV-2/human/USA/WA-UW-1587/2020
+RC   {ECO:0000313|EMBL:QIU81558.1}, SARS-CoV-2/human/USA/WA-UW-1588/2020
+RC   {ECO:0000313|EMBL:QIU81534.1}, SARS-CoV-2/human/USA/WA-UW-1591/2020
+RC   {ECO:0000313|EMBL:QIU81594.1}, SARS-CoV-2/human/USA/WA-UW-1593/2020
+RC   {ECO:0000313|EMBL:QIU81426.1}, SARS-CoV-2/human/USA/WA-UW-1595/2020
+RC   {ECO:0000313|EMBL:QIZ14830.1}, SARS-CoV-2/human/USA/WA-UW-1599/2020
+RC   {ECO:0000313|EMBL:QIU81762.1}, SARS-CoV-2/human/USA/WA-UW-1603/2020
+RC   {ECO:0000313|EMBL:QIU81462.1}, SARS-CoV-2/human/USA/WA-UW-1608/2020
+RC   {ECO:0000313|EMBL:QIU81750.1}, SARS-CoV-2/human/USA/WA-UW-1611/2020
+RC   {ECO:0000313|EMBL:QIU81474.1}, SARS-CoV-2/human/USA/WA-UW-1616/2020
+RC   {ECO:0000313|EMBL:QIZ14794.1}, SARS-CoV-2/human/USA/WA-UW-1620/2020
+RC   {ECO:0000313|EMBL:QIZ14782.1}, SARS-CoV-2/human/USA/WA-UW-1638/2020
+RC   {ECO:0000313|EMBL:QIZ14805.1}, SARS-CoV-2/human/USA/WA-UW-1640/2020
+RC   {ECO:0000313|EMBL:QIZ14158.1}, SARS-CoV-2/human/USA/WA-UW-1644/2020
+RC   {ECO:0000313|EMBL:QIZ14038.1}, SARS-CoV-2/human/USA/WA-UW-1645/2020
+RC   {ECO:0000313|EMBL:QIZ14062.1}, SARS-CoV-2/human/USA/WA-UW-1646/2020
+RC   {ECO:0000313|EMBL:QIZ14050.1}, SARS-CoV-2/human/USA/WA-UW-1651/2020
+RC   {ECO:0000313|EMBL:QIZ14218.1}, SARS-CoV-2/human/USA/WA-UW-1652/2020
+RC   {ECO:0000313|EMBL:QIZ14230.1}, SARS-CoV-2/human/USA/WA-UW-1656/2020
+RC   {ECO:0000313|EMBL:QIZ14170.1}, SARS-CoV-2/human/USA/WA-UW-1659/2020
+RC   {ECO:0000313|EMBL:QIZ14204.1}, SARS-CoV-2/human/USA/WA-UW-1661/2020
+RC   {ECO:0000313|EMBL:QIZ14122.1}, SARS-CoV-2/human/USA/WA-UW-1666/2020
+RC   {ECO:0000313|EMBL:QIZ14146.1}, SARS-CoV-2/human/USA/WA-UW-1670/2020
+RC   {ECO:0000313|EMBL:QIZ14350.1}, SARS-CoV-2/human/USA/WA-UW-1672/2020
+RC   {ECO:0000313|EMBL:QIZ14182.1}, SARS-CoV-2/human/USA/WA-UW-1673/2020
+RC   {ECO:0000313|EMBL:QIZ14266.1}, SARS-CoV-2/human/USA/WA-UW-1675/2020
+RC   {ECO:0000313|EMBL:QIZ14073.1}, SARS-CoV-2/human/USA/WA-UW-1677/2020
+RC   {ECO:0000313|EMBL:QIZ14362.1}, SARS-CoV-2/human/USA/WA-UW-1680/2020
+RC   {ECO:0000313|EMBL:QIZ14374.1}, SARS-CoV-2/human/USA/WA-UW-1682/2020
+RC   {ECO:0000313|EMBL:QIZ14410.1}, SARS-CoV-2/human/USA/WA-UW-1683/2020
+RC   {ECO:0000313|EMBL:QIZ14086.1}, SARS-CoV-2/human/USA/WA-UW-1684/2020
+RC   {ECO:0000313|EMBL:QIZ14393.1}, SARS-CoV-2/human/USA/WA-UW-1688/2020
+RC   {ECO:0000313|EMBL:QIZ14098.1}, SARS-CoV-2/human/USA/WA-UW-1689/2020
+RC   {ECO:0000313|EMBL:QIZ14326.1}, SARS-CoV-2/human/USA/WA-UW-1690/2020
+RC   {ECO:0000313|EMBL:QIZ14386.1}, SARS-CoV-2/human/USA/WA-UW-1695/2020
+RC   {ECO:0000313|EMBL:QIZ14422.1}, SARS-CoV-2/human/USA/WA-UW-1697/2020
+RC   {ECO:0000313|EMBL:QIZ14254.1}, SARS-CoV-2/human/USA/WA-UW-1698/2020
+RC   {ECO:0000313|EMBL:QIZ14242.1}, SARS-CoV-2/human/USA/WA-UW-1700/2020
+RC   {ECO:0000313|EMBL:QIZ14458.1}, SARS-CoV-2/human/USA/WA-UW-1702/2020
+RC   {ECO:0000313|EMBL:QIZ14530.1}, SARS-CoV-2/human/USA/WA-UW-1705/2020
+RC   {ECO:0000313|EMBL:QIZ14506.1}, SARS-CoV-2/human/USA/WA-UW-1706/2020
+RC   {ECO:0000313|EMBL:QIZ14518.1}, SARS-CoV-2/human/USA/WA-UW-1707/2020
+RC   {ECO:0000313|EMBL:QIZ14494.1}, SARS-CoV-2/human/USA/WA-UW-1708/2020
+RC   {ECO:0000313|EMBL:QIZ14578.1}, SARS-CoV-2/human/USA/WA-UW-1709/2020
+RC   {ECO:0000313|EMBL:QIZ14552.1}, SARS-CoV-2/human/USA/WA-UW-1712/2020
+RC   {ECO:0000313|EMBL:QIZ14290.1}, SARS-CoV-2/human/USA/WA-UW-1715/2020
+RC   {ECO:0000313|EMBL:QIZ14338.1}, SARS-CoV-2/human/USA/WA-UW-1716/2020
+RC   {ECO:0000313|EMBL:QIZ14278.1}, SARS-CoV-2/human/USA/WA-UW-1718/2020
+RC   {ECO:0000313|EMBL:QIZ14314.1}, SARS-CoV-2/human/USA/WA-UW-1722/2020
+RC   {ECO:0000313|EMBL:QIZ14602.1}, SARS-CoV-2/human/USA/WA-UW-1723/2020
+RC   {ECO:0000313|EMBL:QIZ14194.1}, SARS-CoV-2/human/USA/WA-UW-1724/2020
+RC   {ECO:0000313|EMBL:QIZ14542.1}, SARS-CoV-2/human/USA/WA-UW-1726/2020
+RC   {ECO:0000313|EMBL:QIZ14134.1}, SARS-CoV-2/human/USA/WA-UW-1728/2020
+RC   {ECO:0000313|EMBL:QIZ14110.1}, SARS-CoV-2/human/USA/WA-UW-1729/2020
+RC   {ECO:0000313|EMBL:QIZ14434.1}, SARS-CoV-2/human/USA/WA-UW-1730/2020
+RC   {ECO:0000313|EMBL:QIZ14672.1}, SARS-CoV-2/human/USA/WA-UW-1731/2020
+RC   {ECO:0000313|EMBL:QIZ14566.1}, SARS-CoV-2/human/USA/WA-UW-1732/2020
+RC   {ECO:0000313|EMBL:QIZ14626.1}, SARS-CoV-2/human/USA/WA-UW-1733/2020
+RC   {ECO:0000313|EMBL:QIZ14614.1}, SARS-CoV-2/human/USA/WA-UW-1735/2020
+RC   {ECO:0000313|EMBL:QIZ14686.1}, SARS-CoV-2/human/USA/WA-UW-1739/2020
+RC   {ECO:0000313|EMBL:QIZ14638.1}, SARS-CoV-2/human/USA/WA-UW-1741/2020
+RC   {ECO:0000313|EMBL:QIZ14650.1}, SARS-CoV-2/human/USA/WA-UW-1744/2020
+RC   {ECO:0000313|EMBL:QIZ14470.1}, SARS-CoV-2/human/USA/WA-UW-1745/2020
+RC   {ECO:0000313|EMBL:QIZ14482.1}, SARS-CoV-2/human/USA/WA-UW-1748/2020
+RC   {ECO:0000313|EMBL:QIZ14446.1}, SARS-CoV-2/human/USA/WA-UW-1750/2020
+RC   {ECO:0000313|EMBL:QIZ14662.1}, SARS-CoV-2/human/USA/WA-UW-1753/2020
+RC   {ECO:0000313|EMBL:QIZ14698.1}, SARS-CoV-2/human/USA/WA-UW-1756/2020
+RC   {ECO:0000313|EMBL:QIZ14710.1}, SARS-CoV-2/human/USA/WA-UW-1758/2020
+RC   {ECO:0000313|EMBL:QIZ14746.1}, SARS-CoV-2/human/USA/WA-UW-1760/2020
+RC   {ECO:0000313|EMBL:QIZ14758.1}, SARS-CoV-2/human/USA/WA-UW-1762/2020
+RC   {ECO:0000313|EMBL:QIZ14734.1}, SARS-CoV-2/human/USA/WA-UW-1765/2020
+RC   {ECO:0000313|EMBL:QIZ14302.1}, SARS-CoV-2/human/USA/WA-UW-1770/2020
+RC   {ECO:0000313|EMBL:QIZ14722.1}, SARS-CoV-2/human/USA/WA-UW-1772/2020
+RC   {ECO:0000313|EMBL:QIZ14590.1}, SARS-CoV-2/human/USA/WA-UW-1774/2020
+RC   {ECO:0000313|EMBL:QIZ13798.1}, SARS-CoV-2/human/USA/WA-UW-1775/2020
+RC   {ECO:0000313|EMBL:QIZ13810.1}, SARS-CoV-2/human/USA/WA-UW-1778/2020
+RC   {ECO:0000313|EMBL:QIZ13822.1}, SARS-CoV-2/human/USA/WA-UW-1779/2020
+RC   {ECO:0000313|EMBL:QIZ13846.1}, SARS-CoV-2/human/USA/WA-UW-1782/2020
+RC   {ECO:0000313|EMBL:QIZ13870.1}, SARS-CoV-2/human/USA/WA-UW-1784/2020
+RC   {ECO:0000313|EMBL:QIZ13858.1}, SARS-CoV-2/human/USA/WA-UW-1785/2020
+RC   {ECO:0000313|EMBL:QIZ13726.1}, SARS-CoV-2/human/USA/WA-UW-1792/2020
+RC   {ECO:0000313|EMBL:QIZ13762.1}, SARS-CoV-2/human/USA/WA-UW-1796/2020
+RC   {ECO:0000313|EMBL:QIZ13774.1}, SARS-CoV-2/human/USA/WA-UW-1797/2020
+RC   {ECO:0000313|EMBL:QIZ13834.1}, SARS-CoV-2/human/USA/WA-UW-1799/2020
+RC   {ECO:0000313|EMBL:QIZ13882.1}, SARS-CoV-2/human/USA/WA-UW-1801/2020
+RC   {ECO:0000313|EMBL:QIZ13738.1}, SARS-CoV-2/human/USA/WA-UW-1805/2020
+RC   {ECO:0000313|EMBL:QIZ13894.1}, SARS-CoV-2/human/USA/WA-UW-1821/2020
+RC   {ECO:0000313|EMBL:QIZ14012.1}, SARS-CoV-2/human/USA/WA-UW-1822/2020
+RC   {ECO:0000313|EMBL:QIZ14026.1}, SARS-CoV-2/human/USA/WA-UW-1825/2020
+RC   {ECO:0000313|EMBL:QIZ13989.1}, SARS-CoV-2/human/USA/WA-UW-1826/2020
+RC   {ECO:0000313|EMBL:QIZ14002.1}, SARS-CoV-2/human/USA/WA-UW-1827/2020
+RC   {ECO:0000313|EMBL:QIZ13978.1}, SARS-CoV-2/human/USA/WA-UW-1828/2020
+RC   {ECO:0000313|EMBL:QIZ13954.1}, SARS-CoV-2/human/USA/WA-UW-1831/2020
+RC   {ECO:0000313|EMBL:QIZ13966.1}, SARS-CoV-2/human/USA/WA-UW-1835/2020
+RC   {ECO:0000313|EMBL:QIZ13140.1}, SARS-CoV-2/human/USA/WA-UW-1840/2020
+RC   {ECO:0000313|EMBL:QIZ13750.1}, SARS-CoV-2/human/USA/WA-UW-1843/2020
+RC   {ECO:0000313|EMBL:QIZ13200.1}, SARS-CoV-2/human/USA/WA-UW-1846/2020
+RC   {ECO:0000313|EMBL:QIZ13212.1}, SARS-CoV-2/human/USA/WA-UW-1850/2020
+RC   {ECO:0000313|EMBL:QIZ13104.1}, SARS-CoV-2/human/USA/WA-UW-1853/2020
+RC   {ECO:0000313|EMBL:QIZ13236.1}, SARS-CoV-2/human/USA/WA-UW-1854/2020
+RC   {ECO:0000313|EMBL:QIZ13248.1}, SARS-CoV-2/human/USA/WA-UW-1855/2020
+RC   {ECO:0000313|EMBL:QIZ13260.1}, SARS-CoV-2/human/USA/WA-UW-1858/2020
+RC   {ECO:0000313|EMBL:QIZ13078.1}, SARS-CoV-2/human/USA/WA-UW-1860/2020
+RC   {ECO:0000313|EMBL:QIZ13224.1}, SARS-CoV-2/human/USA/WA-UW-1863/2020
+RC   {ECO:0000313|EMBL:QIZ13164.1}, SARS-CoV-2/human/USA/WA-UW-1864/2020
+RC   {ECO:0000313|EMBL:QIZ13128.1}, SARS-CoV-2/human/USA/WA-UW-1865/2020
+RC   {ECO:0000313|EMBL:QIZ13678.1}, SARS-CoV-2/human/USA/WA-UW-1866/2020
+RC   {ECO:0000313|EMBL:QIZ13092.1}, SARS-CoV-2/human/USA/WA-UW-1868/2020
+RC   {ECO:0000313|EMBL:QIZ13116.1}, SARS-CoV-2/human/USA/WA-UW-1870/2020
+RC   {ECO:0000313|EMBL:QIZ13272.1}, SARS-CoV-2/human/USA/WA-UW-1872/2020
+RC   {ECO:0000313|EMBL:QIZ13284.1}, SARS-CoV-2/human/USA/WA-UW-1874/2020
+RC   {ECO:0000313|EMBL:QIZ13414.1}, SARS-CoV-2/human/USA/WA-UW-1877/2020
+RC   {ECO:0000313|EMBL:QIZ13404.1}, SARS-CoV-2/human/USA/WA-UW-1878/2020
+RC   {ECO:0000313|EMBL:QIZ13368.1}, SARS-CoV-2/human/USA/WA-UW-1879/2020
+RC   {ECO:0000313|EMBL:QIZ13356.1}, SARS-CoV-2/human/USA/WA-UW-1880/2020
+RC   {ECO:0000313|EMBL:QIZ13476.1}, SARS-CoV-2/human/USA/WA-UW-1881/2020
+RC   {ECO:0000313|EMBL:QIZ13452.1}, SARS-CoV-2/human/USA/WA-UW-1888/2020
+RC   {ECO:0000313|EMBL:QIZ13464.1}, SARS-CoV-2/human/USA/WA-UW-1890/2020
+RC   {ECO:0000313|EMBL:QIZ13524.1}, SARS-CoV-2/human/USA/WA-UW-1904/2020
+RC   {ECO:0000313|EMBL:QIZ13344.1}, SARS-CoV-2/human/USA/WA-UW-1905/2020
+RC   {ECO:0000313|EMBL:QIZ13295.1}, SARS-CoV-2/human/USA/WA-UW-1907/2020
+RC   {ECO:0000313|EMBL:QIZ13690.1}, SARS-CoV-2/human/USA/WA-UW-1913/2020
+RC   {ECO:0000313|EMBL:QIZ13320.1}, SARS-CoV-2/human/USA/WA-UW-1917/2020
+RC   {ECO:0000313|EMBL:QIZ13702.1}, SARS-CoV-2/human/USA/WA-UW-1919/2020
+RC   {ECO:0000313|EMBL:QIZ13308.1}, SARS-CoV-2/human/USA/WA-UW-1920/2020
+RC   {ECO:0000313|EMBL:QIZ13332.1}, SARS-CoV-2/human/USA/WA-UW-1921/2020
+RC   {ECO:0000313|EMBL:QIZ13512.1}, SARS-CoV-2/human/USA/WA-UW-1928/2020
+RC   {ECO:0000313|EMBL:QIZ13536.1}, SARS-CoV-2/human/USA/WA-UW-1930/2020
+RC   {ECO:0000313|EMBL:QIZ13392.1}, SARS-CoV-2/human/USA/WA-UW-1944/2020
+RC   {ECO:0000313|EMBL:QIZ13608.1}, SARS-CoV-2/human/USA/WA-UW-1946/2020
+RC   {ECO:0000313|EMBL:QIZ13151.1}, SARS-CoV-2/human/USA/WA-UW-1954/2020
+RC   {ECO:0000313|EMBL:QIZ13632.1}, SARS-CoV-2/human/USA/WA-UW-1955/2020
+RC   {ECO:0000313|EMBL:QIZ13488.1}, SARS-CoV-2/human/USA/WA-UW-1956/2020
+RC   {ECO:0000313|EMBL:QIZ13500.1}, SARS-CoV-2/human/USA/WA-UW-1963/2020
+RC   {ECO:0000313|EMBL:QIZ13654.1}, SARS-CoV-2/human/USA/WA-UW-1965/2020
+RC   {ECO:0000313|EMBL:QIZ13620.1}, SARS-CoV-2/human/USA/WA-UW-1968/2020
+RC   {ECO:0000313|EMBL:QIZ13641.1}, SARS-CoV-2/human/USA/WA-UW-1977/2020
+RC   {ECO:0000313|EMBL:QIZ13020.1}, SARS-CoV-2/human/USA/WA-UW-1984/2020
+RC   {ECO:0000313|EMBL:QIZ13666.1}, SARS-CoV-2/human/USA/WA-UW-1986/2020
+RC   {ECO:0000313|EMBL:QIZ13032.1}, SARS-CoV-2/human/USA/WA-UW-1988/2020
+RC   {ECO:0000313|EMBL:QIZ13008.1}, SARS-CoV-2/human/USA/WA-UW-1994/2020
+RC   {ECO:0000313|EMBL:QIZ12984.1}, SARS-CoV-2/human/USA/WA-UW-1998/2020
+RC   {ECO:0000313|EMBL:QIZ12996.1}, SARS-CoV-2/human/USA/WA-UW-2006/2020
+RC   {ECO:0000313|EMBL:QIZ12972.1}, SARS-CoV-2/human/USA/WA-UW-2008/2020
+RC   {ECO:0000313|EMBL:QIZ13068.1}, SARS-CoV-2/human/USA/WA-UW-2009/2020
+RC   {ECO:0000313|EMBL:QIZ13056.1}, SARS-CoV-2/human/USA/WA-UW-2016/2020
+RC   {ECO:0000313|EMBL:QIZ13044.1}, SARS-CoV-2/human/USA/WA-UW-2072/2020
+RC   {ECO:0000313|EMBL:QJA16481.1}, SARS-CoV-2/human/USA/WA-UW-2074/2020
+RC   {ECO:0000313|EMBL:QJA16517.1}, SARS-CoV-2/human/USA/WA-UW-2078/2020
+RC   {ECO:0000313|EMBL:QJA16493.1}, SARS-CoV-2/human/USA/WA-UW-2082/2020
+RC   {ECO:0000313|EMBL:QJA16431.1}, SARS-CoV-2/human/USA/WA-UW-2086/2020
+RC   {ECO:0000313|EMBL:QJA16553.1}, SARS-CoV-2/human/USA/WA-UW-2087/2020
+RC   {ECO:0000313|EMBL:QJA16505.1}, SARS-CoV-2/human/USA/WA-UW-2091/2020
+RC   {ECO:0000313|EMBL:QJA16409.1}, SARS-CoV-2/human/USA/WA-UW-2094/2020
+RC   {ECO:0000313|EMBL:QJA16577.1}, SARS-CoV-2/human/USA/WA-UW-2100/2020
+RC   {ECO:0000313|EMBL:QJA16685.1}, SARS-CoV-2/human/USA/WA-UW-2104/2020
+RC   {ECO:0000313|EMBL:QJA16601.1}, SARS-CoV-2/human/USA/WA-UW-2108/2020
+RC   {ECO:0000313|EMBL:QJA16565.1}, SARS-CoV-2/human/USA/WA-UW-2109/2020
+RC   {ECO:0000313|EMBL:QJA16649.1}, SARS-CoV-2/human/USA/WA-UW-2112/2020
+RC   {ECO:0000313|EMBL:QJA16661.1}, SARS-CoV-2/human/USA/WA-UW-2115/2020
+RC   {ECO:0000313|EMBL:QJA16589.1}, SARS-CoV-2/human/USA/WA-UW-2119/2020
+RC   {ECO:0000313|EMBL:QJA16541.1}, SARS-CoV-2/human/USA/WA-UW-2129/2020
+RC   {ECO:0000313|EMBL:QJA16673.1}, SARS-CoV-2/human/USA/WA-UW-2131/2020
+RC   {ECO:0000313|EMBL:QJA16445.1}, SARS-CoV-2/human/USA/WA-UW-2132/2020
+RC   {ECO:0000313|EMBL:QJA16529.1}, SARS-CoV-2/human/USA/WA-UW-2137/2020
+RC   {ECO:0000313|EMBL:QJA16613.1}, SARS-CoV-2/human/USA/WA-UW-2140/2020
+RC   {ECO:0000313|EMBL:QJA16721.1}, SARS-CoV-2/human/USA/WA-UW-2141/2020
+RC   {ECO:0000313|EMBL:QJA16697.1}, SARS-CoV-2/human/USA/WA-UW-2142/2020
+RC   {ECO:0000313|EMBL:QJA16781.1}, SARS-CoV-2/human/USA/WA-UW-2144/2020
+RC   {ECO:0000313|EMBL:QJA16745.1}, SARS-CoV-2/human/USA/WA-UW-2145/2020
+RC   {ECO:0000313|EMBL:QJA16733.1}, SARS-CoV-2/human/USA/WA-UW-2146/2020
+RC   {ECO:0000313|EMBL:QJA16757.1}, SARS-CoV-2/human/USA/WA-UW-2149/2020
+RC   {ECO:0000313|EMBL:QJA16793.1}, SARS-CoV-2/human/USA/WA-UW-2164/2020
+RC   {ECO:0000313|EMBL:QJA16709.1}, SARS-CoV-2/human/USA/WA-UW-2169/2020
+RC   {ECO:0000313|EMBL:QJA16421.1}, SARS-CoV-2/human/USA/WA-UW-2177/2020
+RC   {ECO:0000313|EMBL:QJA16970.1}, SARS-CoV-2/human/USA/WA-UW-2179/2020
+RC   {ECO:0000313|EMBL:QJA16949.1}, SARS-CoV-2/human/USA/WA-UW-2180/2020
+RC   {ECO:0000313|EMBL:QJA16961.1}, SARS-CoV-2/human/USA/WA-UW-2181/2020
+RC   {ECO:0000313|EMBL:QJA16817.1}, SARS-CoV-2/human/USA/WA-UW-2192/2020
+RC   {ECO:0000313|EMBL:QJA17057.1}, SARS-CoV-2/human/USA/WA-UW-2193/2020
+RC   {ECO:0000313|EMBL:QJA17032.1}, SARS-CoV-2/human/USA/WA-UW-2203/2020
+RC   {ECO:0000313|EMBL:QJA16829.1}, SARS-CoV-2/human/USA/WA-UW-2208/2020
+RC   {ECO:0000313|EMBL:QJA17213.1}, SARS-CoV-2/human/USA/WA-UW-2212/2020
+RC   {ECO:0000313|EMBL:QJA17165.1}, SARS-CoV-2/human/USA/WA-UW-2213/2020
+RC   {ECO:0000313|EMBL:QJA17177.1}, SARS-CoV-2/human/USA/WA-UW-2214/2020
+RC   {ECO:0000313|EMBL:QJA17153.1}, SARS-CoV-2/human/USA/WA-UW-2215/2020
+RC   {ECO:0000313|EMBL:QJA17141.1}, SARS-CoV-2/human/USA/WA-UW-2218/2020
+RC   {ECO:0000313|EMBL:QJA17105.1}, SARS-CoV-2/human/USA/WA-UW-2219/2020
+RC   {ECO:0000313|EMBL:QJA17081.1}, SARS-CoV-2/human/USA/WA-UW-2220/2020
+RC   {ECO:0000313|EMBL:QJA16898.1}, SARS-CoV-2/human/USA/WA-UW-2225/2020
+RC   {ECO:0000313|EMBL:QJA16877.1}, SARS-CoV-2/human/USA/WA-UW-2228/2020
+RC   {ECO:0000313|EMBL:QJA16865.1}, SARS-CoV-2/human/USA/WA-UW-2230/2020
+RC   {ECO:0000313|EMBL:QJA17069.1}, SARS-CoV-2/human/USA/WA-UW-2232/2020
+RC   {ECO:0000313|EMBL:QJA17045.1}, SARS-CoV-2/human/USA/WA-UW-2234/2020
+RC   {ECO:0000313|EMBL:QJA16985.1}, SARS-CoV-2/human/USA/WA-UW-2235/2020
+RC   {ECO:0000313|EMBL:QJA17021.1}, SARS-CoV-2/human/USA/WA-UW-2236/2020
+RC   {ECO:0000313|EMBL:QJA16889.1}, SARS-CoV-2/human/USA/WA-UW-2238/2020
+RC   {ECO:0000313|EMBL:QJA17009.1}, SARS-CoV-2/human/USA/WA-UW-2240/2020
+RC   {ECO:0000313|EMBL:QJA16841.1}, SARS-CoV-2/human/USA/WA-UW-2244/2020
+RC   {ECO:0000313|EMBL:QJA16853.1}, SARS-CoV-2/human/USA/WA-UW-2245/2020
+RC   {ECO:0000313|EMBL:QJA17093.1}, SARS-CoV-2/human/USA/WA-UW-2247/2020
+RC   {ECO:0000313|EMBL:QJA16925.1}, SARS-CoV-2/human/USA/WA-UW-2249/2020
+RC   {ECO:0000313|EMBL:QJA16913.1}, SARS-CoV-2/human/USA/WA-UW-2250/2020
+RC   {ECO:0000313|EMBL:QJA16937.1}, SARS-CoV-2/human/USA/WA-UW-2253/2020
+RC   {ECO:0000313|EMBL:QJA16997.1}, SARS-CoV-2/human/USA/WA-UW-2258/2020
+RC   {ECO:0000313|EMBL:QJA17237.1}, SARS-CoV-2/human/USA/WA-UW-3809/2020
+RC   {ECO:0000313|EMBL:QJC19872.1}, SARS-CoV-2/human/USA/WA-UW-3810/2020
+RC   {ECO:0000313|EMBL:QJC19884.1}, SARS-CoV-2/human/USA/WA-UW-3812/2020
+RC   {ECO:0000313|EMBL:QJC19896.1}, SARS-CoV-2/human/USA/WA-UW-3814/2020
+RC   {ECO:0000313|EMBL:QJC19908.1}, SARS-CoV-2/human/USA/WA-UW-3815/2020
+RC   {ECO:0000313|EMBL:QJC19920.1}, SARS-CoV-2/human/USA/WA-UW-3816/2020
+RC   {ECO:0000313|EMBL:QJC19932.1}, SARS-CoV-2/human/USA/WA-UW-3819/2020
+RC   {ECO:0000313|EMBL:QJC19944.1}, SARS-CoV-2/human/USA/WA-UW-3826/2020
+RC   {ECO:0000313|EMBL:QJC19956.1}, SARS-CoV-2/human/USA/WA-UW-3827/2020
+RC   {ECO:0000313|EMBL:QJC19968.1}, SARS-CoV-2/human/USA/WA-UW-3828/2020
+RC   {ECO:0000313|EMBL:QJC19980.1}, SARS-CoV-2/human/USA/WA-UW-3829/2020
+RC   {ECO:0000313|EMBL:QJC19992.1}, SARS-CoV-2/human/USA/WA-UW-3832/2020
+RC   {ECO:0000313|EMBL:QJC20004.1}, SARS-CoV-2/human/USA/WA-UW-3833/2020
+RC   {ECO:0000313|EMBL:QJC20016.1}, SARS-CoV-2/human/USA/WA-UW-3834/2020
+RC   {ECO:0000313|EMBL:QJC20028.1}, SARS-CoV-2/human/USA/WA-UW-3838/2020
+RC   {ECO:0000313|EMBL:QJC20040.1}, SARS-CoV-2/human/USA/WA-UW-3839/2020
+RC   {ECO:0000313|EMBL:QJC20052.1}, SARS-CoV-2/human/USA/WA-UW-3841/2020
+RC   {ECO:0000313|EMBL:QJC20064.1}, SARS-CoV-2/human/USA/WA-UW-3843/2020
+RC   {ECO:0000313|EMBL:QJC20076.1}, SARS-CoV-2/human/USA/WA-UW-3844/2020
+RC   {ECO:0000313|EMBL:QJC20088.1}, SARS-CoV-2/human/USA/WA-UW-3850/2020
+RC   {ECO:0000313|EMBL:QJC20112.1}, SARS-CoV-2/human/USA/WA-UW-3855/2020
+RC   {ECO:0000313|EMBL:QJC20124.1}, SARS-CoV-2/human/USA/WA-UW-3858/2020
+RC   {ECO:0000313|EMBL:QJC20136.1}, SARS-CoV-2/human/USA/WA-UW-3862/2020
+RC   {ECO:0000313|EMBL:QJC20148.1}, SARS-CoV-2/human/USA/WA-UW-3868/2020
+RC   {ECO:0000313|EMBL:QJC20160.1}, SARS-CoV-2/human/USA/WA-UW-3871/2020
+RC   {ECO:0000313|EMBL:QJC20172.1}, SARS-CoV-2/human/USA/WA-UW-3880/2020
+RC   {ECO:0000313|EMBL:QJC20184.1}, SARS-CoV-2/human/USA/WA-UW-3881/2020
+RC   {ECO:0000313|EMBL:QJC20196.1}, SARS-CoV-2/human/USA/WA-UW-3883/2020
+RC   {ECO:0000313|EMBL:QJC20208.1}, SARS-CoV-2/human/USA/WA-UW-3889/2020
+RC   {ECO:0000313|EMBL:QJC20280.1}, SARS-CoV-2/human/USA/WA-UW-3895/2020
+RC   {ECO:0000313|EMBL:QJC20304.1}, SARS-CoV-2/human/USA/WA-UW-3900/2020
+RC   {ECO:0000313|EMBL:QJC20316.1}, SARS-CoV-2/human/USA/WA-UW-3903/2020
+RC   {ECO:0000313|EMBL:QJC20328.1}, SARS-CoV-2/human/USA/WA-UW-3908/2020
+RC   {ECO:0000313|EMBL:QJC20340.1}, SARS-CoV-2/human/USA/WA-UW-3911/2020
+RC   {ECO:0000313|EMBL:QJC20352.1}, SARS-CoV-2/human/USA/WA-UW-3918/2020
+RC   {ECO:0000313|EMBL:QJC20364.1}, SARS-CoV-2/human/USA/WA-UW-3923/2020
+RC   {ECO:0000313|EMBL:QJC20376.1}, SARS-CoV-2/human/USA/WA-UW-3932/2020
+RC   {ECO:0000313|EMBL:QJC20388.1}, SARS-CoV-2/human/USA/WA-UW-3935/2020
+RC   {ECO:0000313|EMBL:QJC20400.1}, SARS-CoV-2/human/USA/WA-UW-3939/2020
+RC   {ECO:0000313|EMBL:QJC20412.1}, SARS-CoV-2/human/USA/WA-UW-3940/2020
+RC   {ECO:0000313|EMBL:QJC20424.1}, SARS-CoV-2/human/USA/WA-UW-3941/2020
+RC   {ECO:0000313|EMBL:QJC20436.1}, SARS-CoV-2/human/USA/WA-UW-3942/2020
+RC   {ECO:0000313|EMBL:QJC20448.1}, SARS-CoV-2/human/USA/WA-UW-3946/2020
+RC   {ECO:0000313|EMBL:QJC20460.1}, SARS-CoV-2/human/USA/WA-UW-3950/2020
+RC   {ECO:0000313|EMBL:QJC20472.1}, SARS-CoV-2/human/USA/WA-UW-3954/2020
+RC   {ECO:0000313|EMBL:QJC20484.1}, SARS-CoV-2/human/USA/WA-UW-3959/2020
+RC   {ECO:0000313|EMBL:QJC20496.1}, SARS-CoV-2/human/USA/WA-UW-3963/2020
+RC   {ECO:0000313|EMBL:QJC20507.1}, SARS-CoV-2/human/USA/WA-UW-3964/2020
+RC   {ECO:0000313|EMBL:QJC20519.1}, SARS-CoV-2/human/USA/WA-UW-3969/2020
+RC   {ECO:0000313|EMBL:QJC20531.1}, SARS-CoV-2/human/USA/WA-UW-3983/2020
+RC   {ECO:0000313|EMBL:QJC20543.1}, SARS-CoV-2/human/USA/WA-UW-3984/2020
+RC   {ECO:0000313|EMBL:QJC20555.1}, SARS-CoV-2/human/USA/WA-UW-3985/2020
+RC   {ECO:0000313|EMBL:QJC20567.1}, SARS-CoV-2/human/USA/WA-UW-3986/2020
+RC   {ECO:0000313|EMBL:QJC20579.1}, SARS-CoV-2/human/USA/WA-UW-3988/2020
+RC   {ECO:0000313|EMBL:QJC20591.1}, SARS-CoV-2/human/USA/WA-UW-3989/2020
+RC   {ECO:0000313|EMBL:QJC20603.1}, SARS-CoV-2/human/USA/WA-UW-3990/2020
+RC   {ECO:0000313|EMBL:QJC20615.1}, SARS-CoV-2/human/USA/WA-UW-3994/2020
+RC   {ECO:0000313|EMBL:QJC20627.1}, SARS-CoV-2/human/USA/WA-UW-3996/2020
+RC   {ECO:0000313|EMBL:QJC20639.1}, SARS-CoV-2/human/USA/WA-UW-3997/2020
+RC   {ECO:0000313|EMBL:QJC20651.1}, SARS-CoV-2/human/USA/WA-UW-4035/2020
+RC   {ECO:0000313|EMBL:QJC20663.1}, SARS-CoV-2/human/USA/WA-UW-4038/2020
+RC   {ECO:0000313|EMBL:QJC20675.1}, SARS-CoV-2/human/USA/WA-UW-4039/2020
+RC   {ECO:0000313|EMBL:QJC20687.1}, SARS-CoV-2/human/USA/WA-UW-4068/2020
+RC   {ECO:0000313|EMBL:QJC20699.1}, SARS-CoV-2/human/USA/WA-UW-4082/2020
+RC   {ECO:0000313|EMBL:QJC20711.1}, SARS-CoV-2/human/USA/WA-UW-4105/2020
+RC   {ECO:0000313|EMBL:QJC20735.1}, SARS-CoV-2/human/USA/WA-UW-4109/2020
+RC   {ECO:0000313|EMBL:QJC20747.1}, SARS-CoV-2/human/USA/WA-UW-4111/2020
+RC   {ECO:0000313|EMBL:QJC20759.1}, SARS-CoV-2/human/USA/WA-UW-4180/2020
+RC   {ECO:0000313|EMBL:QJC19512.1}, SARS-CoV-2/human/USA/WA-UW-4188/2020
+RC   {ECO:0000313|EMBL:QJC19524.1}, SARS-CoV-2/human/USA/WA-UW-4197/2020
+RC   {ECO:0000313|EMBL:QJC19536.1}, SARS-CoV-2/human/USA/WA-UW-4213/2020
+RC   {ECO:0000313|EMBL:QJC19548.1}, SARS-CoV-2/human/USA/WA-UW-4217/2020
+RC   {ECO:0000313|EMBL:QJC19560.1}, SARS-CoV-2/human/USA/WA-UW-4227/2020
+RC   {ECO:0000313|EMBL:QJC19572.1}, SARS-CoV-2/human/USA/WA-UW-4228/2020
+RC   {ECO:0000313|EMBL:QJC19584.1}, SARS-CoV-2/human/USA/WA-UW-4281/2020
+RC   {ECO:0000313|EMBL:QJC19656.1}, SARS-CoV-2/human/USA/WA-UW-4289/2020
+RC   {ECO:0000313|EMBL:QJC19668.1}, SARS-CoV-2/human/USA/WA-UW-4290/2020
+RC   {ECO:0000313|EMBL:QJC19680.1}, SARS-CoV-2/human/USA/WA-UW-4291/2020
+RC   {ECO:0000313|EMBL:QJC19692.1}, SARS-CoV-2/human/USA/WA-UW-4292/2020
+RC   {ECO:0000313|EMBL:QJC19704.1}, SARS-CoV-2/human/USA/WA-UW-4315/2020
+RC   {ECO:0000313|EMBL:QJC19728.1}, SARS-CoV-2/human/USA/WA-UW-4316/2020
+RC   {ECO:0000313|EMBL:QJC19740.1}, SARS-CoV-2/human/USA/WA-UW-4318/2020
+RC   {ECO:0000313|EMBL:QJC19752.1}, SARS-CoV-2/human/USA/WA-UW-4321/2020
+RC   {ECO:0000313|EMBL:QJC19764.1}, SARS-CoV-2/human/USA/WA-UW-4322/2020
+RC   {ECO:0000313|EMBL:QJC19776.1}, SARS-CoV-2/human/USA/WA-UW-4324/2020
+RC   {ECO:0000313|EMBL:QJC19788.1}, SARS-CoV-2/human/USA/WA-UW-4326/2020
+RC   {ECO:0000313|EMBL:QJC19800.1}, SARS-CoV-2/human/USA/WA-UW-4329/2020
+RC   {ECO:0000313|EMBL:QJC19812.1}, SARS-CoV-2/human/USA/WA-UW-4330/2020
+RC   {ECO:0000313|EMBL:QJC19824.1}, SARS-CoV-2/human/USA/WA-UW-4335/2020
+RC   {ECO:0000313|EMBL:QJC19836.1}, SARS-CoV-2/human/USA/WA-UW-4340/2020
+RC   {ECO:0000313|EMBL:QJC19848.1}, SARS-CoV-2/human/USA/WA-UW-4404/2020
+RC   {ECO:0000313|EMBL:QJA17405.1}, SARS-CoV-2/human/USA/WA-UW-4406/2020
+RC   {ECO:0000313|EMBL:QJA17417.1}, SARS-CoV-2/human/USA/WA-UW-4407/2020
+RC   {ECO:0000313|EMBL:QJA17429.1}, SARS-CoV-2/human/USA/WA-UW-4499/2020
+RC   {ECO:0000313|EMBL:QJC20256.1}, SARS-CoV-2/human/USA/WA-UW-4500/2020
+RC   {ECO:0000313|EMBL:QJC20268.1}, SARS-CoV-2/human/USA/WA-UW192/2020
+RC   {ECO:0000313|EMBL:QIQ49770.1}, SARS-CoV-2/human/USA/WA-UW193/2020
+RC   {ECO:0000313|EMBL:QIQ49780.1}, SARS-CoV-2/human/USA/WA-UW194/2020
+RC   {ECO:0000313|EMBL:QIQ49790.1}, SARS-CoV-2/human/USA/WA-UW195/2020
+RC   {ECO:0000313|EMBL:QIQ49800.1}, SARS-CoV-2/human/USA/WA-UW196/2020
+RC   {ECO:0000313|EMBL:QIQ49810.1}, SARS-CoV-2/human/USA/WA-UW197/2020
+RC   {ECO:0000313|EMBL:QIQ49820.1}, SARS-CoV-2/human/USA/WA-UW198/2020
+RC   {ECO:0000313|EMBL:QIQ49830.1}, SARS-CoV-2/human/USA/WA-UW199/2020
+RC   {ECO:0000313|EMBL:QIQ49840.1}, SARS-CoV-2/human/USA/WA-UW200/2020
+RC   {ECO:0000313|EMBL:QIQ49850.1}, SARS-CoV-2/human/USA/WA-UW201/2020
+RC   {ECO:0000313|EMBL:QIQ49860.1}, SARS-CoV-2/human/USA/WA-UW202/2020
+RC   {ECO:0000313|EMBL:QIQ49870.1}, SARS-CoV-2/human/USA/WA-UW203/2020
+RC   {ECO:0000313|EMBL:QIQ49880.1}, SARS-CoV-2/human/USA/WA-UW204/2020
+RC   {ECO:0000313|EMBL:QIQ49890.1}, SARS-CoV-2/human/USA/WA-UW205/2020
+RC   {ECO:0000313|EMBL:QIQ49900.1}, SARS-CoV-2/human/USA/WA-UW206/2020
+RC   {ECO:0000313|EMBL:QIQ49910.1}, SARS-CoV-2/human/USA/WA-UW207/2020
+RC   {ECO:0000313|EMBL:QIQ49920.1}, SARS-CoV-2/human/USA/WA-UW208/2020
+RC   {ECO:0000313|EMBL:QIQ49930.1}, SARS-CoV-2/human/USA/WA-UW209/2020
+RC   {ECO:0000313|EMBL:QIQ49940.1}, SARS-CoV-2/human/USA/WA-UW210/2020
+RC   {ECO:0000313|EMBL:QIQ49950.1}, SARS-CoV-2/human/USA/WA-UW211/2020
+RC   {ECO:0000313|EMBL:QIQ49960.1}, SARS-CoV-2/human/USA/WA-UW212/2020
+RC   {ECO:0000313|EMBL:QIQ49970.1}, SARS-CoV-2/human/USA/WA-UW213/2020
+RC   {ECO:0000313|EMBL:QIQ49980.1}, SARS-CoV-2/human/USA/WA-UW214/2020
+RC   {ECO:0000313|EMBL:QIQ49990.1}, SARS-CoV-2/human/USA/WA-UW215/2020
+RC   {ECO:0000313|EMBL:QIQ50000.1}, SARS-CoV-2/human/USA/WA-UW216/2020
+RC   {ECO:0000313|EMBL:QIQ50010.1}, SARS-CoV-2/human/USA/WA-UW217/2020
+RC   {ECO:0000313|EMBL:QIQ50020.1}, SARS-CoV-2/human/USA/WA-UW218/2020
+RC   {ECO:0000313|EMBL:QIQ50030.1}, SARS-CoV-2/human/USA/WA-UW219/2020
+RC   {ECO:0000313|EMBL:QIQ50040.1}, SARS-CoV-2/human/USA/WA-UW220/2020
+RC   {ECO:0000313|EMBL:QIQ50050.1}, SARS-CoV-2/human/USA/WA-UW221/2020
+RC   {ECO:0000313|EMBL:QIQ50060.1}, SARS-CoV-2/human/USA/WA-UW222/2020
+RC   {ECO:0000313|EMBL:QIQ50070.1}, SARS-CoV-2/human/USA/WA-UW223/2020
+RC   {ECO:0000313|EMBL:QIQ50080.1}, SARS-CoV-2/human/USA/WA-UW224/2020
+RC   {ECO:0000313|EMBL:QIQ50090.1}, SARS-CoV-2/human/USA/WA-UW225/2020
+RC   {ECO:0000313|EMBL:QIQ50100.1}, SARS-CoV-2/human/USA/WA-UW226/2020
+RC   {ECO:0000313|EMBL:QIQ50110.1}, SARS-CoV-2/human/USA/WA-UW227/2020
+RC   {ECO:0000313|EMBL:QIQ50120.1}, SARS-CoV-2/human/USA/WA-UW228/2020
+RC   {ECO:0000313|EMBL:QIQ50130.1}, SARS-CoV-2/human/USA/WA-UW229/2020
+RC   {ECO:0000313|EMBL:QIQ50140.1}, SARS-CoV-2/human/USA/WA-UW230/2020
+RC   {ECO:0000313|EMBL:QIQ50150.1}, SARS-CoV-2/human/USA/WA-UW231/2020
+RC   {ECO:0000313|EMBL:QIQ50160.1}, SARS-CoV-2/human/USA/WA-UW232/2020
+RC   {ECO:0000313|EMBL:QIQ50170.1}, SARS-CoV-2/human/USA/WA-UW233/2020
+RC   {ECO:0000313|EMBL:QIQ50180.1}, SARS-CoV-2/human/USA/WA-UW234/2020
+RC   {ECO:0000313|EMBL:QIQ68522.1}, SARS-CoV-2/human/USA/WA-UW235/2020
+RC   {ECO:0000313|EMBL:QIQ68532.1}, SARS-CoV-2/human/USA/WA-UW236/2020
+RC   {ECO:0000313|EMBL:QIQ68472.1}, SARS-CoV-2/human/USA/WA-UW237/2020
+RC   {ECO:0000313|EMBL:QIQ68482.1}, SARS-CoV-2/human/USA/WA-UW239/2020
+RC   {ECO:0000313|EMBL:QIQ68502.1}, SARS-CoV-2/human/USA/WA-UW240/2020
+RC   {ECO:0000313|EMBL:QIQ68512.1}, SARS-CoV-2/human/USA/WA-UW241/2020
+RC   {ECO:0000313|EMBL:QIQ68542.1}, SARS-CoV-2/human/USA/WA-UW242/2020
+RC   {ECO:0000313|EMBL:QIQ68552.1}, SARS-CoV-2/human/USA/WA-UW243/2020
+RC   {ECO:0000313|EMBL:QIS30163.1}, SARS-CoV-2/human/USA/WA-UW244/2020
+RC   {ECO:0000313|EMBL:QIS30173.1}, SARS-CoV-2/human/USA/WA-UW245/2020
+RC   {ECO:0000313|EMBL:QIS30183.1}, SARS-CoV-2/human/USA/WA-UW246/2020
+RC   {ECO:0000313|EMBL:QIS30193.1}, SARS-CoV-2/human/USA/WA-UW247/2020
+RC   {ECO:0000313|EMBL:QIS30203.1}, SARS-CoV-2/human/USA/WA-UW248/2020
+RC   {ECO:0000313|EMBL:QIS30213.1}, SARS-CoV-2/human/USA/WA-UW249/2020
+RC   {ECO:0000313|EMBL:QIS30223.1}, SARS-CoV-2/human/USA/WA-UW251/2020
+RC   {ECO:0000313|EMBL:QIS30243.1}, SARS-CoV-2/human/USA/WA-UW252/2020
+RC   {ECO:0000313|EMBL:QIS30253.1}, SARS-CoV-2/human/USA/WA-UW253/2020
+RC   {ECO:0000313|EMBL:QIS30263.1}, SARS-CoV-2/human/USA/WA-UW254/2020
+RC   {ECO:0000313|EMBL:QIS30273.1}, SARS-CoV-2/human/USA/WA-UW255/2020
+RC   {ECO:0000313|EMBL:QIS30283.1}, SARS-CoV-2/human/USA/WA-UW257/2020
+RC   {ECO:0000313|EMBL:QIS30303.1}, SARS-CoV-2/human/USA/WA-UW258/2020
+RC   {ECO:0000313|EMBL:QIS30313.1}, SARS-CoV-2/human/USA/WA-UW259/2020
+RC   {ECO:0000313|EMBL:QIS30323.1}, SARS-CoV-2/human/USA/WA-UW260/2020
+RC   {ECO:0000313|EMBL:QIS30333.1}, SARS-CoV-2/human/USA/WA-UW261/2020
+RC   {ECO:0000313|EMBL:QIS30343.1}, SARS-CoV-2/human/USA/WA-UW262/2020
+RC   {ECO:0000313|EMBL:QIS30353.1}, SARS-CoV-2/human/USA/WA-UW263/2020
+RC   {ECO:0000313|EMBL:QIS30363.1}, SARS-CoV-2/human/USA/WA-UW264/2020
+RC   {ECO:0000313|EMBL:QIS30373.1}, SARS-CoV-2/human/USA/WA-UW265/2020
+RC   {ECO:0000313|EMBL:QIS30383.1}, SARS-CoV-2/human/USA/WA-UW267/2020
+RC   {ECO:0000313|EMBL:QIS30403.1}, SARS-CoV-2/human/USA/WA-UW268/2020
+RC   {ECO:0000313|EMBL:QIS30413.1}, SARS-CoV-2/human/USA/WA-UW269/2020
+RC   {ECO:0000313|EMBL:QIS30423.1}, SARS-CoV-2/human/USA/WA-UW270/2020
+RC   {ECO:0000313|EMBL:QIS30433.1}, SARS-CoV-2/human/USA/WA-UW271/2020
+RC   {ECO:0000313|EMBL:QIS30443.1}, SARS-CoV-2/human/USA/WA-UW272/2020
+RC   {ECO:0000313|EMBL:QIS30453.1}, SARS-CoV-2/human/USA/WA-UW273/2020
+RC   {ECO:0000313|EMBL:QIS30463.1}, SARS-CoV-2/human/USA/WA-UW274/2020
+RC   {ECO:0000313|EMBL:QIS30473.1}, SARS-CoV-2/human/USA/WA-UW275/2020
+RC   {ECO:0000313|EMBL:QIS30483.1}, SARS-CoV-2/human/USA/WA-UW276/2020
+RC   {ECO:0000313|EMBL:QIS30493.1}, SARS-CoV-2/human/USA/WA-UW277/2020
+RC   {ECO:0000313|EMBL:QIS30503.1}, SARS-CoV-2/human/USA/WA-UW278/2020
+RC   {ECO:0000313|EMBL:QIS30512.1}, SARS-CoV-2/human/USA/WA-UW279/2020
+RC   {ECO:0000313|EMBL:QIS30523.1}, SARS-CoV-2/human/USA/WA-UW280/2020
+RC   {ECO:0000313|EMBL:QIS30533.1}, SARS-CoV-2/human/USA/WA-UW282/2020
+RC   {ECO:0000313|EMBL:QIS30543.1}, SARS-CoV-2/human/USA/WA-UW284/2020
+RC   {ECO:0000313|EMBL:QIS30553.1}, SARS-CoV-2/human/USA/WA-UW285/2020
+RC   {ECO:0000313|EMBL:QIS30563.1}, SARS-CoV-2/human/USA/WA-UW286/2020
+RC   {ECO:0000313|EMBL:QIS30573.1}, SARS-CoV-2/human/USA/WA-UW287/2020
+RC   {ECO:0000313|EMBL:QIS30583.1}, SARS-CoV-2/human/USA/WA-UW288/2020
+RC   {ECO:0000313|EMBL:QIS30593.1}, SARS-CoV-2/human/USA/WA-UW289/2020
+RC   {ECO:0000313|EMBL:QIS30603.1}, SARS-CoV-2/human/USA/WA-UW290/2020
+RC   {ECO:0000313|EMBL:QIS30613.1}, SARS-CoV-2/human/USA/WA-UW291/2020
+RC   {ECO:0000313|EMBL:QIS30623.1}, SARS-CoV-2/human/USA/WA-UW292/2020
+RC   {ECO:0000313|EMBL:QIS30633.1}, SARS-CoV-2/human/USA/WA-UW293/2020
+RC   {ECO:0000313|EMBL:QIS30643.1}, SARS-CoV-2/human/USA/WA-UW294/2020
+RC   {ECO:0000313|EMBL:QIS30653.1}, SARS-CoV-2/human/USA/WA-UW295/2020
+RC   {ECO:0000313|EMBL:QIS30663.1}, SARS-CoV-2/human/USA/WA-UW296/2020
+RC   {ECO:0000313|EMBL:QIS30673.1}, SARS-CoV-2/human/USA/WA-UW297/2020
+RC   {ECO:0000313|EMBL:QIS30683.1}, SARS-CoV-2/human/USA/WA-UW298/2020
+RC   {ECO:0000313|EMBL:QIS60519.1}, SARS-CoV-2/human/USA/WA-UW299/2020
+RC   {ECO:0000313|EMBL:QIS60531.1}, SARS-CoV-2/human/USA/WA-UW300/2020
+RC   {ECO:0000313|EMBL:QIS60543.1}, SARS-CoV-2/human/USA/WA-UW302/2020
+RC   {ECO:0000313|EMBL:QIS60567.1}, SARS-CoV-2/human/USA/WA-UW304/2020
+RC   {ECO:0000313|EMBL:QIS60591.1}, SARS-CoV-2/human/USA/WA-UW305/2020
+RC   {ECO:0000313|EMBL:QIS60603.1}, SARS-CoV-2/human/USA/WA-UW307/2020
+RC   {ECO:0000313|EMBL:QIS60627.1}, SARS-CoV-2/human/USA/WA-UW308/2020
+RC   {ECO:0000313|EMBL:QIS60639.1}, SARS-CoV-2/human/USA/WA-UW310/2020
+RC   {ECO:0000313|EMBL:QIS60651.1}, SARS-CoV-2/human/USA/WA-UW312/2020
+RC   {ECO:0000313|EMBL:QIS60663.1}, SARS-CoV-2/human/USA/WA-UW313/2020
+RC   {ECO:0000313|EMBL:QIS60675.1}, SARS-CoV-2/human/USA/WA-UW314/2020
+RC   {ECO:0000313|EMBL:QIS60687.1}, SARS-CoV-2/human/USA/WA-UW315/2020
+RC   {ECO:0000313|EMBL:QIS60699.1}, SARS-CoV-2/human/USA/WA-UW316/2020
+RC   {ECO:0000313|EMBL:QIS60711.1}, SARS-CoV-2/human/USA/WA-UW317/2020
+RC   {ECO:0000313|EMBL:QIS60723.1}, SARS-CoV-2/human/USA/WA-UW319/2020
+RC   {ECO:0000313|EMBL:QIS60735.1}, SARS-CoV-2/human/USA/WA-UW320/2020
+RC   {ECO:0000313|EMBL:QIS60747.1}, SARS-CoV-2/human/USA/WA-UW321/2020
+RC   {ECO:0000313|EMBL:QIS60759.1}, SARS-CoV-2/human/USA/WA-UW322/2020
+RC   {ECO:0000313|EMBL:QIS60771.1}, SARS-CoV-2/human/USA/WA-UW323/2020
+RC   {ECO:0000313|EMBL:QIS60783.1}, SARS-CoV-2/human/USA/WA-UW324/2020
+RC   {ECO:0000313|EMBL:QIS60795.1}, SARS-CoV-2/human/USA/WA-UW325/2020
+RC   {ECO:0000313|EMBL:QIS60807.1}, SARS-CoV-2/human/USA/WA-UW328/2020
+RC   {ECO:0000313|EMBL:QIS60843.1}, SARS-CoV-2/human/USA/WA-UW330/2020
+RC   {ECO:0000313|EMBL:QIS60867.1}, SARS-CoV-2/human/USA/WA-UW332/2020
+RC   {ECO:0000313|EMBL:QIS60891.1}, SARS-CoV-2/human/USA/WA-UW333/2020
+RC   {ECO:0000313|EMBL:QIS60903.1}, SARS-CoV-2/human/USA/WA-UW334/2020
+RC   {ECO:0000313|EMBL:QIS60915.1}, SARS-CoV-2/human/USA/WA-UW336/2020
+RC   {ECO:0000313|EMBL:QIS60939.1}, SARS-CoV-2/human/USA/WA-UW337/2020
+RC   {ECO:0000313|EMBL:QIS60951.1}, SARS-CoV-2/human/USA/WA-UW338/2020
+RC   {ECO:0000313|EMBL:QIS60963.1}, SARS-CoV-2/human/USA/WA-UW339/2020
+RC   {ECO:0000313|EMBL:QIS60975.1}, SARS-CoV-2/human/USA/WA-UW340/2020
+RC   {ECO:0000313|EMBL:QIS60987.1}, SARS-CoV-2/human/USA/WA-UW341/2020
+RC   {ECO:0000313|EMBL:QIS60999.1}, SARS-CoV-2/human/USA/WA-UW342/2020
+RC   {ECO:0000313|EMBL:QIS61011.1}, SARS-CoV-2/human/USA/WA-UW343/2020
+RC   {ECO:0000313|EMBL:QIS61023.1}, SARS-CoV-2/human/USA/WA-UW344/2020
+RC   {ECO:0000313|EMBL:QIS61035.1}, SARS-CoV-2/human/USA/WA-UW345/2020
+RC   {ECO:0000313|EMBL:QIS61047.1}, SARS-CoV-2/human/USA/WA-UW346/2020
+RC   {ECO:0000313|EMBL:QIS61059.1}, SARS-CoV-2/human/USA/WA-UW347/2020
+RC   {ECO:0000313|EMBL:QIS61069.1}, SARS-CoV-2/human/USA/WA-UW350/2020
+RC   {ECO:0000313|EMBL:QIS61107.1}, SARS-CoV-2/human/USA/WA-UW351/2020
+RC   {ECO:0000313|EMBL:QIS61119.1}, SARS-CoV-2/human/USA/WA-UW352/2020
+RC   {ECO:0000313|EMBL:QIS61131.1}, SARS-CoV-2/human/USA/WA-UW354/2020
+RC   {ECO:0000313|EMBL:QIS61155.1}, SARS-CoV-2/human/USA/WA-UW355/2020
+RC   {ECO:0000313|EMBL:QIS61167.1}, SARS-CoV-2/human/USA/WA-UW356/2020
+RC   {ECO:0000313|EMBL:QIS61179.1}, SARS-CoV-2/human/USA/WA-UW357/2020
+RC   {ECO:0000313|EMBL:QIS61191.1}, SARS-CoV-2/human/USA/WA-UW358/2020
+RC   {ECO:0000313|EMBL:QIS61203.1}, SARS-CoV-2/human/USA/WA-UW359/2020
+RC   {ECO:0000313|EMBL:QIS61215.1}, SARS-CoV-2/human/USA/WA-UW360/2020
+RC   {ECO:0000313|EMBL:QIS61227.1}, SARS-CoV-2/human/USA/WA-UW361/2020
+RC   {ECO:0000313|EMBL:QIS61239.1}, SARS-CoV-2/human/USA/WA-UW362/2020
+RC   {ECO:0000313|EMBL:QIS61251.1}, SARS-CoV-2/human/USA/WA-UW363/2020
+RC   {ECO:0000313|EMBL:QIS61263.1}, SARS-CoV-2/human/USA/WA-UW364/2020
+RC   {ECO:0000313|EMBL:QIS61275.1}, SARS-CoV-2/human/USA/WA-UW365/2020
+RC   {ECO:0000313|EMBL:QIS61287.1}, SARS-CoV-2/human/USA/WA-UW366/2020
+RC   {ECO:0000313|EMBL:QIS61299.1}, SARS-CoV-2/human/USA/WA-UW367/2020
+RC   {ECO:0000313|EMBL:QIS61311.1}, SARS-CoV-2/human/USA/WA-UW368/2020
+RC   {ECO:0000313|EMBL:QIS61323.1}, SARS-CoV-2/human/USA/WA-UW369/2020
+RC   {ECO:0000313|EMBL:QIS61335.1}, SARS-CoV-2/human/USA/WA-UW370/2020
+RC   {ECO:0000313|EMBL:QIS61347.1}, SARS-CoV-2/human/USA/WA-UW371/2020
+RC   {ECO:0000313|EMBL:QIS61359.1}, SARS-CoV-2/human/USA/WA-UW372/2020
+RC   {ECO:0000313|EMBL:QIS61371.1}, SARS-CoV-2/human/USA/WA-UW373/2020
+RC   {ECO:0000313|EMBL:QIS61383.1}, SARS-CoV-2/human/USA/WA-UW374/2020
+RC   {ECO:0000313|EMBL:QIS61395.1}, SARS-CoV-2/human/USA/WA-UW375/2020
+RC   {ECO:0000313|EMBL:QIS61407.1}, SARS-CoV-2/human/USA/WA-UW376/2020
+RC   {ECO:0000313|EMBL:QIS61419.1}, SARS-CoV-2/human/USA/WA-UW378/2020
+RC   {ECO:0000313|EMBL:QIS61443.1}, SARS-CoV-2/human/USA/WA-UW379/2020
+RC   {ECO:0000313|EMBL:QIS60855.1}, SARS-CoV-2/human/USA/WA-UW380/2020
+RC   {ECO:0000313|EMBL:QIS61455.1}, SARS-CoV-2/human/USA/WA-UW382/2020
+RC   {ECO:0000313|EMBL:QIS61477.1}, SARS-CoV-2/human/USA/WA-UW383/2020
+RC   {ECO:0000313|EMBL:QIS61491.1}, SARS-CoV-2/human/USA/WA-UW384/2020
+RC   {ECO:0000313|EMBL:QIS61515.1}, SARS-CoV-2/human/USA/WA-UW385/2020
+RC   {ECO:0000313|EMBL:QIS61527.1}, SARS-CoV-2/human/USA/WA-UW386/2020
+RC   {ECO:0000313|EMBL:QIS61537.1}, SARS-CoV-2/human/USA/WA-UW387/2020
+RC   {ECO:0000313|EMBL:QIS61551.1}, SARS-CoV-2/human/USA/WA-UW388/2020
+RC   {ECO:0000313|EMBL:QIS61563.1}, SARS-CoV-2/human/USA/WA-UW389/2020
+RC   {ECO:0000313|EMBL:QIS61575.1}, SARS-CoV-2/human/USA/WA-UW390/2020
+RC   {ECO:0000313|EMBL:QIS61431.1}, SARS-CoV-2/human/USACT-UW420/2020
+RC   {ECO:0000313|EMBL:QIU81282.1}, SARS-CoV-2/human/USACT-UW423/2020
+RC   {ECO:0000313|EMBL:QIU81318.1}, SARS-CoV-2/human/USACT-UW427/2020
+RC   {ECO:0000313|EMBL:QIU81366.1}, SARS-CoV-2/human/USACT-UW428/2020
+RC   {ECO:0000313|EMBL:QIU81378.1}, SARS-CoV-2/human/USACT-UW430/2020
+RC   {ECO:0000313|EMBL:QIU81402.1}, SARS-CoV-2/human/USAOR-UW409/2020
+RC   {ECO:0000313|EMBL:QIU81150.1}, SARS-CoV-2/human/USAUNKNOWN-UW398/2020
+RC   {ECO:0000313|EMBL:QIU81018.1}, SARS-CoV-2/human/USAWA-UW391/2020
+RC   {ECO:0000313|EMBL:QIU80934.1}, SARS-CoV-2/human/USAWA-UW392/2020
+RC   {ECO:0000313|EMBL:QIU80946.1}, SARS-CoV-2/human/USAWA-UW408/2020
+RC   {ECO:0000313|EMBL:QIU81138.1}, SARS-CoV-2/human/USAWA-UW410/2020
+RC   {ECO:0000313|EMBL:QIU81162.1}, and SARS-CoV-2/human/USAWA-UW413/2020
+RC   {ECO:0000313|EMBL:QIU81198.1};
+RA   Roychoudhury P., Greninger A., Jerome K.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [85] {ECO:0000313|EMBL:QIZ15558.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/AZ_8132/2020
+RC   {ECO:0000313|EMBL:QIZ15558.1}, SARS-CoV-2/human/USA/AZ_8135/2020
+RC   {ECO:0000313|EMBL:QIZ15570.1}, SARS-CoV-2/human/USA/DC_0004/2020
+RC   {ECO:0000313|EMBL:QIZ15582.1}, SARS-CoV-2/human/USA/FL_1177/2020
+RC   {ECO:0000313|EMBL:QIZ15594.1}, SARS-CoV-2/human/USA/FL_7169/2020
+RC   {ECO:0000313|EMBL:QIZ15606.1}, SARS-CoV-2/human/USA/FL_9590/2020
+RC   {ECO:0000313|EMBL:QIZ15618.1}, SARS-CoV-2/human/USA/FL_9655/2020
+RC   {ECO:0000313|EMBL:QIZ15630.1}, SARS-CoV-2/human/USA/FL_9656/2020
+RC   {ECO:0000313|EMBL:QIZ15642.1}, SARS-CoV-2/human/USA/GA_1621/2020
+RC   {ECO:0000313|EMBL:QIZ15654.1}, SARS-CoV-2/human/USA/GA_1847/2020
+RC   {ECO:0000313|EMBL:QIZ15666.1}, SARS-CoV-2/human/USA/GA_2055/2020
+RC   {ECO:0000313|EMBL:QIZ15678.1}, SARS-CoV-2/human/USA/GA_2118/2020
+RC   {ECO:0000313|EMBL:QIZ15690.1}, SARS-CoV-2/human/USA/GA_2120/2020
+RC   {ECO:0000313|EMBL:QIZ15702.1}, SARS-CoV-2/human/USA/GA_2185/2020
+RC   {ECO:0000313|EMBL:QIZ15714.1}, SARS-CoV-2/human/USA/GA_2343/2020
+RC   {ECO:0000313|EMBL:QIZ15726.1}, SARS-CoV-2/human/USA/IA_6394/2020
+RC   {ECO:0000313|EMBL:QIZ15738.1}, SARS-CoV-2/human/USA/IL_0087/2020
+RC   {ECO:0000313|EMBL:QIZ15750.1}, SARS-CoV-2/human/USA/IL_0089/2020
+RC   {ECO:0000313|EMBL:QIZ15762.1}, SARS-CoV-2/human/USA/IN_2001/2020
+RC   {ECO:0000313|EMBL:QIZ15774.1}, SARS-CoV-2/human/USA/KS_4126/2020
+RC   {ECO:0000313|EMBL:QIZ15786.1}, SARS-CoV-2/human/USA/LA_0842/2020
+RC   {ECO:0000313|EMBL:QIZ15798.1}, SARS-CoV-2/human/USA/MA_0020/2020
+RC   {ECO:0000313|EMBL:QIZ15810.1}, SARS-CoV-2/human/USA/MA_3672/2020
+RC   {ECO:0000313|EMBL:QIZ15822.1}, SARS-CoV-2/human/USA/MA_3699/2020
+RC   {ECO:0000313|EMBL:QIZ15834.1}, SARS-CoV-2/human/USA/MA_3878/2020
+RC   {ECO:0000313|EMBL:QIZ15846.1}, SARS-CoV-2/human/USA/MA_4811/2020
+RC   {ECO:0000313|EMBL:QIZ15858.1}, SARS-CoV-2/human/USA/MD_0026/2020
+RC   {ECO:0000313|EMBL:QIZ15870.1}, SARS-CoV-2/human/USA/MO_4470/2020
+RC   {ECO:0000313|EMBL:QIZ15882.1}, SARS-CoV-2/human/USA/NC_0024/2020
+RC   {ECO:0000313|EMBL:QIZ15894.1}, SARS-CoV-2/human/USA/NC_0031/2020
+RC   {ECO:0000313|EMBL:QIZ15906.1}, SARS-CoV-2/human/USA/NC_6999/2020
+RC   {ECO:0000313|EMBL:QIZ15918.1}, SARS-CoV-2/human/USA/NE_6605/2020
+RC   {ECO:0000313|EMBL:QIZ15930.1}, SARS-CoV-2/human/USA/NE_7025/2020
+RC   {ECO:0000313|EMBL:QIZ15942.1}, SARS-CoV-2/human/USA/NH_0029/2020
+RC   {ECO:0000313|EMBL:QIZ15954.1}, SARS-CoV-2/human/USA/NH_0033/2020
+RC   {ECO:0000313|EMBL:QIZ15966.1}, SARS-CoV-2/human/USA/NJ_3592/2020
+RC   {ECO:0000313|EMBL:QIZ15978.1}, SARS-CoV-2/human/USA/NV_0052/2020
+RC   {ECO:0000313|EMBL:QIZ15990.1}, SARS-CoV-2/human/USA/OH_0023/2020
+RC   {ECO:0000313|EMBL:QIZ16002.1}, SARS-CoV-2/human/USA/PA_1802/2020
+RC   {ECO:0000313|EMBL:QIZ16014.1}, SARS-CoV-2/human/USA/PA_1881/2020
+RC   {ECO:0000313|EMBL:QIZ16026.1}, SARS-CoV-2/human/USA/PA_2317/2020
+RC   {ECO:0000313|EMBL:QIZ16038.1}, SARS-CoV-2/human/USA/PA_2937/2020
+RC   {ECO:0000313|EMBL:QIZ16050.1}, SARS-CoV-2/human/USA/PA_4395/2020
+RC   {ECO:0000313|EMBL:QIZ16062.1}, SARS-CoV-2/human/USA/PA_4405/2020
+RC   {ECO:0000313|EMBL:QIZ16074.1}, SARS-CoV-2/human/USA/RI_0702/2020
+RC   {ECO:0000313|EMBL:QIZ16086.1}, SARS-CoV-2/human/USA/SC_3569/2020
+RC   {ECO:0000313|EMBL:QIZ16098.1}, SARS-CoV-2/human/USA/SC_3575/2020
+RC   {ECO:0000313|EMBL:QIZ16110.1}, SARS-CoV-2/human/USA/SC_6370/2020
+RC   {ECO:0000313|EMBL:QIZ16122.1}, SARS-CoV-2/human/USA/UT_8199/2020
+RC   {ECO:0000313|EMBL:QIZ16134.1}, SARS-CoV-2/human/USA/UT_8906/2020
+RC   {ECO:0000313|EMBL:QIZ16146.1}, SARS-CoV-2/human/USA/VA_6352/2020
+RC   {ECO:0000313|EMBL:QIZ16158.1}, SARS-CoV-2/human/USA/VA_6377/2020
+RC   {ECO:0000313|EMBL:QIZ16170.1}, SARS-CoV-2/human/USA/VA_6382/2020
+RC   {ECO:0000313|EMBL:QIZ16182.1}, and SARS-CoV-2/human/USA/VA_6389/2020
+RC   {ECO:0000313|EMBL:QIZ16194.1};
+RA   Li Y., Queen K., Paden C.R., Marine R., Uehara A., Tao Y., Zhang J.,
+RA   Wang H., Keckler M.S., Laufer Halpin A.S., Elkins C.A., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [86] {ECO:0000313|EMBL:QJD23282.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/NJ-PV09072/2020
+RC   {ECO:0000313|EMBL:QJD24506.1}, SARS-CoV-2/human/USA/NY-PV08109/2020
+RC   {ECO:0000313|EMBL:QJD23642.1}, SARS-CoV-2/human/USA/NY-PV08120/2020
+RC   {ECO:0000313|EMBL:QJD24182.1}, SARS-CoV-2/human/USA/NY-PV08121/2020
+RC   {ECO:0000313|EMBL:QJD23426.1}, SARS-CoV-2/human/USA/NY-PV08122/2020
+RC   {ECO:0000313|EMBL:QJD24014.1}, SARS-CoV-2/human/USA/NY-PV08123/2020
+RC   {ECO:0000313|EMBL:QJD24338.1}, SARS-CoV-2/human/USA/NY-PV08124/2020
+RC   {ECO:0000313|EMBL:QJD23378.1}, SARS-CoV-2/human/USA/NY-PV08125/2020
+RC   {ECO:0000313|EMBL:QJD24290.1}, SARS-CoV-2/human/USA/NY-PV08127/2020
+RC   {ECO:0000313|EMBL:QJD23558.1}, SARS-CoV-2/human/USA/NY-PV08133/2020
+RC   {ECO:0000313|EMBL:QJD24228.1}, SARS-CoV-2/human/USA/NY-PV08135/2020
+RC   {ECO:0000313|EMBL:QJD23702.1}, SARS-CoV-2/human/USA/NY-PV08136/2020
+RC   {ECO:0000313|EMBL:QJD24146.1}, SARS-CoV-2/human/USA/NY-PV08137/2020
+RC   {ECO:0000313|EMBL:QJD23533.1}, SARS-CoV-2/human/USA/NY-PV08138/2020
+RC   {ECO:0000313|EMBL:QJD23882.1}, SARS-CoV-2/human/USA/NY-PV08139/2020
+RC   {ECO:0000313|EMBL:QJD23292.1}, SARS-CoV-2/human/USA/NY-PV08140/2020
+RC   {ECO:0000313|EMBL:QJD23388.1}, SARS-CoV-2/human/USA/NY-PV08143/2020
+RC   {ECO:0000313|EMBL:QJD24266.1}, SARS-CoV-2/human/USA/NY-PV08146/2020
+RC   {ECO:0000313|EMBL:QJD23498.1}, SARS-CoV-2/human/USA/NY-PV08148/2020
+RC   {ECO:0000313|EMBL:QJD23594.1}, SARS-CoV-2/human/USA/NY-PV08149/2020
+RC   {ECO:0000313|EMBL:QJD23798.1}, SARS-CoV-2/human/USA/NY-PV08150/2020
+RC   {ECO:0000313|EMBL:QJD24170.1}, SARS-CoV-2/human/USA/NY-PV08400/2020
+RC   {ECO:0000313|EMBL:QJD23713.1}, SARS-CoV-2/human/USA/NY-PV08401/2020
+RC   {ECO:0000313|EMBL:QJD23462.1}, SARS-CoV-2/human/USA/NY-PV08402/2020
+RC   {ECO:0000313|EMBL:QJD24002.1}, SARS-CoV-2/human/USA/NY-PV08403/2020
+RC   {ECO:0000313|EMBL:QJD23618.1}, SARS-CoV-2/human/USA/NY-PV08404/2020
+RC   {ECO:0000313|EMBL:QJD23784.1}, SARS-CoV-2/human/USA/NY-PV08405/2020
+RC   {ECO:0000313|EMBL:QJD23856.1}, SARS-CoV-2/human/USA/NY-PV08410/2020
+RC   {ECO:0000313|EMBL:QJD24108.1}, SARS-CoV-2/human/USA/NY-PV08412/2020
+RC   {ECO:0000313|EMBL:QJD23654.1}, SARS-CoV-2/human/USA/NY-PV08413/2020
+RC   {ECO:0000313|EMBL:QJD23846.1}, SARS-CoV-2/human/USA/NY-PV08414/2020
+RC   {ECO:0000313|EMBL:QJD24324.1}, SARS-CoV-2/human/USA/NY-PV08415/2020
+RC   {ECO:0000313|EMBL:QJD24050.1}, SARS-CoV-2/human/USA/NY-PV08416/2020
+RC   {ECO:0000313|EMBL:QJD24194.1}, SARS-CoV-2/human/USA/NY-PV08417/2020
+RC   {ECO:0000313|EMBL:QJD23916.1}, SARS-CoV-2/human/USA/NY-PV08419/2020
+RC   {ECO:0000313|EMBL:QJD24024.1}, SARS-CoV-2/human/USA/NY-PV08420/2020
+RC   {ECO:0000313|EMBL:QJD23568.1}, SARS-CoV-2/human/USA/NY-PV08425/2020
+RC   {ECO:0000313|EMBL:QJD23906.1}, SARS-CoV-2/human/USA/NY-PV08426/2020
+RC   {ECO:0000313|EMBL:QJD23330.1}, SARS-CoV-2/human/USA/NY-PV08427/2020
+RC   {ECO:0000313|EMBL:QJD24254.1}, SARS-CoV-2/human/USA/NY-PV08428/2020
+RC   {ECO:0000313|EMBL:QJD23870.1}, SARS-CoV-2/human/USA/NY-PV08429/2020
+RC   {ECO:0000313|EMBL:QJD24314.1}, SARS-CoV-2/human/USA/NY-PV08432/2020
+RC   {ECO:0000313|EMBL:QJD23306.1}, SARS-CoV-2/human/USA/NY-PV08434/2020
+RC   {ECO:0000313|EMBL:QJD23630.1}, SARS-CoV-2/human/USA/NY-PV08435/2020
+RC   {ECO:0000313|EMBL:QJD24206.1}, SARS-CoV-2/human/USA/NY-PV08436/2020
+RC   {ECO:0000313|EMBL:QJD23342.1}, SARS-CoV-2/human/USA/NY-PV08438/2020
+RC   {ECO:0000313|EMBL:QJD23471.1}, SARS-CoV-2/human/USA/NY-PV08441/2020
+RC   {ECO:0000313|EMBL:QJD23486.1}, SARS-CoV-2/human/USA/NY-PV08443/2020
+RC   {ECO:0000313|EMBL:QJD24302.1}, SARS-CoV-2/human/USA/NY-PV08444/2020
+RC   {ECO:0000313|EMBL:QJD24122.1}, SARS-CoV-2/human/USA/NY-PV08445/2020
+RC   {ECO:0000313|EMBL:QJD23582.1}, SARS-CoV-2/human/USA/NY-PV08446/2020
+RC   {ECO:0000313|EMBL:QJD23762.1}, SARS-CoV-2/human/USA/NY-PV08447/2020
+RC   {ECO:0000313|EMBL:QJD24278.1}, SARS-CoV-2/human/USA/NY-PV08448/2020
+RC   {ECO:0000313|EMBL:QJD23822.1}, SARS-CoV-2/human/USA/NY-PV08449/2020
+RC   {ECO:0000313|EMBL:QJD24134.1}, SARS-CoV-2/human/USA/NY-PV08450/2020
+RC   {ECO:0000313|EMBL:QJD23942.1}, SARS-CoV-2/human/USA/NY-PV08452/2020
+RC   {ECO:0000313|EMBL:QJD24074.1}, SARS-CoV-2/human/USA/NY-PV08453/2020
+RC   {ECO:0000313|EMBL:QJD23690.1}, SARS-CoV-2/human/USA/NY-PV08455/2020
+RC   {ECO:0000313|EMBL:QJD24098.1}, SARS-CoV-2/human/USA/NY-PV08456/2020
+RC   {ECO:0000313|EMBL:QJD23366.1}, SARS-CoV-2/human/USA/NY-PV08459/2020
+RC   {ECO:0000313|EMBL:QJD24062.1}, SARS-CoV-2/human/USA/NY-PV08461/2020
+RC   {ECO:0000313|EMBL:QJD23930.1}, SARS-CoV-2/human/USA/NY-PV08462/2020
+RC   {ECO:0000313|EMBL:QJD23738.1}, SARS-CoV-2/human/USA/NY-PV08463/2020
+RC   {ECO:0000313|EMBL:QJD23438.1}, SARS-CoV-2/human/USA/NY-PV08464/2020
+RC   {ECO:0000313|EMBL:QJD23282.1}, SARS-CoV-2/human/USA/NY-PV08466/2020
+RC   {ECO:0000313|EMBL:QJD24350.1}, SARS-CoV-2/human/USA/NY-PV08468/2020
+RC   {ECO:0000313|EMBL:QJD23606.1}, SARS-CoV-2/human/USA/NY-PV08469/2020
+RC   {ECO:0000313|EMBL:QJD23750.1}, SARS-CoV-2/human/USA/NY-PV08471/2020
+RC   {ECO:0000313|EMBL:QJD23666.1}, SARS-CoV-2/human/USA/NY-PV08472/2020
+RC   {ECO:0000313|EMBL:QJD23978.1}, SARS-CoV-2/human/USA/NY-PV08473/2020
+RC   {ECO:0000313|EMBL:QJD23810.1}, SARS-CoV-2/human/USA/NY-PV08474/2020
+RC   {ECO:0000313|EMBL:QJD23834.1}, SARS-CoV-2/human/USA/NY-PV08476/2020
+RC   {ECO:0000313|EMBL:QJD23953.1}, SARS-CoV-2/human/USA/NY-PV08477/2020
+RC   {ECO:0000313|EMBL:QJD23990.1}, SARS-CoV-2/human/USA/NY-PV08478/2020
+RC   {ECO:0000313|EMBL:QJD23318.1}, SARS-CoV-2/human/USA/NY-PV08481/2020
+RC   {ECO:0000313|EMBL:QJD23894.1}, SARS-CoV-2/human/USA/NY-PV08485/2020
+RC   {ECO:0000313|EMBL:QJD23726.1}, SARS-CoV-2/human/USA/NY-PV08486/2020
+RC   {ECO:0000313|EMBL:QJD23354.1}, SARS-CoV-2/human/USA/NY-PV08487/2020
+RC   {ECO:0000313|EMBL:QJD24086.1}, SARS-CoV-2/human/USA/NY-PV08489/2020
+RC   {ECO:0000313|EMBL:QJD24218.1}, SARS-CoV-2/human/USA/NY-PV08490/2020
+RC   {ECO:0000313|EMBL:QJD23402.1}, SARS-CoV-2/human/USA/NY-PV08491/2020
+RC   {ECO:0000313|EMBL:QJD23774.1}, SARS-CoV-2/human/USA/NY-PV08492/2020
+RC   {ECO:0000313|EMBL:QJD23450.1}, SARS-CoV-2/human/USA/NY-PV08493/2020
+RC   {ECO:0000313|EMBL:QJD24242.1}, SARS-CoV-2/human/USA/NY-PV08494/2020
+RC   {ECO:0000313|EMBL:QJD23546.1}, SARS-CoV-2/human/USA/NY-PV08495/2020
+RC   {ECO:0000313|EMBL:QJD23678.1}, SARS-CoV-2/human/USA/NY-PV08496/2020
+RC   {ECO:0000313|EMBL:QJD24038.1}, SARS-CoV-2/human/USA/NY-PV08498/2020
+RC   {ECO:0000313|EMBL:QJD23966.1}, SARS-CoV-2/human/USA/NY-PV08500/2020
+RC   {ECO:0000313|EMBL:QJD23510.1}, SARS-CoV-2/human/USA/NY-PV09000/2020
+RC   {ECO:0000313|EMBL:QJD23522.1}, SARS-CoV-2/human/USA/NY-PV09006/2020
+RC   {ECO:0000313|EMBL:QJD25298.1}, SARS-CoV-2/human/USA/NY-PV09019/2020
+RC   {ECO:0000313|EMBL:QJD24386.1}, SARS-CoV-2/human/USA/NY-PV09020/2020
+RC   {ECO:0000313|EMBL:QJD25562.1}, SARS-CoV-2/human/USA/NY-PV09021/2020
+RC   {ECO:0000313|EMBL:QJD25646.1}, SARS-CoV-2/human/USA/NY-PV09023/2020
+RC   {ECO:0000313|EMBL:QJD25034.1}, SARS-CoV-2/human/USA/NY-PV09025/2020
+RC   {ECO:0000313|EMBL:QJD25730.1}, SARS-CoV-2/human/USA/NY-PV09028/2020
+RC   {ECO:0000313|EMBL:QJD25202.1}, SARS-CoV-2/human/USA/NY-PV09029/2020
+RC   {ECO:0000313|EMBL:QJD25538.1}, SARS-CoV-2/human/USA/NY-PV09030/2020
+RC   {ECO:0000313|EMBL:QJD25476.1}, SARS-CoV-2/human/USA/NY-PV09032/2020
+RC   {ECO:0000313|EMBL:QJD24878.1}, SARS-CoV-2/human/USA/NY-PV09037/2020
+RC   {ECO:0000313|EMBL:QJD25106.1}, SARS-CoV-2/human/USA/NY-PV09039/2020
+RC   {ECO:0000313|EMBL:QJD24674.1}, SARS-CoV-2/human/USA/NY-PV09041/2020
+RC   {ECO:0000313|EMBL:QJD24734.1}, SARS-CoV-2/human/USA/NY-PV09043/2020
+RC   {ECO:0000313|EMBL:QJD25118.1}, SARS-CoV-2/human/USA/NY-PV09044/2020
+RC   {ECO:0000313|EMBL:QJD25058.1}, SARS-CoV-2/human/USA/NY-PV09045/2020
+RC   {ECO:0000313|EMBL:QJD25310.1}, SARS-CoV-2/human/USA/NY-PV09046/2020
+RC   {ECO:0000313|EMBL:QJD25586.1}, SARS-CoV-2/human/USA/NY-PV09047/2020
+RC   {ECO:0000313|EMBL:QJD25597.1}, SARS-CoV-2/human/USA/NY-PV09050/2020
+RC   {ECO:0000313|EMBL:QJD25680.1}, SARS-CoV-2/human/USA/NY-PV09056/2020
+RC   {ECO:0000313|EMBL:QJD24854.1}, SARS-CoV-2/human/USA/NY-PV09057/2020
+RC   {ECO:0000313|EMBL:QJD25418.1}, SARS-CoV-2/human/USA/NY-PV09060/2020
+RC   {ECO:0000313|EMBL:QJD24530.1}, SARS-CoV-2/human/USA/NY-PV09061/2020
+RC   {ECO:0000313|EMBL:QJD24962.1}, SARS-CoV-2/human/USA/NY-PV09063/2020
+RC   {ECO:0000313|EMBL:QJD24986.1}, SARS-CoV-2/human/USA/NY-PV09064/2020
+RC   {ECO:0000313|EMBL:QJD24926.1}, SARS-CoV-2/human/USA/NY-PV09067/2020
+RC   {ECO:0000313|EMBL:QJD25070.1}, SARS-CoV-2/human/USA/NY-PV09068/2020
+RC   {ECO:0000313|EMBL:QJD25382.1}, SARS-CoV-2/human/USA/NY-PV09069/2020
+RC   {ECO:0000313|EMBL:QJD25022.1}, SARS-CoV-2/human/USA/NY-PV09071/2020
+RC   {ECO:0000313|EMBL:QJD24602.1}, SARS-CoV-2/human/USA/NY-PV09073/2020
+RC   {ECO:0000313|EMBL:QJD25634.1}, SARS-CoV-2/human/USA/NY-PV09075/2020
+RC   {ECO:0000313|EMBL:QJD24698.1}, SARS-CoV-2/human/USA/NY-PV09076/2020
+RC   {ECO:0000313|EMBL:QJD25344.1}, SARS-CoV-2/human/USA/NY-PV09077/2020
+RC   {ECO:0000313|EMBL:QJD24662.1}, SARS-CoV-2/human/USA/NY-PV09079/2020
+RC   {ECO:0000313|EMBL:QJD24518.1}, SARS-CoV-2/human/USA/NY-PV09080/2020
+RC   {ECO:0000313|EMBL:QJD25212.1}, SARS-CoV-2/human/USA/NY-PV09083/2020
+RC   {ECO:0000313|EMBL:QJD25190.1}, SARS-CoV-2/human/USA/NY-PV09087/2020
+RC   {ECO:0000313|EMBL:QJD24422.1}, SARS-CoV-2/human/USA/NY-PV09088/2020
+RC   {ECO:0000313|EMBL:QJD25274.1}, SARS-CoV-2/human/USA/NY-PV09090/2020
+RC   {ECO:0000313|EMBL:QJD25622.1}, SARS-CoV-2/human/USA/NY-PV09092/2020
+RC   {ECO:0000313|EMBL:QJD25154.1}, SARS-CoV-2/human/USA/NY-PV09097/2020
+RC   {ECO:0000313|EMBL:QJD24830.1}, SARS-CoV-2/human/USA/NY-PV09098/2020
+RC   {ECO:0000313|EMBL:QJD25178.1}, SARS-CoV-2/human/USA/NY-PV09099/2020
+RC   {ECO:0000313|EMBL:QJD24794.1}, SARS-CoV-2/human/USA/NY-PV09102/2020
+RC   {ECO:0000313|EMBL:QJD25466.1}, SARS-CoV-2/human/USA/NY-PV09103/2020
+RC   {ECO:0000313|EMBL:QJD24434.1}, SARS-CoV-2/human/USA/NY-PV09115/2020
+RC   {ECO:0000313|EMBL:QJD25670.1}, SARS-CoV-2/human/USA/NY-PV09116/2020
+RC   {ECO:0000313|EMBL:QJD24890.1}, SARS-CoV-2/human/USA/NY-PV09118/2020
+RC   {ECO:0000313|EMBL:QJD24766.1}, SARS-CoV-2/human/USA/NY-PV09119/2020
+RC   {ECO:0000313|EMBL:QJD24578.1}, SARS-CoV-2/human/USA/NY-PV09120/2020
+RC   {ECO:0000313|EMBL:QJD24638.1}, SARS-CoV-2/human/USA/NY-PV09121/2020
+RC   {ECO:0000313|EMBL:QJD24445.1}, SARS-CoV-2/human/USA/NY-PV09122/2020
+RC   {ECO:0000313|EMBL:QJD24746.1}, SARS-CoV-2/human/USA/NY-PV09123/2020
+RC   {ECO:0000313|EMBL:QJD25082.1}, SARS-CoV-2/human/USA/NY-PV09125/2020
+RC   {ECO:0000313|EMBL:QJD25226.1}, SARS-CoV-2/human/USA/NY-PV09126/2020
+RC   {ECO:0000313|EMBL:QJD25550.1}, SARS-CoV-2/human/USA/NY-PV09127/2020
+RC   {ECO:0000313|EMBL:QJD25694.1}, SARS-CoV-2/human/USA/NY-PV09128/2020
+RC   {ECO:0000313|EMBL:QJD24614.1}, SARS-CoV-2/human/USA/NY-PV09129/2020
+RC   {ECO:0000313|EMBL:QJD24782.1}, SARS-CoV-2/human/USA/NY-PV09130/2020
+RC   {ECO:0000313|EMBL:QJD25430.1}, SARS-CoV-2/human/USA/NY-PV09132/2020
+RC   {ECO:0000313|EMBL:QJD24806.1}, SARS-CoV-2/human/USA/NY-PV09134/2020
+RC   {ECO:0000313|EMBL:QJD25010.1}, SARS-CoV-2/human/USA/NY-PV09135/2020
+RC   {ECO:0000313|EMBL:QJD25250.1}, SARS-CoV-2/human/USA/NY-PV09137/2020
+RC   {ECO:0000313|EMBL:QJD25658.1}, SARS-CoV-2/human/USA/NY-PV09138/2020
+RC   {ECO:0000313|EMBL:QJD24974.1}, SARS-CoV-2/human/USA/NY-PV09139/2020
+RC   {ECO:0000313|EMBL:QJD25358.1}, SARS-CoV-2/human/USA/NY-PV09140/2020
+RC   {ECO:0000313|EMBL:QJD24842.1}, SARS-CoV-2/human/USA/NY-PV09141/2020
+RC   {ECO:0000313|EMBL:QJD24540.1}, SARS-CoV-2/human/USA/NY-PV09142/2020
+RC   {ECO:0000313|EMBL:QJD24554.1}, SARS-CoV-2/human/USA/NY-PV09143/2020
+RC   {ECO:0000313|EMBL:QJD24362.1}, SARS-CoV-2/human/USA/NY-PV09144/2020
+RC   {ECO:0000313|EMBL:QJD24686.1}, SARS-CoV-2/human/USA/NY-PV09145/2020
+RC   {ECO:0000313|EMBL:QJD24410.1}, SARS-CoV-2/human/USA/NY-PV09147/2020
+RC   {ECO:0000313|EMBL:QJD25130.1}, SARS-CoV-2/human/USA/NY-PV09149/2020
+RC   {ECO:0000313|EMBL:QJD24648.1}, SARS-CoV-2/human/USA/NY-PV09151/2020
+RC   {ECO:0000313|EMBL:QJD25574.1}, SARS-CoV-2/human/USA/NY-PV09152/2020
+RC   {ECO:0000313|EMBL:QJD24626.1}, SARS-CoV-2/human/USA/NY-PV09153/2020
+RC   {ECO:0000313|EMBL:QJD24470.1}, SARS-CoV-2/human/USA/NY-PV09154/2020
+RC   {ECO:0000313|EMBL:QJD24374.1}, SARS-CoV-2/human/USA/NY-PV09156/2020
+RC   {ECO:0000313|EMBL:QJD24758.1}, SARS-CoV-2/human/USA/NY-PV09157/2020
+RC   {ECO:0000313|EMBL:QJD25046.1}, SARS-CoV-2/human/USA/NY-PV09158/2020
+RC   {ECO:0000313|EMBL:QJD25718.1}, SARS-CoV-2/human/USA/NY-PV09161/2020
+RC   {ECO:0000313|EMBL:QJD25440.1}, SARS-CoV-2/human/USA/NY-PV09163/2020
+RC   {ECO:0000313|EMBL:QJD24818.1}, SARS-CoV-2/human/USA/NY-PV09164/2020
+RC   {ECO:0000313|EMBL:QJD24482.1}, SARS-CoV-2/human/USA/NY-PV09165/2020
+RC   {ECO:0000313|EMBL:QJD25406.1}, SARS-CoV-2/human/USA/NY-PV09168/2020
+RC   {ECO:0000313|EMBL:QJD25610.1}, SARS-CoV-2/human/USA/NY-PV09169/2020
+RC   {ECO:0000313|EMBL:QJD25454.1}, SARS-CoV-2/human/USA/NY-PV09170/2020
+RC   {ECO:0000313|EMBL:QJD25094.1}, SARS-CoV-2/human/USA/NY-PV09171/2020
+RC   {ECO:0000313|EMBL:QJD25322.1}, SARS-CoV-2/human/USA/NY-PV09172/2020
+RC   {ECO:0000313|EMBL:QJD25370.1}, SARS-CoV-2/human/USA/NY-PV09176/2020
+RC   {ECO:0000313|EMBL:QJD24722.1}, SARS-CoV-2/human/USA/NY-PV09177/2020
+RC   {ECO:0000313|EMBL:QJD25394.1}, SARS-CoV-2/human/USA/NY-PV09178/2020
+RC   {ECO:0000313|EMBL:QJD25754.1}, SARS-CoV-2/human/USA/NY-PV09179/2020
+RC   {ECO:0000313|EMBL:QJD24866.1}, SARS-CoV-2/human/USA/NY-PV09180/2020
+RC   {ECO:0000313|EMBL:QJD24902.1}, SARS-CoV-2/human/USA/NY-PV09181/2020
+RC   {ECO:0000313|EMBL:QJD25262.1}, SARS-CoV-2/human/USA/NY-PV09182/2020
+RC   {ECO:0000313|EMBL:QJD24590.1}, SARS-CoV-2/human/USA/NY-PV09183/2020
+RC   {ECO:0000313|EMBL:QJD25286.1}, SARS-CoV-2/human/USA/NY-PV09186/2020
+RC   {ECO:0000313|EMBL:QJD25526.1}, SARS-CoV-2/human/USA/NY-PV09187/2020
+RC   {ECO:0000313|EMBL:QJD25490.1}, SARS-CoV-2/human/USA/NY-PV09188/2020
+RC   {ECO:0000313|EMBL:QJD24457.1}, SARS-CoV-2/human/USA/NY-PV09189/2020
+RC   {ECO:0000313|EMBL:QJD25766.1}, SARS-CoV-2/human/USA/NY-PV09190/2020
+RC   {ECO:0000313|EMBL:QJD25142.1}, SARS-CoV-2/human/USA/NY-PV09192/2020
+RC   {ECO:0000313|EMBL:QJD24950.1}, SARS-CoV-2/human/USA/NY-PV09193/2020
+RC   {ECO:0000313|EMBL:QJD24710.1}, SARS-CoV-2/human/USA/NY-PV09194/2020
+RC   {ECO:0000313|EMBL:QJD25238.1}, SARS-CoV-2/human/USA/NY-PV09195/2020
+RC   {ECO:0000313|EMBL:QJD24494.1}, SARS-CoV-2/human/USA/NY-PV09197/2020
+RC   {ECO:0000313|EMBL:QJD25166.1}, SARS-CoV-2/human/USA/NY-PV09198/2020
+RC   {ECO:0000313|EMBL:QJD25742.1}, SARS-CoV-2/human/USA/NY-PV09199/2020
+RC   {ECO:0000313|EMBL:QJD24938.1}, SARS-CoV-2/human/USA/NY-PV09200/2020
+RC   {ECO:0000313|EMBL:QJD25334.1}, SARS-CoV-2/human/USA/NY-PV09301/2020
+RC   {ECO:0000313|EMBL:QJD24566.1}, SARS-CoV-2/human/USA/NY-PV09303/2020
+RC   {ECO:0000313|EMBL:QJD24914.1}, SARS-CoV-2/human/USA/NY-PV09304/2020
+RC   {ECO:0000313|EMBL:QJD25706.1}, SARS-CoV-2/human/USA/NY-PV09305/2020
+RC   {ECO:0000313|EMBL:QJD24398.1}, SARS-CoV-2/human/USA/NY-PV09307/2020
+RC   {ECO:0000313|EMBL:QJD24998.1}, SARS-CoV-2/human/USA/NY-PV09308/2020
+RC   {ECO:0000313|EMBL:QJD25502.1}, SARS-CoV-2/human/USA/NY-PV09309/2020
+RC   {ECO:0000313|EMBL:QJD25514.1}, SARS-CoV-2/human/USA/NY1-PV08001/2020
+RC   {ECO:0000313|EMBL:QJD24158.1}, and
+RC   SARS-CoV-2/human/USA/NY2-PV08100/2020 {ECO:0000313|EMBL:QJD23414.1};
+RG   NIAID Centers of Excellence for Influenza Research and Surveillance (CEIRS);
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [87] {ECO:0000313|EMBL:QJD20846.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/LKA/COV38/2020 {ECO:0000313|EMBL:QJD20846.1},
+RC   SARS-CoV-2/human/LKA/COV486/2020 {ECO:0000313|EMBL:QJD20882.1},
+RC   SARS-CoV-2/human/LKA/COV53/2020 {ECO:0000313|EMBL:QJD20858.1}, and
+RC   SARS-CoV-2/human/LKA/COV91/2020 {ECO:0000313|EMBL:QJD20870.1};
+RA   Jeewandara C., Ariyaratne D., Gomes L., Jayathilaka D., Ranasinghe D.,
+RA   Wijewickrama A., Narangoda E., Idampitiya D., Malavige G.N.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [88] {ECO:0000313|EMBL:QJD23150.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/CZE/2256/2020 {ECO:0000313|EMBL:QJD23150.1},
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_1899/2020
+RC   {ECO:0000313|EMBL:QJD23210.1},
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_1967/2020
+RC   {ECO:0000313|EMBL:QJD23222.1},
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_1968/2020
+RC   {ECO:0000313|EMBL:QJD23186.1},
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_2122/2020
+RC   {ECO:0000313|EMBL:QJD23162.1},
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_2174/2020
+RC   {ECO:0000313|EMBL:QJD23198.1}, and
+RC   SARS-CoV-2/human/CZE/CzechiaMotol_2448/2020
+RC   {ECO:0000313|EMBL:QJD23174.1};
+RA   Kramna L., Polackova K., Cinek O.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [89] {ECO:0000313|EMBL:QJA17533.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/CT_9849/2020
+RC   {ECO:0000313|EMBL:QJA17533.1}, SARS-CoV-2/human/USA/GA_2070/2020
+RC   {ECO:0000313|EMBL:QJA17545.1}, SARS-CoV-2/human/USA/GA_2147/2020
+RC   {ECO:0000313|EMBL:QJA17557.1}, SARS-CoV-2/human/USA/GA_2275/2020
+RC   {ECO:0000313|EMBL:QJA17569.1}, SARS-CoV-2/human/USA/HI_4970/2020
+RC   {ECO:0000313|EMBL:QJA17581.1}, SARS-CoV-2/human/USA/HI_7881/2020
+RC   {ECO:0000313|EMBL:QJA17593.1}, and SARS-CoV-2/human/USA/IN_72003/2020
+RC   {ECO:0000313|EMBL:QJA17605.1};
+RA   Uehara A., Li Y., Queen K., Paden C.R., Marine R., Tao Y., Zhang J.,
+RA   Wang H., Keckler M.S., Laufer Halpin A.S., Elkins C.A., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [90] {ECO:0000313|EMBL:QJC21050.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/LA097/2020 {ECO:0000313|EMBL:QJC21050.1};
+RA   Rose R., Nolan D., Garcia-Diaz J., Yang T., Caruso L., Navia W.,
+RA   Von Borstel L., Zhou X., Cross S., Moraga D., Lamers S., Feehan A.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [91] {ECO:0000313|EMBL:QJA17617.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/IN_82003/2020
+RC   {ECO:0000313|EMBL:QJA17617.1}, SARS-CoV-2/human/USA/IN_92003/2020
+RC   {ECO:0000313|EMBL:QJA17629.1}, SARS-CoV-2/human/USA/MD_0027/2020
+RC   {ECO:0000313|EMBL:QJA17641.1}, SARS-CoV-2/human/USA/MN_0100/2020
+RC   {ECO:0000313|EMBL:QJA17653.1}, SARS-CoV-2/human/USA/MN_0101/2020
+RC   {ECO:0000313|EMBL:QJA17749.1}, SARS-CoV-2/human/USA/NC_0025/2020
+RC   {ECO:0000313|EMBL:QJA17761.1}, SARS-CoV-2/human/USA/NV_0016/2020
+RC   {ECO:0000313|EMBL:QJA17737.1}, SARS-CoV-2/human/USA/OH_0019/2020
+RC   {ECO:0000313|EMBL:QJA17665.1}, SARS-CoV-2/human/USA/OH_0020/2020
+RC   {ECO:0000313|EMBL:QJA17677.1}, SARS-CoV-2/human/USA/PA_2734/2020
+RC   {ECO:0000313|EMBL:QJA17689.1}, SARS-CoV-2/human/USA/PA_2735/2020
+RC   {ECO:0000313|EMBL:QJA17701.1}, SARS-CoV-2/human/USA/PA_2887/2020
+RC   {ECO:0000313|EMBL:QJA17713.1}, and SARS-CoV-2/human/USA/RI_0882/2020
+RC   {ECO:0000313|EMBL:QJA17725.1};
+RA   Queen K., Li Y., Uehara A., Paden C.R., Marine R., Tao Y., Zhang J.,
+RA   Wang H., Keckler M.S., Laufer Halpin A.S., Elkins C.A., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [92] {ECO:0000313|EMBL:QIZ64274.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/UT-00001/2020
+RC   {ECO:0000313|EMBL:QIZ64274.1}, SARS-CoV-2/human/USA/UT-00003/2020
+RC   {ECO:0000313|EMBL:QIZ64287.1}, SARS-CoV-2/human/USA/UT-00004/2020
+RC   {ECO:0000313|EMBL:QIZ64298.1}, SARS-CoV-2/human/USA/UT-00005/2020
+RC   {ECO:0000313|EMBL:QIZ64310.1}, SARS-CoV-2/human/USA/UT-00006/2020
+RC   {ECO:0000313|EMBL:QIZ64323.1}, SARS-CoV-2/human/USA/UT-00008/2020
+RC   {ECO:0000313|EMBL:QIZ64335.1}, SARS-CoV-2/human/USA/UT-00009/2020
+RC   {ECO:0000313|EMBL:QIZ64344.1}, SARS-CoV-2/human/USA/UT-00010/2020
+RC   {ECO:0000313|EMBL:QIZ64359.1}, SARS-CoV-2/human/USA/UT-00011/2020
+RC   {ECO:0000313|EMBL:QIZ64370.1}, SARS-CoV-2/human/USA/UT-00012/2020
+RC   {ECO:0000313|EMBL:QIZ64383.1}, SARS-CoV-2/human/USA/UT-00013/2020
+RC   {ECO:0000313|EMBL:QIZ64394.1}, SARS-CoV-2/human/USA/UT-00014/2020
+RC   {ECO:0000313|EMBL:QIZ64407.1}, SARS-CoV-2/human/USA/UT-00015/2020
+RC   {ECO:0000313|EMBL:QIZ64419.1}, SARS-CoV-2/human/USA/UT-00016/2020
+RC   {ECO:0000313|EMBL:QIZ64431.1}, SARS-CoV-2/human/USA/UT-00017/2020
+RC   {ECO:0000313|EMBL:QIZ64443.1}, SARS-CoV-2/human/USA/UT-00019/2020
+RC   {ECO:0000313|EMBL:QIZ64455.1}, SARS-CoV-2/human/USA/UT-00020/2020
+RC   {ECO:0000313|EMBL:QIZ64467.1}, SARS-CoV-2/human/USA/UT-00021/2020
+RC   {ECO:0000313|EMBL:QIZ64479.1}, SARS-CoV-2/human/USA/UT-00022/2020
+RC   {ECO:0000313|EMBL:QIZ64491.1}, SARS-CoV-2/human/USA/UT-00023/2020
+RC   {ECO:0000313|EMBL:QIZ64503.1}, SARS-CoV-2/human/USA/UT-00025/2020
+RC   {ECO:0000313|EMBL:QIZ64515.1}, SARS-CoV-2/human/USA/UT-00027/2020
+RC   {ECO:0000313|EMBL:QIZ64526.1}, SARS-CoV-2/human/USA/UT-00028/2020
+RC   {ECO:0000313|EMBL:QIZ64539.1}, SARS-CoV-2/human/USA/UT-00031/2020
+RC   {ECO:0000313|EMBL:QIZ64550.1}, SARS-CoV-2/human/USA/UT-00032/2020
+RC   {ECO:0000313|EMBL:QIZ64563.1}, SARS-CoV-2/human/USA/UT-00033/2020
+RC   {ECO:0000313|EMBL:QIZ64575.1}, SARS-CoV-2/human/USA/UT-00034/2020
+RC   {ECO:0000313|EMBL:QIZ64587.1}, SARS-CoV-2/human/USA/UT-00087/2020
+RC   {ECO:0000313|EMBL:QIZ64589.1}, SARS-CoV-2/human/USA/UT-00089/2020
+RC   {ECO:0000313|EMBL:QIZ64609.1}, SARS-CoV-2/human/USA/UT-00090/2020
+RC   {ECO:0000313|EMBL:QIZ64619.1}, SARS-CoV-2/human/USA/UT-00159/2020
+RC   {ECO:0000313|EMBL:QIZ64633.1}, SARS-CoV-2/human/USA/UT-00284/2020
+RC   {ECO:0000313|EMBL:QIZ64643.1}, SARS-CoV-2/human/USA/UT-00287/2020
+RC   {ECO:0000313|EMBL:QIZ64657.1}, SARS-CoV-2/human/USA/UT-00288/2020
+RC   {ECO:0000313|EMBL:QIZ64667.1}, SARS-CoV-2/human/USA/UT-00289/2020
+RC   {ECO:0000313|EMBL:QIZ64681.1}, SARS-CoV-2/human/USA/UT-00290/2020
+RC   {ECO:0000313|EMBL:QIZ64694.1}, SARS-CoV-2/human/USA/UT-00291/2020
+RC   {ECO:0000313|EMBL:QIZ64703.1}, SARS-CoV-2/human/USA/UT-00297/2020
+RC   {ECO:0000313|EMBL:QIZ64717.1}, SARS-CoV-2/human/USA/UT-00300/2020
+RC   {ECO:0000313|EMBL:QIZ64728.1}, SARS-CoV-2/human/USA/UT-00301/2020
+RC   {ECO:0000313|EMBL:QIZ64741.1}, SARS-CoV-2/human/USA/UT-00303/2020
+RC   {ECO:0000313|EMBL:QIZ64763.1}, SARS-CoV-2/human/USA/UT-00342/2020
+RC   {ECO:0000313|EMBL:QIZ64773.1}, SARS-CoV-2/human/USA/UT-00344/2020
+RC   {ECO:0000313|EMBL:QIZ64785.1}, SARS-CoV-2/human/USA/UT-00345/2020
+RC   {ECO:0000313|EMBL:QIZ64797.1}, SARS-CoV-2/human/USA/UT-00346/2020
+RC   {ECO:0000313|EMBL:QIZ64809.1}, SARS-CoV-2/human/USA/UT-00347/2020
+RC   {ECO:0000313|EMBL:QIZ64821.1}, SARS-CoV-2/human/USA/UT-00348/2020
+RC   {ECO:0000313|EMBL:QIZ64835.1}, SARS-CoV-2/human/USA/UT-00349/2020
+RC   {ECO:0000313|EMBL:QIZ64847.1}, SARS-CoV-2/human/USA/UT-00350/2020
+RC   {ECO:0000313|EMBL:QIZ64857.1}, SARS-CoV-2/human/USA/UT-00352/2020
+RC   {ECO:0000313|EMBL:QIZ64871.1}, and SARS-CoV-2/human/USA/UT-00361/2020
+RC   {ECO:0000313|EMBL:QIZ64883.1};
+RA   Young E., Oakeson K.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [93] {ECO:0000313|EMBL:QJD23234.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/MYS/186197/2020 {ECO:0000313|EMBL:QJD23267.1},
+RC   SARS-CoV-2/human/MYS/188407/2020 {ECO:0000313|EMBL:QJD23234.1},
+RC   SARS-CoV-2/human/MYS/189332/2020 {ECO:0000313|EMBL:QJD23246.1}, and
+RC   SARS-CoV-2/human/MYS/190300/2020 {ECO:0000313|EMBL:QJD23258.1};
+RA   Chan Y.F.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [94] {ECO:0000313|EMBL:QIU80906.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/IRN/HGRC-01-IPI-8206/2020
+RC   {ECO:0000313|EMBL:QIU80906.1};
+RG   Rapid Response Team from Pasteur Institute of Iran;
+RA   Zeinali S., Khosravi M.A., Abbasalipour Bashash M., Mostafavi Jabbari S.,
+RA   Firoozi M., Pourtavakoli S., Khateri E., Zeinali R., Hoseini F.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [95] {ECO:0000313|EMBL:QJA41650.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/BRA/SP02cc/2020 {ECO:0000313|EMBL:QJA41650.1};
+RA   Malta F., Amgarten D., de Oliveira D.B.L., Araujo D.B., Machado R.R.G.,
+RA   Santana R.A.F., Mangueira C.L.P., Durigon E.L., Pinho J.R.R.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [96] {ECO:0000313|EMBL:QIT07008.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ISR/ISR_IT0320/2020
+RC   {ECO:0000313|EMBL:QIT07008.1};
+RA   Cohen-Gihon I., Israeli O., Shifman O., Stein D., Melamed S., Paran N.,
+RA   Israely T., Achdout H., Yahalom Ronen Y., Tamir H., Politi B., Cherry L.,
+RA   Vitner E., Laskar O., Weiss S., Mandelboim M., Erster O., Regev-Yochay G.,
+RA   Segal G., Yitzhaki S., Shapira S.C., Beth-Din A., Zvi A.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [97] {ECO:0000313|EMBL:QIT06960.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/FL_5091/2020
+RC   {ECO:0000313|EMBL:QIT06972.1}, SARS-CoV-2/human/USA/FL_5125/2020
+RC   {ECO:0000313|EMBL:QIT06960.1}, and SARS-CoV-2/human/USA/TX_2020/2020
+RC   {ECO:0000313|EMBL:QIT06984.1};
+RA   Uehara A., Tao Y., Zhang J., Queen K., Paden C.R., Li Y., Wang H.,
+RA   Padilla J., Lee J., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [98] {ECO:0000313|EMBL:QJD20641.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/TWN/CGMH-CGU-03/2020
+RC   {ECO:0000313|EMBL:QJD20641.1}, SARS-CoV-2/human/TWN/CGMH-CGU-04/2020
+RC   {ECO:0000313|EMBL:QJD20653.1}, and
+RC   SARS-CoV-2/human/TWN/CGMH-CGU-05/2020 {ECO:0000313|EMBL:QJD20665.1};
+RA   Tsao K.-C., Gong Y.-N., Yang S.-L., Liu Y.-C., Huang C.-G., Hsiao M.-J.,
+RA   Huang P.-W., Yang C.-T., Chiu C.-H., Huang C.-H., Le K.-T., Lin S.-M.,
+RA   Huang P.-N., Lee K.-M., Chen G.-W., Shih S.-R.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [99] {ECO:0000313|EMBL:QIZ16206.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/IA_6390/2020
+RC   {ECO:0000313|EMBL:QIZ16278.1}, SARS-CoV-2/human/USA/IA_6391/2020
+RC   {ECO:0000313|EMBL:QIZ16206.1}, SARS-CoV-2/human/USA/IA_6395/2020
+RC   {ECO:0000313|EMBL:QIZ16242.1}, SARS-CoV-2/human/USA/IA_6396/2020
+RC   {ECO:0000313|EMBL:QIZ16230.1}, SARS-CoV-2/human/USA/IA_6399/2020
+RC   {ECO:0000313|EMBL:QIZ16266.1}, SARS-CoV-2/human/USA/IA_6401/2020
+RC   {ECO:0000313|EMBL:QIZ16254.1}, SARS-CoV-2/human/USA/MA_1355/2020
+RC   {ECO:0000313|EMBL:QIZ16434.1}, SARS-CoV-2/human/USA/MA_2652/2020
+RC   {ECO:0000313|EMBL:QIZ16446.1}, SARS-CoV-2/human/USA/MA_3614/2020
+RC   {ECO:0000313|EMBL:QIZ16458.1}, SARS-CoV-2/human/USA/MA_3616/2020
+RC   {ECO:0000313|EMBL:QIZ16470.1}, SARS-CoV-2/human/USA/MA_3623/2020
+RC   {ECO:0000313|EMBL:QIZ16218.1}, SARS-CoV-2/human/USA/MA_3626/2020
+RC   {ECO:0000313|EMBL:QIZ16482.1}, SARS-CoV-2/human/USA/MA_3642/2020
+RC   {ECO:0000313|EMBL:QIZ16494.1}, SARS-CoV-2/human/USA/MA_3653/2020
+RC   {ECO:0000313|EMBL:QIZ16506.1}, SARS-CoV-2/human/USA/MA_8932/2020
+RC   {ECO:0000313|EMBL:QIZ16374.1}, SARS-CoV-2/human/USA/MA_8933/2020
+RC   {ECO:0000313|EMBL:QIZ16386.1}, SARS-CoV-2/human/USA/MA_9703/2020
+RC   {ECO:0000313|EMBL:QIZ16398.1}, SARS-CoV-2/human/USA/MA_9704/2020
+RC   {ECO:0000313|EMBL:QIZ16410.1}, SARS-CoV-2/human/USA/MA_9889/2020
+RC   {ECO:0000313|EMBL:QIZ16422.1}, SARS-CoV-2/human/USA/NJ_3201/2020
+RC   {ECO:0000313|EMBL:QIZ16290.1}, SARS-CoV-2/human/USA/NY_1922/2020
+RC   {ECO:0000313|EMBL:QIZ16350.1}, SARS-CoV-2/human/USA/SC_3520/2020
+RC   {ECO:0000313|EMBL:QIZ16302.1}, SARS-CoV-2/human/USA/SC_3570/2020
+RC   {ECO:0000313|EMBL:QIZ16314.1}, SARS-CoV-2/human/USA/SC_3571/2020
+RC   {ECO:0000313|EMBL:QIZ16326.1}, SARS-CoV-2/human/USA/SC_3572/2020
+RC   {ECO:0000313|EMBL:QIZ16338.1}, and SARS-CoV-2/human/USA/VA_6171/2020
+RC   {ECO:0000313|EMBL:QIZ16362.1};
+RA   Tao Y., Paden C.R., Zhang J., Queen K., Uehara A., Li Y., Wang H.,
+RA   Keckler M.S., Laufer Halpin A.S., Elkins C.A., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [100] {ECO:0000313|EMBL:QJC21014.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/ESP/VH000001133/2020
+RC   {ECO:0000313|EMBL:QJC21014.1}, and
+RC   SARS-CoV-2/human/ESP/VH198152683/2020 {ECO:0000313|EMBL:QJC21026.1};
+RA   Andres C., Garcia-Cehic D., Pinana M., Guerrero-Murillo M., Rando A.,
+RA   Pumarola T., Codina M.G., Anton A., Quer J.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [101] {ECO:0000313|EMBL:QJA41734.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/USA-WA_0422/2020
+RC   {ECO:0000313|EMBL:QJA41794.1}, SARS-CoV-2/human/USA/USA-WA_0429/2020
+RC   {ECO:0000313|EMBL:QJA41818.1}, SARS-CoV-2/human/USA/USA-WA_0432/2020
+RC   {ECO:0000313|EMBL:QJA41746.1}, SARS-CoV-2/human/USA/USA-WA_0440/2020
+RC   {ECO:0000313|EMBL:QJA41842.1}, SARS-CoV-2/human/USA/USA-WA_0441/2020
+RC   {ECO:0000313|EMBL:QJA41830.1}, SARS-CoV-2/human/USA/USA-WA_0447/2020
+RC   {ECO:0000313|EMBL:QJA41866.1}, SARS-CoV-2/human/USA/USA-WA_0448/2020
+RC   {ECO:0000313|EMBL:QJA41770.1}, SARS-CoV-2/human/USA/USA-WA_0457/2020
+RC   {ECO:0000313|EMBL:QJA41758.1}, SARS-CoV-2/human/USA/USA-WA_0478/2020
+RC   {ECO:0000313|EMBL:QJA41782.1}, SARS-CoV-2/human/USA/USA-WA_0484/2020
+RC   {ECO:0000313|EMBL:QJA41806.1}, SARS-CoV-2/human/USA/USA-WA_0711/2020
+RC   {ECO:0000313|EMBL:QJA41854.1}, and
+RC   SARS-CoV-2/human/USA/USA-WA_0797/2020 {ECO:0000313|EMBL:QJA41734.1};
+RA   Tao Y., Zhang J., Paden C.R., Queen K., Uehara A., Li Y., Wang H.,
+RA   Jacobs J., Russell D., Hiatt B., Gant J., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [102] {ECO:0000313|EMBL:QIZ16544.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/GRC/10/2020 {ECO:0000313|EMBL:QIZ16544.1},
+RC   SARS-CoV-2/human/GRC/12/2020 {ECO:0000313|EMBL:QIZ16556.1},
+RC   SARS-CoV-2/human/GRC/13/2020 {ECO:0000313|EMBL:QIZ16580.1}, and
+RC   SARS-CoV-2/human/GRC/16/2020 {ECO:0000313|EMBL:QIZ16568.1};
+RA   Bampali M., Dovrolis N., Gatzidou E., Froukala E., Stavropoulou A.,
+RA   Veletza S., Tsakris A., Spanakis N., Karakasiliotis I.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [103] {ECO:0000313|EMBL:QIV14993.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/KOR/BA-ACH_2604/2020
+RC   {ECO:0000313|EMBL:QIV14993.1}, SARS-CoV-2/human/KOR/BA-ACH_2718/2020
+RC   {ECO:0000313|EMBL:QIV15005.1}, SARS-CoV-2/human/KOR/BA-ACH_2719/2020
+RC   {ECO:0000313|EMBL:QIV15017.1}, SARS-CoV-2/human/USA/AZ_4811/2020
+RC   {ECO:0000313|EMBL:QIV15029.1}, SARS-CoV-2/human/USA/FL_6318/2020
+RC   {ECO:0000313|EMBL:QIV15041.1}, SARS-CoV-2/human/USA/GA_1299/2020
+RC   {ECO:0000313|EMBL:QIV15053.1}, SARS-CoV-2/human/USA/GA_1320/2020
+RC   {ECO:0000313|EMBL:QIV15065.1}, SARS-CoV-2/human/USA/GA_1445/2020
+RC   {ECO:0000313|EMBL:QIV15077.1}, SARS-CoV-2/human/USA/IL_1293/2020
+RC   {ECO:0000313|EMBL:QIV15089.1}, SARS-CoV-2/human/USA/IL_1375/2020
+RC   {ECO:0000313|EMBL:QIV15101.1}, SARS-CoV-2/human/USA/NH_0004/2020
+RC   {ECO:0000313|EMBL:QIV15113.1}, SARS-CoV-2/human/USA/NH_0008/2020
+RC   {ECO:0000313|EMBL:QIV15125.1}, SARS-CoV-2/human/USA/NY_2929/2020
+RC   {ECO:0000313|EMBL:QIV15137.1}, SARS-CoV-2/human/USA/OR_5430/2020
+RC   {ECO:0000313|EMBL:QIV15149.1}, SARS-CoV-2/human/USA/RI_0556/2020
+RC   {ECO:0000313|EMBL:QIV15161.1}, SARS-CoV-2/human/USA/TX_2039/2020
+RC   {ECO:0000313|EMBL:QIV15173.1}, SARS-CoV-2/human/USA/TX_2817/2020
+RC   {ECO:0000313|EMBL:QIV15185.1}, and SARS-CoV-2/human/USA/TX_2967/2020
+RC   {ECO:0000313|EMBL:QIV15197.1};
+RA   Queen K., Li Y., Tao Y., Zhang J., Uehara A., Paden C.R., Wang H.,
+RA   Marine R., Keckler M.S., Laufer Halpin A.S., Padilla J., Lee J.,
+RA   Elkins C.A., Tong S.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [104] {ECO:0000313|EMBL:QIV65008.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/MI-SC2-0001/2020
+RC   {ECO:0000313|EMBL:QIV65008.1}, SARS-CoV-2/human/USA/MI-SC2-0002/2020
+RC   {ECO:0000313|EMBL:QIV65019.1}, SARS-CoV-2/human/USA/MI-SC2-0003/2020
+RC   {ECO:0000313|EMBL:QIV65030.1}, SARS-CoV-2/human/USA/MI-SC2-0004/2020
+RC   {ECO:0000313|EMBL:QIV65041.1}, SARS-CoV-2/human/USA/MI-SC2-0005/2020
+RC   {ECO:0000313|EMBL:QIV65052.1}, SARS-CoV-2/human/USA/MI-SC2-0006/2020
+RC   {ECO:0000313|EMBL:QIV65063.1}, SARS-CoV-2/human/USA/MI-SC2-0007/2020
+RC   {ECO:0000313|EMBL:QIV65074.1}, SARS-CoV-2/human/USA/MI-SC2-0008/2020
+RC   {ECO:0000313|EMBL:QIV65085.1}, and
+RC   SARS-CoV-2/human/USA/MI-SC2-0009/2020 {ECO:0000313|EMBL:QIV65096.1};
+RA   Blankenship H.M., Riner D., Soehnlen M.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+RN   [105] {ECO:0000313|EMBL:QJC21038.1}
+RP   NUCLEOTIDE SEQUENCE.
+RC   STRAIN=SARS-CoV-2/human/USA/LA096/2020 {ECO:0000313|EMBL:QJC21038.1};
+RA   Rose R., Nolan D., Garcia-Diaz J., Yang T., Caruso L., Navia W.,
+RA   Von Borstel L., Zhou X., Cross S., Lamers S., Feehan A.;
+RL   Submitted (APR-2020) to the EMBL/GenBank/DDBJ databases.
+CC   ---------------------------------------------------------------------------
+CC   Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms
+CC   Distributed under the Creative Commons Attribution (CC BY 4.0) License
+CC   ---------------------------------------------------------------------------
+DR   EMBL; LC522972; BCA25652.1; -; Genomic_RNA.
+DR   EMBL; LC522973; BCA25662.1; -; Genomic_RNA.
+DR   EMBL; LC522974; BCA25672.1; -; Genomic_RNA.
+DR   EMBL; LC522975; BCA25682.1; -; Genomic_RNA.
+DR   EMBL; LC528232; BCA87369.1; -; Genomic_RNA.
+DR   EMBL; LC528233; BCA87379.1; -; Genomic_RNA.
+DR   EMBL; LC529905; BCB15099.1; -; Genomic_RNA.
+DR   EMBL; LC534418; BCB97899.1; -; Genomic_RNA.
+DR   EMBL; LC534419; BCB97909.1; -; Genomic_RNA.
+DR   EMBL; LC542809; BCD57652.1; -; Genomic_RNA.
+DR   EMBL; LC542976; BCD58762.1; -; Genomic_RNA.
+DR   EMBL; MN908947; QHI42199.1; -; Genomic_RNA.
+DR   EMBL; MT007544; QHR84457.1; -; Genomic_RNA.
+DR   EMBL; MT012098; QHS34554.1; -; Genomic_RNA.
+DR   EMBL; MT020781; QHU79182.1; -; Genomic_RNA.
+DR   EMBL; MT020880; QHU79202.1; -; Genomic_RNA.
+DR   EMBL; MT020881; QHU79212.1; -; Genomic_RNA.
+DR   EMBL; MT027062; QHW06047.1; -; Genomic_RNA.
+DR   EMBL; MT027063; QHW06057.1; -; Genomic_RNA.
+DR   EMBL; MT027064; QHW06067.1; -; Genomic_RNA.
+DR   EMBL; MT039873; QHZ00366.1; -; Genomic_RNA.
+DR   EMBL; MT039890; QHZ00387.1; -; Genomic_RNA.
+DR   EMBL; MT039887; QHZ00397.1; -; Genomic_RNA.
+DR   EMBL; MT039888; QHZ00407.1; -; Genomic_RNA.
+DR   EMBL; MT044257; QHZ87590.1; -; Genomic_RNA.
+DR   EMBL; MT044258; QHZ87600.1; -; Genomic_RNA.
+DR   EMBL; MT049951; QIA20053.1; -; Genomic_RNA.
+DR   EMBL; MT066156; QIA98562.1; -; Genomic_RNA.
+DR   EMBL; MT050493; QIA98591.1; -; Genomic_RNA.
+DR   EMBL; MT066175; QIA98603.1; -; Genomic_RNA.
+DR   EMBL; MT066176; QIA98614.1; -; Genomic_RNA.
+DR   EMBL; MT072688; QIB84681.1; -; Genomic_RNA.
+DR   EMBL; MT077125; QIC50506.1; -; Genomic_RNA.
+DR   EMBL; MT093571; QIC53212.1; -; Genomic_RNA.
+DR   EMBL; MT106052; QID21056.1; -; Genomic_RNA.
+DR   EMBL; MT106053; QID21066.1; -; Genomic_RNA.
+DR   EMBL; MT106054; QID21076.1; -; Genomic_RNA.
+DR   EMBL; MT118835; QID98802.1; -; Genomic_RNA.
+DR   EMBL; MT123290; QIE07459.1; -; Genomic_RNA.
+DR   EMBL; MT123291; QIE07469.1; -; Genomic_RNA.
+DR   EMBL; MT123292; QIE07479.1; -; Genomic_RNA.
+DR   EMBL; MT123293; QIE07489.1; -; Genomic_RNA.
+DR   EMBL; MT114412; QIG55873.1; -; Genomic_RNA.
+DR   EMBL; MT114413; QIG55883.1; -; Genomic_RNA.
+DR   EMBL; MT114414; QIG55893.1; -; Genomic_RNA.
+DR   EMBL; MT114415; QIG55903.1; -; Genomic_RNA.
+DR   EMBL; MT114416; QIG55913.1; -; Genomic_RNA.
+DR   EMBL; MT114417; QIG55923.1; -; Genomic_RNA.
+DR   EMBL; MT114418; QIG55933.1; -; Genomic_RNA.
+DR   EMBL; MT114419; QIG55943.1; -; Genomic_RNA.
+DR   EMBL; MT126808; QIG56002.1; -; Genomic_RNA.
+DR   EMBL; MT135041; QIH45031.1; -; Genomic_RNA.
+DR   EMBL; MT135042; QIH45041.1; -; Genomic_RNA.
+DR   EMBL; MT135043; QIH45051.1; -; Genomic_RNA.
+DR   EMBL; MT135044; QIH45061.1; -; Genomic_RNA.
+DR   EMBL; MT152824; QIH55229.1; -; Genomic_RNA.
+DR   EMBL; MT159705; QII57176.1; -; Genomic_RNA.
+DR   EMBL; MT159706; QII57186.1; -; Genomic_RNA.
+DR   EMBL; MT159707; QII57196.1; -; Genomic_RNA.
+DR   EMBL; MT159708; QII57206.1; -; Genomic_RNA.
+DR   EMBL; MT159709; QII57216.1; -; Genomic_RNA.
+DR   EMBL; MT159710; QII57226.1; -; Genomic_RNA.
+DR   EMBL; MT159711; QII57236.1; -; Genomic_RNA.
+DR   EMBL; MT159712; QII57246.1; -; Genomic_RNA.
+DR   EMBL; MT159713; QII57256.1; -; Genomic_RNA.
+DR   EMBL; MT159714; QII57266.1; -; Genomic_RNA.
+DR   EMBL; MT159715; QII57276.1; -; Genomic_RNA.
+DR   EMBL; MT159716; QII57286.1; -; Genomic_RNA.
+DR   EMBL; MT159717; QII57296.1; -; Genomic_RNA.
+DR   EMBL; MT159718; QII57306.1; -; Genomic_RNA.
+DR   EMBL; MT159719; QII57316.1; -; Genomic_RNA.
+DR   EMBL; MT159720; QII57326.1; -; Genomic_RNA.
+DR   EMBL; MT159721; QII57336.1; -; Genomic_RNA.
+DR   EMBL; MT159722; QII57346.1; -; Genomic_RNA.
+DR   EMBL; MT163716; QII87791.1; -; Genomic_RNA.
+DR   EMBL; MT163717; QII87803.1; -; Genomic_RNA.
+DR   EMBL; MT163718; QII87815.1; -; Genomic_RNA.
+DR   EMBL; MT163719; QII87827.1; -; Genomic_RNA.
+DR   EMBL; MT163720; QII87839.1; -; Genomic_RNA.
+DR   EMBL; MT163721; QII87849.1; -; Genomic_RNA.
+DR   EMBL; MT184907; QIJ96471.1; -; Genomic_RNA.
+DR   EMBL; MT184908; QIJ96481.1; -; Genomic_RNA.
+DR   EMBL; MT184909; QIJ96491.1; -; Genomic_RNA.
+DR   EMBL; MT184910; QIJ96501.1; -; Genomic_RNA.
+DR   EMBL; MT184911; QIJ96511.1; -; Genomic_RNA.
+DR   EMBL; MT184912; QIJ96521.1; -; Genomic_RNA.
+DR   EMBL; MT184913; QIJ96531.1; -; Genomic_RNA.
+DR   EMBL; MT188339; QIK02952.1; -; Genomic_RNA.
+DR   EMBL; MT188340; QIK02962.1; -; Genomic_RNA.
+DR   EMBL; MT188341; QIK02972.1; -; Genomic_RNA.
+DR   EMBL; MT192759; QIK50425.1; -; Genomic_RNA.
+DR   EMBL; MT192765; QIK50436.1; -; Genomic_RNA.
+DR   EMBL; MT192772; QIK50446.1; -; Genomic_RNA.
+DR   EMBL; MT192773; QIK50456.1; -; Genomic_RNA.
+DR   EMBL; MT226610; QIO04375.1; -; Genomic_RNA.
+DR   EMBL; MT233519; QIQ08798.1; -; Genomic_RNA.
+DR   EMBL; MT233520; QIQ08808.1; -; Genomic_RNA.
+DR   EMBL; MT233521; QIQ08818.1; -; Genomic_RNA.
+DR   EMBL; MT233522; QIQ08828.1; -; Genomic_RNA.
+DR   EMBL; MT233523; QIQ08838.1; -; Genomic_RNA.
+DR   EMBL; MT246449; QIQ49770.1; -; Genomic_RNA.
+DR   EMBL; MT246450; QIQ49780.1; -; Genomic_RNA.
+DR   EMBL; MT246451; QIQ49790.1; -; Genomic_RNA.
+DR   EMBL; MT246452; QIQ49800.1; -; Genomic_RNA.
+DR   EMBL; MT246453; QIQ49810.1; -; Genomic_RNA.
+DR   EMBL; MT246454; QIQ49820.1; -; Genomic_RNA.
+DR   EMBL; MT246455; QIQ49830.1; -; Genomic_RNA.
+DR   EMBL; MT246456; QIQ49840.1; -; Genomic_RNA.
+DR   EMBL; MT246457; QIQ49850.1; -; Genomic_RNA.
+DR   EMBL; MT246458; QIQ49860.1; -; Genomic_RNA.
+DR   EMBL; MT246459; QIQ49870.1; -; Genomic_RNA.
+DR   EMBL; MT246460; QIQ49880.1; -; Genomic_RNA.
+DR   EMBL; MT246461; QIQ49890.1; -; Genomic_RNA.
+DR   EMBL; MT246462; QIQ49900.1; -; Genomic_RNA.
+DR   EMBL; MT246463; QIQ49910.1; -; Genomic_RNA.
+DR   EMBL; MT246464; QIQ49920.1; -; Genomic_RNA.
+DR   EMBL; MT246465; QIQ49930.1; -; Genomic_RNA.
+DR   EMBL; MT246466; QIQ49940.1; -; Genomic_RNA.
+DR   EMBL; MT246467; QIQ49950.1; -; Genomic_RNA.
+DR   EMBL; MT246468; QIQ49960.1; -; Genomic_RNA.
+DR   EMBL; MT246469; QIQ49970.1; -; Genomic_RNA.
+DR   EMBL; MT246470; QIQ49980.1; -; Genomic_RNA.
+DR   EMBL; MT246471; QIQ49990.1; -; Genomic_RNA.
+DR   EMBL; MT246472; QIQ50000.1; -; Genomic_RNA.
+DR   EMBL; MT246473; QIQ50010.1; -; Genomic_RNA.
+DR   EMBL; MT246474; QIQ50020.1; -; Genomic_RNA.
+DR   EMBL; MT246475; QIQ50030.1; -; Genomic_RNA.
+DR   EMBL; MT246476; QIQ50040.1; -; Genomic_RNA.
+DR   EMBL; MT246477; QIQ50050.1; -; Genomic_RNA.
+DR   EMBL; MT246478; QIQ50060.1; -; Genomic_RNA.
+DR   EMBL; MT246479; QIQ50070.1; -; Genomic_RNA.
+DR   EMBL; MT246480; QIQ50080.1; -; Genomic_RNA.
+DR   EMBL; MT246481; QIQ50090.1; -; Genomic_RNA.
+DR   EMBL; MT246482; QIQ50100.1; -; Genomic_RNA.
+DR   EMBL; MT246483; QIQ50110.1; -; Genomic_RNA.
+DR   EMBL; MT246484; QIQ50120.1; -; Genomic_RNA.
+DR   EMBL; MT246485; QIQ50130.1; -; Genomic_RNA.
+DR   EMBL; MT246486; QIQ50140.1; -; Genomic_RNA.
+DR   EMBL; MT246487; QIQ50150.1; -; Genomic_RNA.
+DR   EMBL; MT246488; QIQ50160.1; -; Genomic_RNA.
+DR   EMBL; MT246489; QIQ50170.1; -; Genomic_RNA.
+DR   EMBL; MT246490; QIQ50180.1; -; Genomic_RNA.
+DR   EMBL; MT233526; QIQ50190.1; -; Genomic_RNA.
+DR   EMBL; MT246667; QIQ50200.1; -; Genomic_RNA.
+DR   EMBL; MT251972; QIQ68472.1; -; Genomic_RNA.
+DR   EMBL; MT251973; QIQ68482.1; -; Genomic_RNA.
+DR   EMBL; MT251974; QIQ68492.1; -; Genomic_RNA.
+DR   EMBL; MT251975; QIQ68502.1; -; Genomic_RNA.
+DR   EMBL; MT251976; QIQ68512.1; -; Genomic_RNA.
+DR   EMBL; MT251977; QIQ68522.1; -; Genomic_RNA.
+DR   EMBL; MT251978; QIQ68532.1; -; Genomic_RNA.
+DR   EMBL; MT251979; QIQ68542.1; -; Genomic_RNA.
+DR   EMBL; MT251980; QIQ68552.1; -; Genomic_RNA.
+DR   EMBL; MT253696; QIQ68562.1; -; Genomic_RNA.
+DR   EMBL; MT253697; QIQ68572.1; -; Genomic_RNA.
+DR   EMBL; MT253698; QIQ68582.1; -; Genomic_RNA.
+DR   EMBL; MT253699; QIQ68592.1; -; Genomic_RNA.
+DR   EMBL; MT253700; QIQ68602.1; -; Genomic_RNA.
+DR   EMBL; MT253701; QIQ68612.1; -; Genomic_RNA.
+DR   EMBL; MT253702; QIQ68622.1; -; Genomic_RNA.
+DR   EMBL; MT253703; QIQ68632.1; -; Genomic_RNA.
+DR   EMBL; MT253704; QIQ68642.1; -; Genomic_RNA.
+DR   EMBL; MT253705; QIQ68652.1; -; Genomic_RNA.
+DR   EMBL; MT253706; QIQ68662.1; -; Genomic_RNA.
+DR   EMBL; MT253707; QIQ68672.1; -; Genomic_RNA.
+DR   EMBL; MT253708; QIQ68682.1; -; Genomic_RNA.
+DR   EMBL; MT253709; QIQ68692.1; -; Genomic_RNA.
+DR   EMBL; MT253710; QIQ68702.1; -; Genomic_RNA.
+DR   EMBL; MT198652; QIQ68704.1; -; Genomic_RNA.
+DR   EMBL; MT259227; QIS30003.1; -; Genomic_RNA.
+DR   EMBL; MT259228; QIS30015.1; -; Genomic_RNA.
+DR   EMBL; MT259229; QIS30027.1; -; Genomic_RNA.
+DR   EMBL; MT259230; QIS30039.1; -; Genomic_RNA.
+DR   EMBL; MT259231; QIS30051.1; -; Genomic_RNA.
+DR   EMBL; MT256924; QIS30063.1; -; Genomic_RNA.
+DR   EMBL; MT258377; QIS30073.1; -; Genomic_RNA.
+DR   EMBL; MT258378; QIS30083.1; -; Genomic_RNA.
+DR   EMBL; MT258379; QIS30093.1; -; Genomic_RNA.
+DR   EMBL; MT258380; QIS30103.1; -; Genomic_RNA.
+DR   EMBL; MT258381; QIS30113.1; -; Genomic_RNA.
+DR   EMBL; MT258382; QIS30123.1; -; Genomic_RNA.
+DR   EMBL; MT258383; QIS30133.1; -; Genomic_RNA.
+DR   EMBL; MT256917; QIS30143.1; -; Genomic_RNA.
+DR   EMBL; MT256918; QIS30153.1; -; Genomic_RNA.
+DR   EMBL; MT259235; QIS30163.1; -; Genomic_RNA.
+DR   EMBL; MT259236; QIS30173.1; -; Genomic_RNA.
+DR   EMBL; MT259237; QIS30183.1; -; Genomic_RNA.
+DR   EMBL; MT259238; QIS30193.1; -; Genomic_RNA.
+DR   EMBL; MT259239; QIS30203.1; -; Genomic_RNA.
+DR   EMBL; MT259240; QIS30213.1; -; Genomic_RNA.
+DR   EMBL; MT259241; QIS30223.1; -; Genomic_RNA.
+DR   EMBL; MT259242; QIS30233.1; -; Genomic_RNA.
+DR   EMBL; MT259243; QIS30243.1; -; Genomic_RNA.
+DR   EMBL; MT259244; QIS30253.1; -; Genomic_RNA.
+DR   EMBL; MT259245; QIS30263.1; -; Genomic_RNA.
+DR   EMBL; MT259246; QIS30273.1; -; Genomic_RNA.
+DR   EMBL; MT259247; QIS30283.1; -; Genomic_RNA.
+DR   EMBL; MT259248; QIS30293.1; -; Genomic_RNA.
+DR   EMBL; MT259249; QIS30303.1; -; Genomic_RNA.
+DR   EMBL; MT259250; QIS30313.1; -; Genomic_RNA.
+DR   EMBL; MT259251; QIS30323.1; -; Genomic_RNA.
+DR   EMBL; MT259252; QIS30333.1; -; Genomic_RNA.
+DR   EMBL; MT259253; QIS30343.1; -; Genomic_RNA.
+DR   EMBL; MT259254; QIS30353.1; -; Genomic_RNA.
+DR   EMBL; MT259255; QIS30363.1; -; Genomic_RNA.
+DR   EMBL; MT259256; QIS30373.1; -; Genomic_RNA.
+DR   EMBL; MT259257; QIS30383.1; -; Genomic_RNA.
+DR   EMBL; MT259258; QIS30393.1; -; Genomic_RNA.
+DR   EMBL; MT259259; QIS30403.1; -; Genomic_RNA.
+DR   EMBL; MT259260; QIS30413.1; -; Genomic_RNA.
+DR   EMBL; MT259261; QIS30423.1; -; Genomic_RNA.
+DR   EMBL; MT259262; QIS30433.1; -; Genomic_RNA.
+DR   EMBL; MT259263; QIS30443.1; -; Genomic_RNA.
+DR   EMBL; MT259264; QIS30453.1; -; Genomic_RNA.
+DR   EMBL; MT259265; QIS30463.1; -; Genomic_RNA.
+DR   EMBL; MT259266; QIS30473.1; -; Genomic_RNA.
+DR   EMBL; MT259267; QIS30483.1; -; Genomic_RNA.
+DR   EMBL; MT259268; QIS30493.1; -; Genomic_RNA.
+DR   EMBL; MT259269; QIS30503.1; -; Genomic_RNA.
+DR   EMBL; MT259270; QIS30512.1; -; Genomic_RNA.
+DR   EMBL; MT259271; QIS30523.1; -; Genomic_RNA.
+DR   EMBL; MT259272; QIS30533.1; -; Genomic_RNA.
+DR   EMBL; MT259273; QIS30543.1; -; Genomic_RNA.
+DR   EMBL; MT259274; QIS30553.1; -; Genomic_RNA.
+DR   EMBL; MT259275; QIS30563.1; -; Genomic_RNA.
+DR   EMBL; MT259276; QIS30573.1; -; Genomic_RNA.
+DR   EMBL; MT259277; QIS30583.1; -; Genomic_RNA.
+DR   EMBL; MT259278; QIS30593.1; -; Genomic_RNA.
+DR   EMBL; MT259279; QIS30603.1; -; Genomic_RNA.
+DR   EMBL; MT259280; QIS30613.1; -; Genomic_RNA.
+DR   EMBL; MT259281; QIS30623.1; -; Genomic_RNA.
+DR   EMBL; MT259282; QIS30633.1; -; Genomic_RNA.
+DR   EMBL; MT259283; QIS30643.1; -; Genomic_RNA.
+DR   EMBL; MT259284; QIS30653.1; -; Genomic_RNA.
+DR   EMBL; MT259285; QIS30663.1; -; Genomic_RNA.
+DR   EMBL; MT259286; QIS30673.1; -; Genomic_RNA.
+DR   EMBL; MT259287; QIS30683.1; -; Genomic_RNA.
+DR   EMBL; MT262993; QIS60285.1; -; Genomic_RNA.
+DR   EMBL; MT263074; QIS60297.1; -; Genomic_RNA.
+DR   EMBL; MT262896; QIS60307.1; -; Genomic_RNA.
+DR   EMBL; MT262897; QIS60317.1; -; Genomic_RNA.
+DR   EMBL; MT262898; QIS60327.1; -; Genomic_RNA.
+DR   EMBL; MT262899; QIS60337.1; -; Genomic_RNA.
+DR   EMBL; MT262900; QIS60347.1; -; Genomic_RNA.
+DR   EMBL; MT262901; QIS60357.1; -; Genomic_RNA.
+DR   EMBL; MT262902; QIS60367.1; -; Genomic_RNA.
+DR   EMBL; MT262903; QIS60377.1; -; Genomic_RNA.
+DR   EMBL; MT262904; QIS60387.1; -; Genomic_RNA.
+DR   EMBL; MT262905; QIS60397.1; -; Genomic_RNA.
+DR   EMBL; MT262906; QIS60407.1; -; Genomic_RNA.
+DR   EMBL; MT262907; QIS60417.1; -; Genomic_RNA.
+DR   EMBL; MT262908; QIS60427.1; -; Genomic_RNA.
+DR   EMBL; MT262909; QIS60437.1; -; Genomic_RNA.
+DR   EMBL; MT262910; QIS60447.1; -; Genomic_RNA.
+DR   EMBL; MT262911; QIS60457.1; -; Genomic_RNA.
+DR   EMBL; MT262912; QIS60467.1; -; Genomic_RNA.
+DR   EMBL; MT262913; QIS60477.1; -; Genomic_RNA.
+DR   EMBL; MT262914; QIS60487.1; -; Genomic_RNA.
+DR   EMBL; MT262915; QIS60497.1; -; Genomic_RNA.
+DR   EMBL; MT262916; QIS60507.1; -; Genomic_RNA.
+DR   EMBL; MT263381; QIS60519.1; -; Genomic_RNA.
+DR   EMBL; MT263382; QIS60531.1; -; Genomic_RNA.
+DR   EMBL; MT263383; QIS60543.1; -; Genomic_RNA.
+DR   EMBL; MT263385; QIS60567.1; -; Genomic_RNA.
+DR   EMBL; MT263386; QIS60579.1; -; Genomic_RNA.
+DR   EMBL; MT263387; QIS60591.1; -; Genomic_RNA.
+DR   EMBL; MT263388; QIS60603.1; -; Genomic_RNA.
+DR   EMBL; MT263390; QIS60627.1; -; Genomic_RNA.
+DR   EMBL; MT263391; QIS60639.1; -; Genomic_RNA.
+DR   EMBL; MT263392; QIS60651.1; -; Genomic_RNA.
+DR   EMBL; MT263393; QIS60663.1; -; Genomic_RNA.
+DR   EMBL; MT263394; QIS60675.1; -; Genomic_RNA.
+DR   EMBL; MT263395; QIS60687.1; -; Genomic_RNA.
+DR   EMBL; MT263396; QIS60699.1; -; Genomic_RNA.
+DR   EMBL; MT263397; QIS60711.1; -; Genomic_RNA.
+DR   EMBL; MT263398; QIS60723.1; -; Genomic_RNA.
+DR   EMBL; MT263399; QIS60735.1; -; Genomic_RNA.
+DR   EMBL; MT263400; QIS60747.1; -; Genomic_RNA.
+DR   EMBL; MT263401; QIS60759.1; -; Genomic_RNA.
+DR   EMBL; MT263402; QIS60771.1; -; Genomic_RNA.
+DR   EMBL; MT263403; QIS60783.1; -; Genomic_RNA.
+DR   EMBL; MT263404; QIS60795.1; -; Genomic_RNA.
+DR   EMBL; MT263405; QIS60807.1; -; Genomic_RNA.
+DR   EMBL; MT263406; QIS60819.1; -; Genomic_RNA.
+DR   EMBL; MT263407; QIS60831.1; -; Genomic_RNA.
+DR   EMBL; MT263408; QIS60843.1; -; Genomic_RNA.
+DR   EMBL; MT263409; QIS60855.1; -; Genomic_RNA.
+DR   EMBL; MT263410; QIS60867.1; -; Genomic_RNA.
+DR   EMBL; MT263411; QIS60879.1; -; Genomic_RNA.
+DR   EMBL; MT263412; QIS60891.1; -; Genomic_RNA.
+DR   EMBL; MT263413; QIS60903.1; -; Genomic_RNA.
+DR   EMBL; MT263414; QIS60915.1; -; Genomic_RNA.
+DR   EMBL; MT263415; QIS60927.1; -; Genomic_RNA.
+DR   EMBL; MT263416; QIS60939.1; -; Genomic_RNA.
+DR   EMBL; MT263417; QIS60951.1; -; Genomic_RNA.
+DR   EMBL; MT263418; QIS60963.1; -; Genomic_RNA.
+DR   EMBL; MT263419; QIS60975.1; -; Genomic_RNA.
+DR   EMBL; MT263420; QIS60987.1; -; Genomic_RNA.
+DR   EMBL; MT263421; QIS60999.1; -; Genomic_RNA.
+DR   EMBL; MT263422; QIS61011.1; -; Genomic_RNA.
+DR   EMBL; MT263423; QIS61023.1; -; Genomic_RNA.
+DR   EMBL; MT263424; QIS61035.1; -; Genomic_RNA.
+DR   EMBL; MT263425; QIS61047.1; -; Genomic_RNA.
+DR   EMBL; MT263426; QIS61059.1; -; Genomic_RNA.
+DR   EMBL; MT263427; QIS61069.1; -; Genomic_RNA.
+DR   EMBL; MT263428; QIS61083.1; -; Genomic_RNA.
+DR   EMBL; MT263429; QIS61095.1; -; Genomic_RNA.
+DR   EMBL; MT263430; QIS61107.1; -; Genomic_RNA.
+DR   EMBL; MT263431; QIS61119.1; -; Genomic_RNA.
+DR   EMBL; MT263432; QIS61131.1; -; Genomic_RNA.
+DR   EMBL; MT263433; QIS61143.1; -; Genomic_RNA.
+DR   EMBL; MT263434; QIS61155.1; -; Genomic_RNA.
+DR   EMBL; MT263435; QIS61167.1; -; Genomic_RNA.
+DR   EMBL; MT263436; QIS61179.1; -; Genomic_RNA.
+DR   EMBL; MT263437; QIS61191.1; -; Genomic_RNA.
+DR   EMBL; MT263438; QIS61203.1; -; Genomic_RNA.
+DR   EMBL; MT263439; QIS61215.1; -; Genomic_RNA.
+DR   EMBL; MT263440; QIS61227.1; -; Genomic_RNA.
+DR   EMBL; MT263441; QIS61239.1; -; Genomic_RNA.
+DR   EMBL; MT263442; QIS61251.1; -; Genomic_RNA.
+DR   EMBL; MT263443; QIS61263.1; -; Genomic_RNA.
+DR   EMBL; MT263444; QIS61275.1; -; Genomic_RNA.
+DR   EMBL; MT263445; QIS61287.1; -; Genomic_RNA.
+DR   EMBL; MT263446; QIS61299.1; -; Genomic_RNA.
+DR   EMBL; MT263447; QIS61311.1; -; Genomic_RNA.
+DR   EMBL; MT263448; QIS61323.1; -; Genomic_RNA.
+DR   EMBL; MT263449; QIS61335.1; -; Genomic_RNA.
+DR   EMBL; MT263450; QIS61347.1; -; Genomic_RNA.
+DR   EMBL; MT263451; QIS61359.1; -; Genomic_RNA.
+DR   EMBL; MT263452; QIS61371.1; -; Genomic_RNA.
+DR   EMBL; MT263453; QIS61383.1; -; Genomic_RNA.
+DR   EMBL; MT263454; QIS61395.1; -; Genomic_RNA.
+DR   EMBL; MT263455; QIS61407.1; -; Genomic_RNA.
+DR   EMBL; MT263456; QIS61419.1; -; Genomic_RNA.
+DR   EMBL; MT263457; QIS61431.1; -; Genomic_RNA.
+DR   EMBL; MT263458; QIS61443.1; -; Genomic_RNA.
+DR   EMBL; MT263459; QIS61455.1; -; Genomic_RNA.
+DR   EMBL; MT263460; QIS61465.1; -; Genomic_RNA.
+DR   EMBL; MT263461; QIS61477.1; -; Genomic_RNA.
+DR   EMBL; MT263462; QIS61491.1; -; Genomic_RNA.
+DR   EMBL; MT263463; QIS61503.1; -; Genomic_RNA.
+DR   EMBL; MT263464; QIS61515.1; -; Genomic_RNA.
+DR   EMBL; MT263465; QIS61527.1; -; Genomic_RNA.
+DR   EMBL; MT263466; QIS61537.1; -; Genomic_RNA.
+DR   EMBL; MT263467; QIS61551.1; -; Genomic_RNA.
+DR   EMBL; MT263468; QIS61563.1; -; Genomic_RNA.
+DR   EMBL; MT263469; QIS61575.1; -; Genomic_RNA.
+DR   EMBL; MT276323; QIT06888.1; -; Genomic_RNA.
+DR   EMBL; MT276324; QIT06900.1; -; Genomic_RNA.
+DR   EMBL; MT276325; QIT06912.1; -; Genomic_RNA.
+DR   EMBL; MT276326; QIT06924.1; -; Genomic_RNA.
+DR   EMBL; MT276327; QIT06936.1; -; Genomic_RNA.
+DR   EMBL; MT276328; QIT06948.1; -; Genomic_RNA.
+DR   EMBL; MT276329; QIT06960.1; -; Genomic_RNA.
+DR   EMBL; MT276330; QIT06972.1; -; Genomic_RNA.
+DR   EMBL; MT276331; QIT06984.1; -; Genomic_RNA.
+DR   EMBL; MT276597; QIT06996.1; -; Genomic_RNA.
+DR   EMBL; MT276598; QIT07008.1; -; Genomic_RNA.
+DR   EMBL; MT292569; QIU78716.1; -; Genomic_RNA.
+DR   EMBL; MT292570; QIU78728.1; -; Genomic_RNA.
+DR   EMBL; MT292571; QIU78740.1; -; Genomic_RNA.
+DR   EMBL; MT292572; QIU78752.1; -; Genomic_RNA.
+DR   EMBL; MT292573; QIU78764.1; -; Genomic_RNA.
+DR   EMBL; MT292574; QIU78776.1; -; Genomic_RNA.
+DR   EMBL; MT292575; QIU78788.1; -; Genomic_RNA.
+DR   EMBL; MT292576; QIU78799.1; -; Genomic_RNA.
+DR   EMBL; MT292577; QIU78811.1; -; Genomic_RNA.
+DR   EMBL; MT292578; QIU78822.1; -; Genomic_RNA.
+DR   EMBL; MT292579; QIU78832.1; -; Genomic_RNA.
+DR   EMBL; MT292580; QIU78843.1; -; Genomic_RNA.
+DR   EMBL; MT292581; QIU78856.1; -; Genomic_RNA.
+DR   EMBL; MT292582; QIU78864.1; -; Genomic_RNA.
+DR   EMBL; MT281530; QIU80906.1; -; Genomic_RNA.
+DR   EMBL; MT293156; QIU80934.1; -; Genomic_RNA.
+DR   EMBL; MT293157; QIU80946.1; -; Genomic_RNA.
+DR   EMBL; MT293158; QIU80958.1; -; Genomic_RNA.
+DR   EMBL; MT293159; QIU80970.1; -; Genomic_RNA.
+DR   EMBL; MT293160; QIU80982.1; -; Genomic_RNA.
+DR   EMBL; MT293161; QIU80994.1; -; Genomic_RNA.
+DR   EMBL; MT293162; QIU81006.1; -; Genomic_RNA.
+DR   EMBL; MT293163; QIU81018.1; -; Genomic_RNA.
+DR   EMBL; MT293164; QIU81030.1; -; Genomic_RNA.
+DR   EMBL; MT293165; QIU81042.1; -; Genomic_RNA.
+DR   EMBL; MT293166; QIU81054.1; -; Genomic_RNA.
+DR   EMBL; MT293167; QIU81066.1; -; Genomic_RNA.
+DR   EMBL; MT293168; QIU81078.1; -; Genomic_RNA.
+DR   EMBL; MT293169; QIU81090.1; -; Genomic_RNA.
+DR   EMBL; MT293170; QIU81102.1; -; Genomic_RNA.
+DR   EMBL; MT293171; QIU81114.1; -; Genomic_RNA.
+DR   EMBL; MT293172; QIU81126.1; -; Genomic_RNA.
+DR   EMBL; MT293173; QIU81138.1; -; Genomic_RNA.
+DR   EMBL; MT293174; QIU81150.1; -; Genomic_RNA.
+DR   EMBL; MT293175; QIU81162.1; -; Genomic_RNA.
+DR   EMBL; MT293176; QIU81174.1; -; Genomic_RNA.
+DR   EMBL; MT293177; QIU81186.1; -; Genomic_RNA.
+DR   EMBL; MT293178; QIU81198.1; -; Genomic_RNA.
+DR   EMBL; MT293179; QIU81210.1; -; Genomic_RNA.
+DR   EMBL; MT293180; QIU81222.1; -; Genomic_RNA.
+DR   EMBL; MT293181; QIU81234.1; -; Genomic_RNA.
+DR   EMBL; MT293182; QIU81246.1; -; Genomic_RNA.
+DR   EMBL; MT293183; QIU81258.1; -; Genomic_RNA.
+DR   EMBL; MT293184; QIU81270.1; -; Genomic_RNA.
+DR   EMBL; MT293185; QIU81282.1; -; Genomic_RNA.
+DR   EMBL; MT293186; QIU81294.1; -; Genomic_RNA.
+DR   EMBL; MT293187; QIU81306.1; -; Genomic_RNA.
+DR   EMBL; MT293188; QIU81318.1; -; Genomic_RNA.
+DR   EMBL; MT293189; QIU81330.1; -; Genomic_RNA.
+DR   EMBL; MT293190; QIU81342.1; -; Genomic_RNA.
+DR   EMBL; MT293191; QIU81354.1; -; Genomic_RNA.
+DR   EMBL; MT293192; QIU81366.1; -; Genomic_RNA.
+DR   EMBL; MT293193; QIU81378.1; -; Genomic_RNA.
+DR   EMBL; MT293194; QIU81390.1; -; Genomic_RNA.
+DR   EMBL; MT293195; QIU81402.1; -; Genomic_RNA.
+DR   EMBL; MT293196; QIU81414.1; -; Genomic_RNA.
+DR   EMBL; MT293197; QIU81426.1; -; Genomic_RNA.
+DR   EMBL; MT293198; QIU81438.1; -; Genomic_RNA.
+DR   EMBL; MT293199; QIU81450.1; -; Genomic_RNA.
+DR   EMBL; MT293200; QIU81462.1; -; Genomic_RNA.
+DR   EMBL; MT293201; QIU81474.1; -; Genomic_RNA.
+DR   EMBL; MT293202; QIU81486.1; -; Genomic_RNA.
+DR   EMBL; MT293203; QIU81498.1; -; Genomic_RNA.
+DR   EMBL; MT293204; QIU81510.1; -; Genomic_RNA.
+DR   EMBL; MT293205; QIU81522.1; -; Genomic_RNA.
+DR   EMBL; MT293206; QIU81534.1; -; Genomic_RNA.
+DR   EMBL; MT293207; QIU81546.1; -; Genomic_RNA.
+DR   EMBL; MT293208; QIU81558.1; -; Genomic_RNA.
+DR   EMBL; MT293209; QIU81570.1; -; Genomic_RNA.
+DR   EMBL; MT293210; QIU81582.1; -; Genomic_RNA.
+DR   EMBL; MT293211; QIU81594.1; -; Genomic_RNA.
+DR   EMBL; MT293212; QIU81606.1; -; Genomic_RNA.
+DR   EMBL; MT293213; QIU81618.1; -; Genomic_RNA.
+DR   EMBL; MT293214; QIU81630.1; -; Genomic_RNA.
+DR   EMBL; MT293215; QIU81642.1; -; Genomic_RNA.
+DR   EMBL; MT293216; QIU81654.1; -; Genomic_RNA.
+DR   EMBL; MT293217; QIU81666.1; -; Genomic_RNA.
+DR   EMBL; MT293218; QIU81678.1; -; Genomic_RNA.
+DR   EMBL; MT293219; QIU81690.1; -; Genomic_RNA.
+DR   EMBL; MT293220; QIU81702.1; -; Genomic_RNA.
+DR   EMBL; MT293221; QIU81714.1; -; Genomic_RNA.
+DR   EMBL; MT293222; QIU81726.1; -; Genomic_RNA.
+DR   EMBL; MT293223; QIU81738.1; -; Genomic_RNA.
+DR   EMBL; MT293224; QIU81750.1; -; Genomic_RNA.
+DR   EMBL; MT293225; QIU81762.1; -; Genomic_RNA.
+DR   EMBL; MT295464; QIU81907.1; -; Genomic_RNA.
+DR   EMBL; MT295465; QIU81919.1; -; Genomic_RNA.
+DR   EMBL; MT300186; QIV14981.1; -; Genomic_RNA.
+DR   EMBL; MT304474; QIV14993.1; -; Genomic_RNA.
+DR   EMBL; MT304475; QIV15005.1; -; Genomic_RNA.
+DR   EMBL; MT304476; QIV15017.1; -; Genomic_RNA.
+DR   EMBL; MT304477; QIV15029.1; -; Genomic_RNA.
+DR   EMBL; MT304478; QIV15041.1; -; Genomic_RNA.
+DR   EMBL; MT304479; QIV15053.1; -; Genomic_RNA.
+DR   EMBL; MT304480; QIV15065.1; -; Genomic_RNA.
+DR   EMBL; MT304481; QIV15077.1; -; Genomic_RNA.
+DR   EMBL; MT304482; QIV15089.1; -; Genomic_RNA.
+DR   EMBL; MT304483; QIV15101.1; -; Genomic_RNA.
+DR   EMBL; MT304484; QIV15113.1; -; Genomic_RNA.
+DR   EMBL; MT304485; QIV15125.1; -; Genomic_RNA.
+DR   EMBL; MT304486; QIV15137.1; -; Genomic_RNA.
+DR   EMBL; MT304487; QIV15149.1; -; Genomic_RNA.
+DR   EMBL; MT304488; QIV15161.1; -; Genomic_RNA.
+DR   EMBL; MT304489; QIV15173.1; -; Genomic_RNA.
+DR   EMBL; MT304490; QIV15185.1; -; Genomic_RNA.
+DR   EMBL; MT304491; QIV15197.1; -; Genomic_RNA.
+DR   EMBL; MT308702; QIV64974.1; -; Genomic_RNA.
+DR   EMBL; MT308703; QIV64986.1; -; Genomic_RNA.
+DR   EMBL; MT308704; QIV64998.1; -; Genomic_RNA.
+DR   EMBL; MT308692; QIV65008.1; -; Genomic_RNA.
+DR   EMBL; MT308693; QIV65019.1; -; Genomic_RNA.
+DR   EMBL; MT308694; QIV65030.1; -; Genomic_RNA.
+DR   EMBL; MT308695; QIV65041.1; -; Genomic_RNA.
+DR   EMBL; MT308696; QIV65052.1; -; Genomic_RNA.
+DR   EMBL; MT308697; QIV65063.1; -; Genomic_RNA.
+DR   EMBL; MT308698; QIV65074.1; -; Genomic_RNA.
+DR   EMBL; MT308699; QIV65085.1; -; Genomic_RNA.
+DR   EMBL; MT308700; QIV65096.1; -; Genomic_RNA.
+DR   EMBL; MT320891; QIX12204.1; -; Genomic_RNA.
+DR   EMBL; MT322394; QIX13684.1; -; Genomic_RNA.
+DR   EMBL; MT322395; QIX13696.1; -; Genomic_RNA.
+DR   EMBL; MT322396; QIX13708.1; -; Genomic_RNA.
+DR   EMBL; MT322397; QIX13720.1; -; Genomic_RNA.
+DR   EMBL; MT322398; QIX13732.1; -; Genomic_RNA.
+DR   EMBL; MT322399; QIX13743.1; -; Genomic_RNA.
+DR   EMBL; MT322400; QIX13756.1; -; Genomic_RNA.
+DR   EMBL; MT322401; QIX13768.1; -; Genomic_RNA.
+DR   EMBL; MT322402; QIX13780.1; -; Genomic_RNA.
+DR   EMBL; MT322403; QIX13792.1; -; Genomic_RNA.
+DR   EMBL; MT322404; QIX13804.1; -; Genomic_RNA.
+DR   EMBL; MT322405; QIX13816.1; -; Genomic_RNA.
+DR   EMBL; MT322406; QIX13828.1; -; Genomic_RNA.
+DR   EMBL; MT322407; QIX13840.1; -; Genomic_RNA.
+DR   EMBL; MT322408; QIX13852.1; -; Genomic_RNA.
+DR   EMBL; MT322409; QIX13864.1; -; Genomic_RNA.
+DR   EMBL; MT322410; QIX13876.1; -; Genomic_RNA.
+DR   EMBL; MT322411; QIX13888.1; -; Genomic_RNA.
+DR   EMBL; MT322412; QIX13900.1; -; Genomic_RNA.
+DR   EMBL; MT322413; QIX13912.1; -; Genomic_RNA.
+DR   EMBL; MT322414; QIX13924.1; -; Genomic_RNA.
+DR   EMBL; MT322415; QIX13936.1; -; Genomic_RNA.
+DR   EMBL; MT322416; QIX13948.1; -; Genomic_RNA.
+DR   EMBL; MT322417; QIX13960.1; -; Genomic_RNA.
+DR   EMBL; MT322418; QIX13972.1; -; Genomic_RNA.
+DR   EMBL; MT322419; QIX13984.1; -; Genomic_RNA.
+DR   EMBL; MT322420; QIX13996.1; -; Genomic_RNA.
+DR   EMBL; MT322421; QIX14008.1; -; Genomic_RNA.
+DR   EMBL; MT322422; QIX14020.1; -; Genomic_RNA.
+DR   EMBL; MT322423; QIX14032.1; -; Genomic_RNA.
+DR   EMBL; MT322424; QIX14044.1; -; Genomic_RNA.
+DR   EMBL; MT039874; QIX14045.1; -; Genomic_RNA.
+DR   EMBL; MT326023; QIZ12972.1; -; Genomic_RNA.
+DR   EMBL; MT326024; QIZ12984.1; -; Genomic_RNA.
+DR   EMBL; MT326025; QIZ12996.1; -; Genomic_RNA.
+DR   EMBL; MT326026; QIZ13008.1; -; Genomic_RNA.
+DR   EMBL; MT326027; QIZ13020.1; -; Genomic_RNA.
+DR   EMBL; MT326028; QIZ13032.1; -; Genomic_RNA.
+DR   EMBL; MT326029; QIZ13044.1; -; Genomic_RNA.
+DR   EMBL; MT326030; QIZ13056.1; -; Genomic_RNA.
+DR   EMBL; MT326031; QIZ13068.1; -; Genomic_RNA.
+DR   EMBL; MT326032; QIZ13078.1; -; Genomic_RNA.
+DR   EMBL; MT326033; QIZ13092.1; -; Genomic_RNA.
+DR   EMBL; MT326034; QIZ13104.1; -; Genomic_RNA.
+DR   EMBL; MT326035; QIZ13116.1; -; Genomic_RNA.
+DR   EMBL; MT326036; QIZ13128.1; -; Genomic_RNA.
+DR   EMBL; MT326037; QIZ13140.1; -; Genomic_RNA.
+DR   EMBL; MT326038; QIZ13151.1; -; Genomic_RNA.
+DR   EMBL; MT326039; QIZ13164.1; -; Genomic_RNA.
+DR   EMBL; MT326040; QIZ13176.1; -; Genomic_RNA.
+DR   EMBL; MT326041; QIZ13188.1; -; Genomic_RNA.
+DR   EMBL; MT326042; QIZ13200.1; -; Genomic_RNA.
+DR   EMBL; MT326043; QIZ13212.1; -; Genomic_RNA.
+DR   EMBL; MT326044; QIZ13224.1; -; Genomic_RNA.
+DR   EMBL; MT326045; QIZ13236.1; -; Genomic_RNA.
+DR   EMBL; MT326046; QIZ13248.1; -; Genomic_RNA.
+DR   EMBL; MT326047; QIZ13260.1; -; Genomic_RNA.
+DR   EMBL; MT326048; QIZ13272.1; -; Genomic_RNA.
+DR   EMBL; MT326049; QIZ13284.1; -; Genomic_RNA.
+DR   EMBL; MT326050; QIZ13295.1; -; Genomic_RNA.
+DR   EMBL; MT326051; QIZ13308.1; -; Genomic_RNA.
+DR   EMBL; MT326052; QIZ13320.1; -; Genomic_RNA.
+DR   EMBL; MT326053; QIZ13332.1; -; Genomic_RNA.
+DR   EMBL; MT326054; QIZ13344.1; -; Genomic_RNA.
+DR   EMBL; MT326055; QIZ13356.1; -; Genomic_RNA.
+DR   EMBL; MT326056; QIZ13368.1; -; Genomic_RNA.
+DR   EMBL; MT326057; QIZ13379.1; -; Genomic_RNA.
+DR   EMBL; MT326058; QIZ13392.1; -; Genomic_RNA.
+DR   EMBL; MT326059; QIZ13404.1; -; Genomic_RNA.
+DR   EMBL; MT326060; QIZ13414.1; -; Genomic_RNA.
+DR   EMBL; MT326061; QIZ13428.1; -; Genomic_RNA.
+DR   EMBL; MT326062; QIZ13440.1; -; Genomic_RNA.
+DR   EMBL; MT326063; QIZ13452.1; -; Genomic_RNA.
+DR   EMBL; MT326064; QIZ13464.1; -; Genomic_RNA.
+DR   EMBL; MT326065; QIZ13476.1; -; Genomic_RNA.
+DR   EMBL; MT326066; QIZ13488.1; -; Genomic_RNA.
+DR   EMBL; MT326067; QIZ13500.1; -; Genomic_RNA.
+DR   EMBL; MT326068; QIZ13512.1; -; Genomic_RNA.
+DR   EMBL; MT326069; QIZ13524.1; -; Genomic_RNA.
+DR   EMBL; MT326070; QIZ13536.1; -; Genomic_RNA.
+DR   EMBL; MT326071; QIZ13548.1; -; Genomic_RNA.
+DR   EMBL; MT326072; QIZ13558.1; -; Genomic_RNA.
+DR   EMBL; MT326073; QIZ13568.1; -; Genomic_RNA.
+DR   EMBL; MT326074; QIZ13584.1; -; Genomic_RNA.
+DR   EMBL; MT326075; QIZ13596.1; -; Genomic_RNA.
+DR   EMBL; MT326076; QIZ13608.1; -; Genomic_RNA.
+DR   EMBL; MT326077; QIZ13620.1; -; Genomic_RNA.
+DR   EMBL; MT326078; QIZ13632.1; -; Genomic_RNA.
+DR   EMBL; MT326079; QIZ13641.1; -; Genomic_RNA.
+DR   EMBL; MT326080; QIZ13654.1; -; Genomic_RNA.
+DR   EMBL; MT326081; QIZ13666.1; -; Genomic_RNA.
+DR   EMBL; MT326082; QIZ13678.1; -; Genomic_RNA.
+DR   EMBL; MT326083; QIZ13690.1; -; Genomic_RNA.
+DR   EMBL; MT326084; QIZ13702.1; -; Genomic_RNA.
+DR   EMBL; MT326085; QIZ13714.1; -; Genomic_RNA.
+DR   EMBL; MT326086; QIZ13726.1; -; Genomic_RNA.
+DR   EMBL; MT326087; QIZ13738.1; -; Genomic_RNA.
+DR   EMBL; MT326088; QIZ13750.1; -; Genomic_RNA.
+DR   EMBL; MT326089; QIZ13762.1; -; Genomic_RNA.
+DR   EMBL; MT326090; QIZ13774.1; -; Genomic_RNA.
+DR   EMBL; MT326091; QIZ13786.1; -; Genomic_RNA.
+DR   EMBL; MT326092; QIZ13798.1; -; Genomic_RNA.
+DR   EMBL; MT326093; QIZ13810.1; -; Genomic_RNA.
+DR   EMBL; MT326094; QIZ13822.1; -; Genomic_RNA.
+DR   EMBL; MT326095; QIZ13834.1; -; Genomic_RNA.
+DR   EMBL; MT326096; QIZ13846.1; -; Genomic_RNA.
+DR   EMBL; MT326097; QIZ13858.1; -; Genomic_RNA.
+DR   EMBL; MT326098; QIZ13870.1; -; Genomic_RNA.
+DR   EMBL; MT326099; QIZ13882.1; -; Genomic_RNA.
+DR   EMBL; MT326100; QIZ13894.1; -; Genomic_RNA.
+DR   EMBL; MT326101; QIZ13903.1; -; Genomic_RNA.
+DR   EMBL; MT326102; QIZ13918.1; -; Genomic_RNA.
+DR   EMBL; MT326103; QIZ13930.1; -; Genomic_RNA.
+DR   EMBL; MT326104; QIZ13942.1; -; Genomic_RNA.
+DR   EMBL; MT326105; QIZ13954.1; -; Genomic_RNA.
+DR   EMBL; MT326106; QIZ13966.1; -; Genomic_RNA.
+DR   EMBL; MT326107; QIZ13978.1; -; Genomic_RNA.
+DR   EMBL; MT326108; QIZ13989.1; -; Genomic_RNA.
+DR   EMBL; MT326109; QIZ14002.1; -; Genomic_RNA.
+DR   EMBL; MT326110; QIZ14012.1; -; Genomic_RNA.
+DR   EMBL; MT326111; QIZ14026.1; -; Genomic_RNA.
+DR   EMBL; MT326112; QIZ14038.1; -; Genomic_RNA.
+DR   EMBL; MT326113; QIZ14050.1; -; Genomic_RNA.
+DR   EMBL; MT326114; QIZ14062.1; -; Genomic_RNA.
+DR   EMBL; MT326115; QIZ14073.1; -; Genomic_RNA.
+DR   EMBL; MT326116; QIZ14086.1; -; Genomic_RNA.
+DR   EMBL; MT326117; QIZ14098.1; -; Genomic_RNA.
+DR   EMBL; MT326118; QIZ14110.1; -; Genomic_RNA.
+DR   EMBL; MT326119; QIZ14122.1; -; Genomic_RNA.
+DR   EMBL; MT326120; QIZ14134.1; -; Genomic_RNA.
+DR   EMBL; MT326121; QIZ14146.1; -; Genomic_RNA.
+DR   EMBL; MT326122; QIZ14158.1; -; Genomic_RNA.
+DR   EMBL; MT326123; QIZ14170.1; -; Genomic_RNA.
+DR   EMBL; MT326124; QIZ14182.1; -; Genomic_RNA.
+DR   EMBL; MT326125; QIZ14194.1; -; Genomic_RNA.
+DR   EMBL; MT326126; QIZ14204.1; -; Genomic_RNA.
+DR   EMBL; MT326127; QIZ14218.1; -; Genomic_RNA.
+DR   EMBL; MT326128; QIZ14230.1; -; Genomic_RNA.
+DR   EMBL; MT326129; QIZ14242.1; -; Genomic_RNA.
+DR   EMBL; MT326130; QIZ14254.1; -; Genomic_RNA.
+DR   EMBL; MT326131; QIZ14266.1; -; Genomic_RNA.
+DR   EMBL; MT326132; QIZ14278.1; -; Genomic_RNA.
+DR   EMBL; MT326133; QIZ14290.1; -; Genomic_RNA.
+DR   EMBL; MT326134; QIZ14302.1; -; Genomic_RNA.
+DR   EMBL; MT326135; QIZ14314.1; -; Genomic_RNA.
+DR   EMBL; MT326136; QIZ14326.1; -; Genomic_RNA.
+DR   EMBL; MT326137; QIZ14338.1; -; Genomic_RNA.
+DR   EMBL; MT326138; QIZ14350.1; -; Genomic_RNA.
+DR   EMBL; MT326139; QIZ14362.1; -; Genomic_RNA.
+DR   EMBL; MT326140; QIZ14374.1; -; Genomic_RNA.
+DR   EMBL; MT326141; QIZ14386.1; -; Genomic_RNA.
+DR   EMBL; MT326142; QIZ14393.1; -; Genomic_RNA.
+DR   EMBL; MT326143; QIZ14410.1; -; Genomic_RNA.
+DR   EMBL; MT326144; QIZ14422.1; -; Genomic_RNA.
+DR   EMBL; MT326145; QIZ14434.1; -; Genomic_RNA.
+DR   EMBL; MT326146; QIZ14446.1; -; Genomic_RNA.
+DR   EMBL; MT326147; QIZ14458.1; -; Genomic_RNA.
+DR   EMBL; MT326148; QIZ14470.1; -; Genomic_RNA.
+DR   EMBL; MT326149; QIZ14482.1; -; Genomic_RNA.
+DR   EMBL; MT326150; QIZ14494.1; -; Genomic_RNA.
+DR   EMBL; MT326151; QIZ14506.1; -; Genomic_RNA.
+DR   EMBL; MT326152; QIZ14518.1; -; Genomic_RNA.
+DR   EMBL; MT326153; QIZ14530.1; -; Genomic_RNA.
+DR   EMBL; MT326154; QIZ14542.1; -; Genomic_RNA.
+DR   EMBL; MT326155; QIZ14552.1; -; Genomic_RNA.
+DR   EMBL; MT326156; QIZ14566.1; -; Genomic_RNA.
+DR   EMBL; MT326157; QIZ14578.1; -; Genomic_RNA.
+DR   EMBL; MT326158; QIZ14590.1; -; Genomic_RNA.
+DR   EMBL; MT326159; QIZ14602.1; -; Genomic_RNA.
+DR   EMBL; MT326160; QIZ14614.1; -; Genomic_RNA.
+DR   EMBL; MT326161; QIZ14626.1; -; Genomic_RNA.
+DR   EMBL; MT326162; QIZ14638.1; -; Genomic_RNA.
+DR   EMBL; MT326163; QIZ14650.1; -; Genomic_RNA.
+DR   EMBL; MT326164; QIZ14662.1; -; Genomic_RNA.
+DR   EMBL; MT326165; QIZ14672.1; -; Genomic_RNA.
+DR   EMBL; MT326166; QIZ14686.1; -; Genomic_RNA.
+DR   EMBL; MT326167; QIZ14698.1; -; Genomic_RNA.
+DR   EMBL; MT326168; QIZ14710.1; -; Genomic_RNA.
+DR   EMBL; MT326169; QIZ14722.1; -; Genomic_RNA.
+DR   EMBL; MT326170; QIZ14734.1; -; Genomic_RNA.
+DR   EMBL; MT326171; QIZ14746.1; -; Genomic_RNA.
+DR   EMBL; MT326172; QIZ14758.1; -; Genomic_RNA.
+DR   EMBL; MT326173; QIZ14770.1; -; Genomic_RNA.
+DR   EMBL; MT326174; QIZ14782.1; -; Genomic_RNA.
+DR   EMBL; MT326175; QIZ14794.1; -; Genomic_RNA.
+DR   EMBL; MT326176; QIZ14805.1; -; Genomic_RNA.
+DR   EMBL; MT326177; QIZ14818.1; -; Genomic_RNA.
+DR   EMBL; MT326178; QIZ14830.1; -; Genomic_RNA.
+DR   EMBL; MT326179; QIZ14842.1; -; Genomic_RNA.
+DR   EMBL; MT326180; QIZ14854.1; -; Genomic_RNA.
+DR   EMBL; MT326181; QIZ14866.1; -; Genomic_RNA.
+DR   EMBL; MT326182; QIZ14878.1; -; Genomic_RNA.
+DR   EMBL; MT326183; QIZ14888.1; -; Genomic_RNA.
+DR   EMBL; MT326184; QIZ14902.1; -; Genomic_RNA.
+DR   EMBL; MT326185; QIZ14914.1; -; Genomic_RNA.
+DR   EMBL; MT326186; QIZ14926.1; -; Genomic_RNA.
+DR   EMBL; MT326187; QIZ14938.1; -; Genomic_RNA.
+DR   EMBL; MT326188; QIZ14948.1; -; Genomic_RNA.
+DR   EMBL; MT326189; QIZ14962.1; -; Genomic_RNA.
+DR   EMBL; MT326190; QIZ14974.1; -; Genomic_RNA.
+DR   EMBL; MT326191; QIZ14986.1; -; Genomic_RNA.
+DR   EMBL; MT324684; QIZ15006.1; -; Genomic_RNA.
+DR   EMBL; MT324062; QIZ15546.1; -; Genomic_RNA.
+DR   EMBL; MT325561; QIZ15558.1; -; Genomic_RNA.
+DR   EMBL; MT325562; QIZ15570.1; -; Genomic_RNA.
+DR   EMBL; MT325563; QIZ15582.1; -; Genomic_RNA.
+DR   EMBL; MT325564; QIZ15594.1; -; Genomic_RNA.
+DR   EMBL; MT325565; QIZ15606.1; -; Genomic_RNA.
+DR   EMBL; MT325566; QIZ15618.1; -; Genomic_RNA.
+DR   EMBL; MT325567; QIZ15630.1; -; Genomic_RNA.
+DR   EMBL; MT325568; QIZ15642.1; -; Genomic_RNA.
+DR   EMBL; MT325569; QIZ15654.1; -; Genomic_RNA.
+DR   EMBL; MT325570; QIZ15666.1; -; Genomic_RNA.
+DR   EMBL; MT325571; QIZ15678.1; -; Genomic_RNA.
+DR   EMBL; MT325572; QIZ15690.1; -; Genomic_RNA.
+DR   EMBL; MT325573; QIZ15702.1; -; Genomic_RNA.
+DR   EMBL; MT325574; QIZ15714.1; -; Genomic_RNA.
+DR   EMBL; MT325575; QIZ15726.1; -; Genomic_RNA.
+DR   EMBL; MT325576; QIZ15738.1; -; Genomic_RNA.
+DR   EMBL; MT325577; QIZ15750.1; -; Genomic_RNA.
+DR   EMBL; MT325578; QIZ15762.1; -; Genomic_RNA.
+DR   EMBL; MT325579; QIZ15774.1; -; Genomic_RNA.
+DR   EMBL; MT325580; QIZ15786.1; -; Genomic_RNA.
+DR   EMBL; MT325581; QIZ15798.1; -; Genomic_RNA.
+DR   EMBL; MT325582; QIZ15810.1; -; Genomic_RNA.
+DR   EMBL; MT325583; QIZ15822.1; -; Genomic_RNA.
+DR   EMBL; MT325584; QIZ15834.1; -; Genomic_RNA.
+DR   EMBL; MT325585; QIZ15846.1; -; Genomic_RNA.
+DR   EMBL; MT325586; QIZ15858.1; -; Genomic_RNA.
+DR   EMBL; MT325587; QIZ15870.1; -; Genomic_RNA.
+DR   EMBL; MT325588; QIZ15882.1; -; Genomic_RNA.
+DR   EMBL; MT325589; QIZ15894.1; -; Genomic_RNA.
+DR   EMBL; MT325590; QIZ15906.1; -; Genomic_RNA.
+DR   EMBL; MT325591; QIZ15918.1; -; Genomic_RNA.
+DR   EMBL; MT325592; QIZ15930.1; -; Genomic_RNA.
+DR   EMBL; MT325593; QIZ15942.1; -; Genomic_RNA.
+DR   EMBL; MT325594; QIZ15954.1; -; Genomic_RNA.
+DR   EMBL; MT325595; QIZ15966.1; -; Genomic_RNA.
+DR   EMBL; MT325596; QIZ15978.1; -; Genomic_RNA.
+DR   EMBL; MT325597; QIZ15990.1; -; Genomic_RNA.
+DR   EMBL; MT325598; QIZ16002.1; -; Genomic_RNA.
+DR   EMBL; MT325599; QIZ16014.1; -; Genomic_RNA.
+DR   EMBL; MT325600; QIZ16026.1; -; Genomic_RNA.
+DR   EMBL; MT325601; QIZ16038.1; -; Genomic_RNA.
+DR   EMBL; MT325602; QIZ16050.1; -; Genomic_RNA.
+DR   EMBL; MT325603; QIZ16062.1; -; Genomic_RNA.
+DR   EMBL; MT325604; QIZ16074.1; -; Genomic_RNA.
+DR   EMBL; MT325605; QIZ16086.1; -; Genomic_RNA.
+DR   EMBL; MT325606; QIZ16098.1; -; Genomic_RNA.
+DR   EMBL; MT325607; QIZ16110.1; -; Genomic_RNA.
+DR   EMBL; MT325608; QIZ16122.1; -; Genomic_RNA.
+DR   EMBL; MT325609; QIZ16134.1; -; Genomic_RNA.
+DR   EMBL; MT325610; QIZ16146.1; -; Genomic_RNA.
+DR   EMBL; MT325611; QIZ16158.1; -; Genomic_RNA.
+DR   EMBL; MT325612; QIZ16170.1; -; Genomic_RNA.
+DR   EMBL; MT325613; QIZ16182.1; -; Genomic_RNA.
+DR   EMBL; MT325614; QIZ16194.1; -; Genomic_RNA.
+DR   EMBL; MT325615; QIZ16206.1; -; Genomic_RNA.
+DR   EMBL; MT325616; QIZ16218.1; -; Genomic_RNA.
+DR   EMBL; MT325617; QIZ16230.1; -; Genomic_RNA.
+DR   EMBL; MT325618; QIZ16242.1; -; Genomic_RNA.
+DR   EMBL; MT325619; QIZ16254.1; -; Genomic_RNA.
+DR   EMBL; MT325620; QIZ16266.1; -; Genomic_RNA.
+DR   EMBL; MT325621; QIZ16278.1; -; Genomic_RNA.
+DR   EMBL; MT325622; QIZ16290.1; -; Genomic_RNA.
+DR   EMBL; MT325623; QIZ16302.1; -; Genomic_RNA.
+DR   EMBL; MT325624; QIZ16314.1; -; Genomic_RNA.
+DR   EMBL; MT325625; QIZ16326.1; -; Genomic_RNA.
+DR   EMBL; MT325626; QIZ16338.1; -; Genomic_RNA.
+DR   EMBL; MT325627; QIZ16350.1; -; Genomic_RNA.
+DR   EMBL; MT325628; QIZ16362.1; -; Genomic_RNA.
+DR   EMBL; MT325629; QIZ16374.1; -; Genomic_RNA.
+DR   EMBL; MT325630; QIZ16386.1; -; Genomic_RNA.
+DR   EMBL; MT325631; QIZ16398.1; -; Genomic_RNA.
+DR   EMBL; MT325632; QIZ16410.1; -; Genomic_RNA.
+DR   EMBL; MT325633; QIZ16422.1; -; Genomic_RNA.
+DR   EMBL; MT325634; QIZ16434.1; -; Genomic_RNA.
+DR   EMBL; MT325635; QIZ16446.1; -; Genomic_RNA.
+DR   EMBL; MT325636; QIZ16458.1; -; Genomic_RNA.
+DR   EMBL; MT325637; QIZ16470.1; -; Genomic_RNA.
+DR   EMBL; MT325638; QIZ16482.1; -; Genomic_RNA.
+DR   EMBL; MT325639; QIZ16494.1; -; Genomic_RNA.
+DR   EMBL; MT325640; QIZ16506.1; -; Genomic_RNA.
+DR   EMBL; MT327745; QIZ16518.1; -; Genomic_RNA.
+DR   EMBL; MT328032; QIZ16544.1; -; Genomic_RNA.
+DR   EMBL; MT328033; QIZ16556.1; -; Genomic_RNA.
+DR   EMBL; MT328034; QIZ16568.1; -; Genomic_RNA.
+DR   EMBL; MT328035; QIZ16580.1; -; Genomic_RNA.
+DR   EMBL; MT334522; QIZ64274.1; -; Genomic_RNA.
+DR   EMBL; MT334523; QIZ64287.1; -; Genomic_RNA.
+DR   EMBL; MT334524; QIZ64298.1; -; Genomic_RNA.
+DR   EMBL; MT334525; QIZ64310.1; -; Genomic_RNA.
+DR   EMBL; MT334526; QIZ64323.1; -; Genomic_RNA.
+DR   EMBL; MT334527; QIZ64335.1; -; Genomic_RNA.
+DR   EMBL; MT334528; QIZ64344.1; -; Genomic_RNA.
+DR   EMBL; MT334529; QIZ64359.1; -; Genomic_RNA.
+DR   EMBL; MT334530; QIZ64370.1; -; Genomic_RNA.
+DR   EMBL; MT334531; QIZ64383.1; -; Genomic_RNA.
+DR   EMBL; MT334532; QIZ64394.1; -; Genomic_RNA.
+DR   EMBL; MT334533; QIZ64407.1; -; Genomic_RNA.
+DR   EMBL; MT334534; QIZ64419.1; -; Genomic_RNA.
+DR   EMBL; MT334535; QIZ64431.1; -; Genomic_RNA.
+DR   EMBL; MT334536; QIZ64443.1; -; Genomic_RNA.
+DR   EMBL; MT334537; QIZ64455.1; -; Genomic_RNA.
+DR   EMBL; MT334538; QIZ64467.1; -; Genomic_RNA.
+DR   EMBL; MT334539; QIZ64479.1; -; Genomic_RNA.
+DR   EMBL; MT334540; QIZ64491.1; -; Genomic_RNA.
+DR   EMBL; MT334541; QIZ64503.1; -; Genomic_RNA.
+DR   EMBL; MT334542; QIZ64515.1; -; Genomic_RNA.
+DR   EMBL; MT334543; QIZ64526.1; -; Genomic_RNA.
+DR   EMBL; MT334544; QIZ64539.1; -; Genomic_RNA.
+DR   EMBL; MT334545; QIZ64550.1; -; Genomic_RNA.
+DR   EMBL; MT334546; QIZ64563.1; -; Genomic_RNA.
+DR   EMBL; MT334547; QIZ64575.1; -; Genomic_RNA.
+DR   EMBL; MT334548; QIZ64587.1; -; Genomic_RNA.
+DR   EMBL; MT334549; QIZ64589.1; -; Genomic_RNA.
+DR   EMBL; MT334550; QIZ64609.1; -; Genomic_RNA.
+DR   EMBL; MT334551; QIZ64619.1; -; Genomic_RNA.
+DR   EMBL; MT334552; QIZ64633.1; -; Genomic_RNA.
+DR   EMBL; MT334553; QIZ64643.1; -; Genomic_RNA.
+DR   EMBL; MT334554; QIZ64657.1; -; Genomic_RNA.
+DR   EMBL; MT334555; QIZ64667.1; -; Genomic_RNA.
+DR   EMBL; MT334556; QIZ64681.1; -; Genomic_RNA.
+DR   EMBL; MT334557; QIZ64694.1; -; Genomic_RNA.
+DR   EMBL; MT334558; QIZ64703.1; -; Genomic_RNA.
+DR   EMBL; MT334559; QIZ64717.1; -; Genomic_RNA.
+DR   EMBL; MT334560; QIZ64728.1; -; Genomic_RNA.
+DR   EMBL; MT334561; QIZ64741.1; -; Genomic_RNA.
+DR   EMBL; MT334563; QIZ64763.1; -; Genomic_RNA.
+DR   EMBL; MT334564; QIZ64773.1; -; Genomic_RNA.
+DR   EMBL; MT334565; QIZ64785.1; -; Genomic_RNA.
+DR   EMBL; MT334566; QIZ64797.1; -; Genomic_RNA.
+DR   EMBL; MT334567; QIZ64809.1; -; Genomic_RNA.
+DR   EMBL; MT334568; QIZ64821.1; -; Genomic_RNA.
+DR   EMBL; MT334569; QIZ64835.1; -; Genomic_RNA.
+DR   EMBL; MT334570; QIZ64847.1; -; Genomic_RNA.
+DR   EMBL; MT334571; QIZ64857.1; -; Genomic_RNA.
+DR   EMBL; MT334572; QIZ64871.1; -; Genomic_RNA.
+DR   EMBL; MT334573; QIZ64883.1; -; Genomic_RNA.
+DR   EMBL; MT339039; QIZ97048.1; -; Genomic_RNA.
+DR   EMBL; MT339040; QIZ97059.1; -; Genomic_RNA.
+DR   EMBL; MT339041; QIZ97071.1; -; Genomic_RNA.
+DR   EMBL; MT345798; QJA16409.1; -; Genomic_RNA.
+DR   EMBL; MT345799; QJA16421.1; -; Genomic_RNA.
+DR   EMBL; MT345800; QJA16431.1; -; Genomic_RNA.
+DR   EMBL; MT345801; QJA16445.1; -; Genomic_RNA.
+DR   EMBL; MT345802; QJA16457.1; -; Genomic_RNA.
+DR   EMBL; MT345803; QJA16469.1; -; Genomic_RNA.
+DR   EMBL; MT345804; QJA16481.1; -; Genomic_RNA.
+DR   EMBL; MT345805; QJA16493.1; -; Genomic_RNA.
+DR   EMBL; MT345806; QJA16505.1; -; Genomic_RNA.
+DR   EMBL; MT345807; QJA16517.1; -; Genomic_RNA.
+DR   EMBL; MT345808; QJA16529.1; -; Genomic_RNA.
+DR   EMBL; MT345809; QJA16541.1; -; Genomic_RNA.
+DR   EMBL; MT345810; QJA16553.1; -; Genomic_RNA.
+DR   EMBL; MT345811; QJA16565.1; -; Genomic_RNA.
+DR   EMBL; MT345812; QJA16577.1; -; Genomic_RNA.
+DR   EMBL; MT345813; QJA16589.1; -; Genomic_RNA.
+DR   EMBL; MT345814; QJA16601.1; -; Genomic_RNA.
+DR   EMBL; MT345815; QJA16613.1; -; Genomic_RNA.
+DR   EMBL; MT345816; QJA16625.1; -; Genomic_RNA.
+DR   EMBL; MT345817; QJA16637.1; -; Genomic_RNA.
+DR   EMBL; MT345818; QJA16649.1; -; Genomic_RNA.
+DR   EMBL; MT345819; QJA16661.1; -; Genomic_RNA.
+DR   EMBL; MT345820; QJA16673.1; -; Genomic_RNA.
+DR   EMBL; MT345821; QJA16685.1; -; Genomic_RNA.
+DR   EMBL; MT345822; QJA16697.1; -; Genomic_RNA.
+DR   EMBL; MT345823; QJA16709.1; -; Genomic_RNA.
+DR   EMBL; MT345824; QJA16721.1; -; Genomic_RNA.
+DR   EMBL; MT345825; QJA16733.1; -; Genomic_RNA.
+DR   EMBL; MT345826; QJA16745.1; -; Genomic_RNA.
+DR   EMBL; MT345827; QJA16757.1; -; Genomic_RNA.
+DR   EMBL; MT345828; QJA16769.1; -; Genomic_RNA.
+DR   EMBL; MT345829; QJA16781.1; -; Genomic_RNA.
+DR   EMBL; MT345830; QJA16793.1; -; Genomic_RNA.
+DR   EMBL; MT345831; QJA16803.1; -; Genomic_RNA.
+DR   EMBL; MT345832; QJA16817.1; -; Genomic_RNA.
+DR   EMBL; MT345833; QJA16829.1; -; Genomic_RNA.
+DR   EMBL; MT345834; QJA16841.1; -; Genomic_RNA.
+DR   EMBL; MT345835; QJA16853.1; -; Genomic_RNA.
+DR   EMBL; MT345836; QJA16865.1; -; Genomic_RNA.
+DR   EMBL; MT345837; QJA16877.1; -; Genomic_RNA.
+DR   EMBL; MT345838; QJA16889.1; -; Genomic_RNA.
+DR   EMBL; MT345839; QJA16898.1; -; Genomic_RNA.
+DR   EMBL; MT345840; QJA16913.1; -; Genomic_RNA.
+DR   EMBL; MT345841; QJA16925.1; -; Genomic_RNA.
+DR   EMBL; MT345842; QJA16937.1; -; Genomic_RNA.
+DR   EMBL; MT345843; QJA16949.1; -; Genomic_RNA.
+DR   EMBL; MT345844; QJA16961.1; -; Genomic_RNA.
+DR   EMBL; MT345845; QJA16970.1; -; Genomic_RNA.
+DR   EMBL; MT345846; QJA16985.1; -; Genomic_RNA.
+DR   EMBL; MT345847; QJA16997.1; -; Genomic_RNA.
+DR   EMBL; MT345848; QJA17009.1; -; Genomic_RNA.
+DR   EMBL; MT345849; QJA17021.1; -; Genomic_RNA.
+DR   EMBL; MT345850; QJA17032.1; -; Genomic_RNA.
+DR   EMBL; MT345851; QJA17045.1; -; Genomic_RNA.
+DR   EMBL; MT345852; QJA17057.1; -; Genomic_RNA.
+DR   EMBL; MT345853; QJA17069.1; -; Genomic_RNA.
+DR   EMBL; MT345854; QJA17081.1; -; Genomic_RNA.
+DR   EMBL; MT345855; QJA17093.1; -; Genomic_RNA.
+DR   EMBL; MT345856; QJA17105.1; -; Genomic_RNA.
+DR   EMBL; MT345857; QJA17117.1; -; Genomic_RNA.
+DR   EMBL; MT345858; QJA17129.1; -; Genomic_RNA.
+DR   EMBL; MT345859; QJA17141.1; -; Genomic_RNA.
+DR   EMBL; MT345860; QJA17153.1; -; Genomic_RNA.
+DR   EMBL; MT345861; QJA17165.1; -; Genomic_RNA.
+DR   EMBL; MT345862; QJA17177.1; -; Genomic_RNA.
+DR   EMBL; MT345863; QJA17189.1; -; Genomic_RNA.
+DR   EMBL; MT345864; QJA17201.1; -; Genomic_RNA.
+DR   EMBL; MT345865; QJA17213.1; -; Genomic_RNA.
+DR   EMBL; MT345866; QJA17225.1; -; Genomic_RNA.
+DR   EMBL; MT345867; QJA17237.1; -; Genomic_RNA.
+DR   EMBL; MT345868; QJA17249.1; -; Genomic_RNA.
+DR   EMBL; MT345869; QJA17261.1; -; Genomic_RNA.
+DR   EMBL; MT345870; QJA17273.1; -; Genomic_RNA.
+DR   EMBL; MT345871; QJA17284.1; -; Genomic_RNA.
+DR   EMBL; MT345872; QJA17297.1; -; Genomic_RNA.
+DR   EMBL; MT345873; QJA17309.1; -; Genomic_RNA.
+DR   EMBL; MT345874; QJA17321.1; -; Genomic_RNA.
+DR   EMBL; MT345875; QJA17333.1; -; Genomic_RNA.
+DR   EMBL; MT345876; QJA17345.1; -; Genomic_RNA.
+DR   EMBL; MT345877; QJA17357.1; -; Genomic_RNA.
+DR   EMBL; MT345878; QJA17369.1; -; Genomic_RNA.
+DR   EMBL; MT345879; QJA17381.1; -; Genomic_RNA.
+DR   EMBL; MT345880; QJA17393.1; -; Genomic_RNA.
+DR   EMBL; MT345881; QJA17405.1; -; Genomic_RNA.
+DR   EMBL; MT345882; QJA17417.1; -; Genomic_RNA.
+DR   EMBL; MT345883; QJA17429.1; -; Genomic_RNA.
+DR   EMBL; MT345884; QJA17440.1; -; Genomic_RNA.
+DR   EMBL; MT345885; QJA17453.1; -; Genomic_RNA.
+DR   EMBL; MT345886; QJA17465.1; -; Genomic_RNA.
+DR   EMBL; MT345887; QJA17477.1; -; Genomic_RNA.
+DR   EMBL; MT345888; QJA17489.1; -; Genomic_RNA.
+DR   EMBL; MT344944; QJA17533.1; -; Genomic_RNA.
+DR   EMBL; MT344945; QJA17545.1; -; Genomic_RNA.
+DR   EMBL; MT344946; QJA17557.1; -; Genomic_RNA.
+DR   EMBL; MT344947; QJA17569.1; -; Genomic_RNA.
+DR   EMBL; MT344948; QJA17581.1; -; Genomic_RNA.
+DR   EMBL; MT344949; QJA17593.1; -; Genomic_RNA.
+DR   EMBL; MT344950; QJA17605.1; -; Genomic_RNA.
+DR   EMBL; MT344951; QJA17617.1; -; Genomic_RNA.
+DR   EMBL; MT344952; QJA17629.1; -; Genomic_RNA.
+DR   EMBL; MT344953; QJA17641.1; -; Genomic_RNA.
+DR   EMBL; MT344954; QJA17653.1; -; Genomic_RNA.
+DR   EMBL; MT344955; QJA17665.1; -; Genomic_RNA.
+DR   EMBL; MT344956; QJA17677.1; -; Genomic_RNA.
+DR   EMBL; MT344957; QJA17689.1; -; Genomic_RNA.
+DR   EMBL; MT344958; QJA17701.1; -; Genomic_RNA.
+DR   EMBL; MT344959; QJA17713.1; -; Genomic_RNA.
+DR   EMBL; MT344960; QJA17725.1; -; Genomic_RNA.
+DR   EMBL; MT344961; QJA17737.1; -; Genomic_RNA.
+DR   EMBL; MT344962; QJA17749.1; -; Genomic_RNA.
+DR   EMBL; MT344963; QJA17761.1; -; Genomic_RNA.
+DR   EMBL; MT350282; QJA41650.1; -; Genomic_RNA.
+DR   EMBL; MT350263; QJA41662.1; -; Genomic_RNA.
+DR   EMBL; MT350264; QJA41674.1; -; Genomic_RNA.
+DR   EMBL; MT350265; QJA41686.1; -; Genomic_RNA.
+DR   EMBL; MT350266; QJA41698.1; -; Genomic_RNA.
+DR   EMBL; MT350267; QJA41710.1; -; Genomic_RNA.
+DR   EMBL; MT350268; QJA41722.1; -; Genomic_RNA.
+DR   EMBL; MT350269; QJA41734.1; -; Genomic_RNA.
+DR   EMBL; MT350270; QJA41746.1; -; Genomic_RNA.
+DR   EMBL; MT350271; QJA41758.1; -; Genomic_RNA.
+DR   EMBL; MT350272; QJA41770.1; -; Genomic_RNA.
+DR   EMBL; MT350273; QJA41782.1; -; Genomic_RNA.
+DR   EMBL; MT350274; QJA41794.1; -; Genomic_RNA.
+DR   EMBL; MT350275; QJA41806.1; -; Genomic_RNA.
+DR   EMBL; MT350276; QJA41818.1; -; Genomic_RNA.
+DR   EMBL; MT350277; QJA41830.1; -; Genomic_RNA.
+DR   EMBL; MT350278; QJA41842.1; -; Genomic_RNA.
+DR   EMBL; MT350279; QJA41854.1; -; Genomic_RNA.
+DR   EMBL; MT350280; QJA41866.1; -; Genomic_RNA.
+DR   EMBL; MT350236; QJA41994.1; -; Genomic_RNA.
+DR   EMBL; MT350237; QJA42006.1; -; Genomic_RNA.
+DR   EMBL; MT350238; QJA42018.1; -; Genomic_RNA.
+DR   EMBL; MT350239; QJA42030.1; -; Genomic_RNA.
+DR   EMBL; MT350240; QJA42042.1; -; Genomic_RNA.
+DR   EMBL; MT350241; QJA42054.1; -; Genomic_RNA.
+DR   EMBL; MT350242; QJA42066.1; -; Genomic_RNA.
+DR   EMBL; MT350243; QJA42078.1; -; Genomic_RNA.
+DR   EMBL; MT350244; QJA42090.1; -; Genomic_RNA.
+DR   EMBL; MT350245; QJA42102.1; -; Genomic_RNA.
+DR   EMBL; MT350246; QJA42114.1; -; Genomic_RNA.
+DR   EMBL; MT350247; QJA42126.1; -; Genomic_RNA.
+DR   EMBL; MT350248; QJA42138.1; -; Genomic_RNA.
+DR   EMBL; MT350249; QJA42150.1; -; Genomic_RNA.
+DR   EMBL; MT350250; QJA42162.1; -; Genomic_RNA.
+DR   EMBL; MT350251; QJA42174.1; -; Genomic_RNA.
+DR   EMBL; MT350252; QJA42186.1; -; Genomic_RNA.
+DR   EMBL; MT350253; QJA42198.1; -; Genomic_RNA.
+DR   EMBL; MT350254; QJA42210.1; -; Genomic_RNA.
+DR   EMBL; MT350255; QJA42222.1; -; Genomic_RNA.
+DR   EMBL; MT350256; QJA42234.1; -; Genomic_RNA.
+DR   EMBL; MT350257; QJA42246.1; -; Genomic_RNA.
+DR   EMBL; MT358637; QJC19500.1; -; Genomic_RNA.
+DR   EMBL; MT358644; QJC19512.1; -; Genomic_RNA.
+DR   EMBL; MT358645; QJC19524.1; -; Genomic_RNA.
+DR   EMBL; MT358646; QJC19536.1; -; Genomic_RNA.
+DR   EMBL; MT358647; QJC19548.1; -; Genomic_RNA.
+DR   EMBL; MT358648; QJC19560.1; -; Genomic_RNA.
+DR   EMBL; MT358649; QJC19572.1; -; Genomic_RNA.
+DR   EMBL; MT358650; QJC19584.1; -; Genomic_RNA.
+DR   EMBL; MT358651; QJC19596.1; -; Genomic_RNA.
+DR   EMBL; MT358652; QJC19608.1; -; Genomic_RNA.
+DR   EMBL; MT358653; QJC19620.1; -; Genomic_RNA.
+DR   EMBL; MT358654; QJC19632.1; -; Genomic_RNA.
+DR   EMBL; MT358655; QJC19644.1; -; Genomic_RNA.
+DR   EMBL; MT358656; QJC19656.1; -; Genomic_RNA.
+DR   EMBL; MT358657; QJC19668.1; -; Genomic_RNA.
+DR   EMBL; MT358658; QJC19680.1; -; Genomic_RNA.
+DR   EMBL; MT358659; QJC19692.1; -; Genomic_RNA.
+DR   EMBL; MT358660; QJC19704.1; -; Genomic_RNA.
+DR   EMBL; MT358661; QJC19716.1; -; Genomic_RNA.
+DR   EMBL; MT358662; QJC19728.1; -; Genomic_RNA.
+DR   EMBL; MT358663; QJC19740.1; -; Genomic_RNA.
+DR   EMBL; MT358664; QJC19752.1; -; Genomic_RNA.
+DR   EMBL; MT358665; QJC19764.1; -; Genomic_RNA.
+DR   EMBL; MT358666; QJC19776.1; -; Genomic_RNA.
+DR   EMBL; MT358667; QJC19788.1; -; Genomic_RNA.
+DR   EMBL; MT358668; QJC19800.1; -; Genomic_RNA.
+DR   EMBL; MT358669; QJC19812.1; -; Genomic_RNA.
+DR   EMBL; MT358670; QJC19824.1; -; Genomic_RNA.
+DR   EMBL; MT358671; QJC19836.1; -; Genomic_RNA.
+DR   EMBL; MT358672; QJC19848.1; -; Genomic_RNA.
+DR   EMBL; MT358673; QJC19860.1; -; Genomic_RNA.
+DR   EMBL; MT358674; QJC19872.1; -; Genomic_RNA.
+DR   EMBL; MT358675; QJC19884.1; -; Genomic_RNA.
+DR   EMBL; MT358676; QJC19896.1; -; Genomic_RNA.
+DR   EMBL; MT358677; QJC19908.1; -; Genomic_RNA.
+DR   EMBL; MT358678; QJC19920.1; -; Genomic_RNA.
+DR   EMBL; MT358679; QJC19932.1; -; Genomic_RNA.
+DR   EMBL; MT358680; QJC19944.1; -; Genomic_RNA.
+DR   EMBL; MT358681; QJC19956.1; -; Genomic_RNA.
+DR   EMBL; MT358682; QJC19968.1; -; Genomic_RNA.
+DR   EMBL; MT358683; QJC19980.1; -; Genomic_RNA.
+DR   EMBL; MT358684; QJC19992.1; -; Genomic_RNA.
+DR   EMBL; MT358685; QJC20004.1; -; Genomic_RNA.
+DR   EMBL; MT358686; QJC20016.1; -; Genomic_RNA.
+DR   EMBL; MT358687; QJC20028.1; -; Genomic_RNA.
+DR   EMBL; MT358688; QJC20040.1; -; Genomic_RNA.
+DR   EMBL; MT358689; QJC20052.1; -; Genomic_RNA.
+DR   EMBL; MT358690; QJC20064.1; -; Genomic_RNA.
+DR   EMBL; MT358691; QJC20076.1; -; Genomic_RNA.
+DR   EMBL; MT358692; QJC20088.1; -; Genomic_RNA.
+DR   EMBL; MT358693; QJC20100.1; -; Genomic_RNA.
+DR   EMBL; MT358694; QJC20112.1; -; Genomic_RNA.
+DR   EMBL; MT358695; QJC20124.1; -; Genomic_RNA.
+DR   EMBL; MT358696; QJC20136.1; -; Genomic_RNA.
+DR   EMBL; MT358697; QJC20148.1; -; Genomic_RNA.
+DR   EMBL; MT358698; QJC20160.1; -; Genomic_RNA.
+DR   EMBL; MT358699; QJC20172.1; -; Genomic_RNA.
+DR   EMBL; MT358700; QJC20184.1; -; Genomic_RNA.
+DR   EMBL; MT358701; QJC20196.1; -; Genomic_RNA.
+DR   EMBL; MT358702; QJC20208.1; -; Genomic_RNA.
+DR   EMBL; MT358703; QJC20220.1; -; Genomic_RNA.
+DR   EMBL; MT358704; QJC20232.1; -; Genomic_RNA.
+DR   EMBL; MT358705; QJC20244.1; -; Genomic_RNA.
+DR   EMBL; MT358706; QJC20256.1; -; Genomic_RNA.
+DR   EMBL; MT358707; QJC20268.1; -; Genomic_RNA.
+DR   EMBL; MT358708; QJC20280.1; -; Genomic_RNA.
+DR   EMBL; MT358709; QJC20292.1; -; Genomic_RNA.
+DR   EMBL; MT358710; QJC20304.1; -; Genomic_RNA.
+DR   EMBL; MT358711; QJC20316.1; -; Genomic_RNA.
+DR   EMBL; MT358712; QJC20328.1; -; Genomic_RNA.
+DR   EMBL; MT358713; QJC20340.1; -; Genomic_RNA.
+DR   EMBL; MT358714; QJC20352.1; -; Genomic_RNA.
+DR   EMBL; MT358715; QJC20364.1; -; Genomic_RNA.
+DR   EMBL; MT358716; QJC20376.1; -; Genomic_RNA.
+DR   EMBL; MT358717; QJC20388.1; -; Genomic_RNA.
+DR   EMBL; MT358718; QJC20400.1; -; Genomic_RNA.
+DR   EMBL; MT358719; QJC20412.1; -; Genomic_RNA.
+DR   EMBL; MT358720; QJC20424.1; -; Genomic_RNA.
+DR   EMBL; MT358721; QJC20436.1; -; Genomic_RNA.
+DR   EMBL; MT358722; QJC20448.1; -; Genomic_RNA.
+DR   EMBL; MT358723; QJC20460.1; -; Genomic_RNA.
+DR   EMBL; MT358724; QJC20472.1; -; Genomic_RNA.
+DR   EMBL; MT358725; QJC20484.1; -; Genomic_RNA.
+DR   EMBL; MT358726; QJC20496.1; -; Genomic_RNA.
+DR   EMBL; MT358727; QJC20507.1; -; Genomic_RNA.
+DR   EMBL; MT358728; QJC20519.1; -; Genomic_RNA.
+DR   EMBL; MT358729; QJC20531.1; -; Genomic_RNA.
+DR   EMBL; MT358730; QJC20543.1; -; Genomic_RNA.
+DR   EMBL; MT358731; QJC20555.1; -; Genomic_RNA.
+DR   EMBL; MT358732; QJC20567.1; -; Genomic_RNA.
+DR   EMBL; MT358733; QJC20579.1; -; Genomic_RNA.
+DR   EMBL; MT358734; QJC20591.1; -; Genomic_RNA.
+DR   EMBL; MT358735; QJC20603.1; -; Genomic_RNA.
+DR   EMBL; MT358736; QJC20615.1; -; Genomic_RNA.
+DR   EMBL; MT358737; QJC20627.1; -; Genomic_RNA.
+DR   EMBL; MT358738; QJC20639.1; -; Genomic_RNA.
+DR   EMBL; MT358739; QJC20651.1; -; Genomic_RNA.
+DR   EMBL; MT358740; QJC20663.1; -; Genomic_RNA.
+DR   EMBL; MT358741; QJC20675.1; -; Genomic_RNA.
+DR   EMBL; MT358742; QJC20687.1; -; Genomic_RNA.
+DR   EMBL; MT358743; QJC20699.1; -; Genomic_RNA.
+DR   EMBL; MT358744; QJC20711.1; -; Genomic_RNA.
+DR   EMBL; MT358745; QJC20723.1; -; Genomic_RNA.
+DR   EMBL; MT358746; QJC20735.1; -; Genomic_RNA.
+DR   EMBL; MT358747; QJC20747.1; -; Genomic_RNA.
+DR   EMBL; MT358748; QJC20759.1; -; Genomic_RNA.
+DR   EMBL; MT230904; QJC21002.1; -; Genomic_RNA.
+DR   EMBL; MT359865; QJC21014.1; -; Genomic_RNA.
+DR   EMBL; MT359866; QJC21026.1; -; Genomic_RNA.
+DR   EMBL; MT358401; QJC21038.1; -; Genomic_RNA.
+DR   EMBL; MT358402; QJC21050.1; -; Genomic_RNA.
+DR   EMBL; MT370516; QJD20641.1; -; Genomic_RNA.
+DR   EMBL; MT370517; QJD20653.1; -; Genomic_RNA.
+DR   EMBL; MT370518; QJD20665.1; -; Genomic_RNA.
+DR   EMBL; MT371047; QJD20846.1; -; Genomic_RNA.
+DR   EMBL; MT371048; QJD20858.1; -; Genomic_RNA.
+DR   EMBL; MT371049; QJD20870.1; -; Genomic_RNA.
+DR   EMBL; MT371050; QJD20882.1; -; Genomic_RNA.
+DR   EMBL; MT371568; QJD23150.1; -; Genomic_RNA.
+DR   EMBL; MT371569; QJD23162.1; -; Genomic_RNA.
+DR   EMBL; MT371570; QJD23174.1; -; Genomic_RNA.
+DR   EMBL; MT371571; QJD23186.1; -; Genomic_RNA.
+DR   EMBL; MT371572; QJD23198.1; -; Genomic_RNA.
+DR   EMBL; MT371573; QJD23210.1; -; Genomic_RNA.
+DR   EMBL; MT371574; QJD23222.1; -; Genomic_RNA.
+DR   EMBL; MT372480; QJD23234.1; -; Genomic_RNA.
+DR   EMBL; MT372481; QJD23246.1; -; Genomic_RNA.
+DR   EMBL; MT372482; QJD23258.1; -; Genomic_RNA.
+DR   EMBL; MT372483; QJD23267.1; -; Genomic_RNA.
+DR   EMBL; MT370831; QJD23282.1; -; Genomic_RNA.
+DR   EMBL; MT370832; QJD23292.1; -; Genomic_RNA.
+DR   EMBL; MT370833; QJD23306.1; -; Genomic_RNA.
+DR   EMBL; MT370834; QJD23318.1; -; Genomic_RNA.
+DR   EMBL; MT370835; QJD23330.1; -; Genomic_RNA.
+DR   EMBL; MT370836; QJD23342.1; -; Genomic_RNA.
+DR   EMBL; MT370837; QJD23354.1; -; Genomic_RNA.
+DR   EMBL; MT370838; QJD23366.1; -; Genomic_RNA.
+DR   EMBL; MT370839; QJD23378.1; -; Genomic_RNA.
+DR   EMBL; MT370840; QJD23388.1; -; Genomic_RNA.
+DR   EMBL; MT370841; QJD23402.1; -; Genomic_RNA.
+DR   EMBL; MT370842; QJD23414.1; -; Genomic_RNA.
+DR   EMBL; MT370843; QJD23426.1; -; Genomic_RNA.
+DR   EMBL; MT370844; QJD23438.1; -; Genomic_RNA.
+DR   EMBL; MT370845; QJD23450.1; -; Genomic_RNA.
+DR   EMBL; MT370846; QJD23462.1; -; Genomic_RNA.
+DR   EMBL; MT370847; QJD23471.1; -; Genomic_RNA.
+DR   EMBL; MT370848; QJD23486.1; -; Genomic_RNA.
+DR   EMBL; MT370849; QJD23498.1; -; Genomic_RNA.
+DR   EMBL; MT370850; QJD23510.1; -; Genomic_RNA.
+DR   EMBL; MT370851; QJD23522.1; -; Genomic_RNA.
+DR   EMBL; MT370852; QJD23533.1; -; Genomic_RNA.
+DR   EMBL; MT370853; QJD23546.1; -; Genomic_RNA.
+DR   EMBL; MT370854; QJD23558.1; -; Genomic_RNA.
+DR   EMBL; MT370855; QJD23568.1; -; Genomic_RNA.
+DR   EMBL; MT370856; QJD23582.1; -; Genomic_RNA.
+DR   EMBL; MT370857; QJD23594.1; -; Genomic_RNA.
+DR   EMBL; MT370858; QJD23606.1; -; Genomic_RNA.
+DR   EMBL; MT370859; QJD23618.1; -; Genomic_RNA.
+DR   EMBL; MT370860; QJD23630.1; -; Genomic_RNA.
+DR   EMBL; MT370861; QJD23642.1; -; Genomic_RNA.
+DR   EMBL; MT370862; QJD23654.1; -; Genomic_RNA.
+DR   EMBL; MT370863; QJD23666.1; -; Genomic_RNA.
+DR   EMBL; MT370864; QJD23678.1; -; Genomic_RNA.
+DR   EMBL; MT370865; QJD23690.1; -; Genomic_RNA.
+DR   EMBL; MT370866; QJD23702.1; -; Genomic_RNA.
+DR   EMBL; MT370867; QJD23713.1; -; Genomic_RNA.
+DR   EMBL; MT370868; QJD23726.1; -; Genomic_RNA.
+DR   EMBL; MT370869; QJD23738.1; -; Genomic_RNA.
+DR   EMBL; MT370870; QJD23750.1; -; Genomic_RNA.
+DR   EMBL; MT370871; QJD23762.1; -; Genomic_RNA.
+DR   EMBL; MT370872; QJD23774.1; -; Genomic_RNA.
+DR   EMBL; MT370873; QJD23784.1; -; Genomic_RNA.
+DR   EMBL; MT370874; QJD23798.1; -; Genomic_RNA.
+DR   EMBL; MT370875; QJD23810.1; -; Genomic_RNA.
+DR   EMBL; MT370876; QJD23822.1; -; Genomic_RNA.
+DR   EMBL; MT370877; QJD23834.1; -; Genomic_RNA.
+DR   EMBL; MT370878; QJD23846.1; -; Genomic_RNA.
+DR   EMBL; MT370879; QJD23856.1; -; Genomic_RNA.
+DR   EMBL; MT370880; QJD23870.1; -; Genomic_RNA.
+DR   EMBL; MT370881; QJD23882.1; -; Genomic_RNA.
+DR   EMBL; MT370882; QJD23894.1; -; Genomic_RNA.
+DR   EMBL; MT370883; QJD23906.1; -; Genomic_RNA.
+DR   EMBL; MT370884; QJD23916.1; -; Genomic_RNA.
+DR   EMBL; MT370885; QJD23930.1; -; Genomic_RNA.
+DR   EMBL; MT370886; QJD23942.1; -; Genomic_RNA.
+DR   EMBL; MT370887; QJD23953.1; -; Genomic_RNA.
+DR   EMBL; MT370888; QJD23966.1; -; Genomic_RNA.
+DR   EMBL; MT370889; QJD23978.1; -; Genomic_RNA.
+DR   EMBL; MT370890; QJD23990.1; -; Genomic_RNA.
+DR   EMBL; MT370891; QJD24002.1; -; Genomic_RNA.
+DR   EMBL; MT370892; QJD24014.1; -; Genomic_RNA.
+DR   EMBL; MT370893; QJD24024.1; -; Genomic_RNA.
+DR   EMBL; MT370894; QJD24038.1; -; Genomic_RNA.
+DR   EMBL; MT370895; QJD24050.1; -; Genomic_RNA.
+DR   EMBL; MT370896; QJD24062.1; -; Genomic_RNA.
+DR   EMBL; MT370897; QJD24074.1; -; Genomic_RNA.
+DR   EMBL; MT370898; QJD24086.1; -; Genomic_RNA.
+DR   EMBL; MT370899; QJD24098.1; -; Genomic_RNA.
+DR   EMBL; MT370900; QJD24108.1; -; Genomic_RNA.
+DR   EMBL; MT370901; QJD24122.1; -; Genomic_RNA.
+DR   EMBL; MT370902; QJD24134.1; -; Genomic_RNA.
+DR   EMBL; MT370903; QJD24146.1; -; Genomic_RNA.
+DR   EMBL; MT370904; QJD24158.1; -; Genomic_RNA.
+DR   EMBL; MT370905; QJD24170.1; -; Genomic_RNA.
+DR   EMBL; MT370906; QJD24182.1; -; Genomic_RNA.
+DR   EMBL; MT370907; QJD24194.1; -; Genomic_RNA.
+DR   EMBL; MT370908; QJD24206.1; -; Genomic_RNA.
+DR   EMBL; MT370909; QJD24218.1; -; Genomic_RNA.
+DR   EMBL; MT370910; QJD24228.1; -; Genomic_RNA.
+DR   EMBL; MT370911; QJD24242.1; -; Genomic_RNA.
+DR   EMBL; MT370912; QJD24254.1; -; Genomic_RNA.
+DR   EMBL; MT370913; QJD24266.1; -; Genomic_RNA.
+DR   EMBL; MT370914; QJD24278.1; -; Genomic_RNA.
+DR   EMBL; MT370915; QJD24290.1; -; Genomic_RNA.
+DR   EMBL; MT370916; QJD24302.1; -; Genomic_RNA.
+DR   EMBL; MT370917; QJD24314.1; -; Genomic_RNA.
+DR   EMBL; MT370918; QJD24324.1; -; Genomic_RNA.
+DR   EMBL; MT370919; QJD24338.1; -; Genomic_RNA.
+DR   EMBL; MT370920; QJD24350.1; -; Genomic_RNA.
+DR   EMBL; MT370921; QJD24362.1; -; Genomic_RNA.
+DR   EMBL; MT370922; QJD24374.1; -; Genomic_RNA.
+DR   EMBL; MT370923; QJD24386.1; -; Genomic_RNA.
+DR   EMBL; MT370924; QJD24398.1; -; Genomic_RNA.
+DR   EMBL; MT370925; QJD24410.1; -; Genomic_RNA.
+DR   EMBL; MT370926; QJD24422.1; -; Genomic_RNA.
+DR   EMBL; MT370927; QJD24434.1; -; Genomic_RNA.
+DR   EMBL; MT370928; QJD24445.1; -; Genomic_RNA.
+DR   EMBL; MT370929; QJD24457.1; -; Genomic_RNA.
+DR   EMBL; MT370930; QJD24470.1; -; Genomic_RNA.
+DR   EMBL; MT370931; QJD24482.1; -; Genomic_RNA.
+DR   EMBL; MT370932; QJD24494.1; -; Genomic_RNA.
+DR   EMBL; MT370933; QJD24506.1; -; Genomic_RNA.
+DR   EMBL; MT370934; QJD24518.1; -; Genomic_RNA.
+DR   EMBL; MT370935; QJD24530.1; -; Genomic_RNA.
+DR   EMBL; MT370936; QJD24540.1; -; Genomic_RNA.
+DR   EMBL; MT370937; QJD24554.1; -; Genomic_RNA.
+DR   EMBL; MT370938; QJD24566.1; -; Genomic_RNA.
+DR   EMBL; MT370939; QJD24578.1; -; Genomic_RNA.
+DR   EMBL; MT370940; QJD24590.1; -; Genomic_RNA.
+DR   EMBL; MT370941; QJD24602.1; -; Genomic_RNA.
+DR   EMBL; MT370942; QJD24614.1; -; Genomic_RNA.
+DR   EMBL; MT370943; QJD24626.1; -; Genomic_RNA.
+DR   EMBL; MT370944; QJD24638.1; -; Genomic_RNA.
+DR   EMBL; MT370945; QJD24648.1; -; Genomic_RNA.
+DR   EMBL; MT370946; QJD24662.1; -; Genomic_RNA.
+DR   EMBL; MT370947; QJD24674.1; -; Genomic_RNA.
+DR   EMBL; MT370948; QJD24686.1; -; Genomic_RNA.
+DR   EMBL; MT370949; QJD24698.1; -; Genomic_RNA.
+DR   EMBL; MT370950; QJD24710.1; -; Genomic_RNA.
+DR   EMBL; MT370951; QJD24722.1; -; Genomic_RNA.
+DR   EMBL; MT370952; QJD24734.1; -; Genomic_RNA.
+DR   EMBL; MT370953; QJD24746.1; -; Genomic_RNA.
+DR   EMBL; MT370954; QJD24758.1; -; Genomic_RNA.
+DR   EMBL; MT370955; QJD24766.1; -; Genomic_RNA.
+DR   EMBL; MT370956; QJD24782.1; -; Genomic_RNA.
+DR   EMBL; MT370957; QJD24794.1; -; Genomic_RNA.
+DR   EMBL; MT370958; QJD24806.1; -; Genomic_RNA.
+DR   EMBL; MT370959; QJD24818.1; -; Genomic_RNA.
+DR   EMBL; MT370960; QJD24830.1; -; Genomic_RNA.
+DR   EMBL; MT370961; QJD24842.1; -; Genomic_RNA.
+DR   EMBL; MT370962; QJD24854.1; -; Genomic_RNA.
+DR   EMBL; MT370963; QJD24866.1; -; Genomic_RNA.
+DR   EMBL; MT370964; QJD24878.1; -; Genomic_RNA.
+DR   EMBL; MT370965; QJD24890.1; -; Genomic_RNA.
+DR   EMBL; MT370966; QJD24902.1; -; Genomic_RNA.
+DR   EMBL; MT370967; QJD24914.1; -; Genomic_RNA.
+DR   EMBL; MT370968; QJD24926.1; -; Genomic_RNA.
+DR   EMBL; MT370969; QJD24938.1; -; Genomic_RNA.
+DR   EMBL; MT370970; QJD24950.1; -; Genomic_RNA.
+DR   EMBL; MT370971; QJD24962.1; -; Genomic_RNA.
+DR   EMBL; MT370972; QJD24974.1; -; Genomic_RNA.
+DR   EMBL; MT370973; QJD24986.1; -; Genomic_RNA.
+DR   EMBL; MT370974; QJD24998.1; -; Genomic_RNA.
+DR   EMBL; MT370975; QJD25010.1; -; Genomic_RNA.
+DR   EMBL; MT370976; QJD25022.1; -; Genomic_RNA.
+DR   EMBL; MT370977; QJD25034.1; -; Genomic_RNA.
+DR   EMBL; MT370978; QJD25046.1; -; Genomic_RNA.
+DR   EMBL; MT370979; QJD25058.1; -; Genomic_RNA.
+DR   EMBL; MT370980; QJD25070.1; -; Genomic_RNA.
+DR   EMBL; MT370981; QJD25082.1; -; Genomic_RNA.
+DR   EMBL; MT370982; QJD25094.1; -; Genomic_RNA.
+DR   EMBL; MT370983; QJD25106.1; -; Genomic_RNA.
+DR   EMBL; MT370984; QJD25118.1; -; Genomic_RNA.
+DR   EMBL; MT370985; QJD25130.1; -; Genomic_RNA.
+DR   EMBL; MT370986; QJD25142.1; -; Genomic_RNA.
+DR   EMBL; MT370987; QJD25154.1; -; Genomic_RNA.
+DR   EMBL; MT370988; QJD25166.1; -; Genomic_RNA.
+DR   EMBL; MT370989; QJD25178.1; -; Genomic_RNA.
+DR   EMBL; MT370990; QJD25190.1; -; Genomic_RNA.
+DR   EMBL; MT370991; QJD25202.1; -; Genomic_RNA.
+DR   EMBL; MT370992; QJD25212.1; -; Genomic_RNA.
+DR   EMBL; MT370993; QJD25226.1; -; Genomic_RNA.
+DR   EMBL; MT370994; QJD25238.1; -; Genomic_RNA.
+DR   EMBL; MT370995; QJD25250.1; -; Genomic_RNA.
+DR   EMBL; MT370996; QJD25262.1; -; Genomic_RNA.
+DR   EMBL; MT370997; QJD25274.1; -; Genomic_RNA.
+DR   EMBL; MT370998; QJD25286.1; -; Genomic_RNA.
+DR   EMBL; MT370999; QJD25298.1; -; Genomic_RNA.
+DR   EMBL; MT371000; QJD25310.1; -; Genomic_RNA.
+DR   EMBL; MT371001; QJD25322.1; -; Genomic_RNA.
+DR   EMBL; MT371002; QJD25334.1; -; Genomic_RNA.
+DR   EMBL; MT371003; QJD25344.1; -; Genomic_RNA.
+DR   EMBL; MT371004; QJD25358.1; -; Genomic_RNA.
+DR   EMBL; MT371005; QJD25370.1; -; Genomic_RNA.
+DR   EMBL; MT371006; QJD25382.1; -; Genomic_RNA.
+DR   EMBL; MT371007; QJD25394.1; -; Genomic_RNA.
+DR   EMBL; MT371008; QJD25406.1; -; Genomic_RNA.
+DR   EMBL; MT371009; QJD25418.1; -; Genomic_RNA.
+DR   EMBL; MT371010; QJD25430.1; -; Genomic_RNA.
+DR   EMBL; MT371011; QJD25440.1; -; Genomic_RNA.
+DR   EMBL; MT371012; QJD25454.1; -; Genomic_RNA.
+DR   EMBL; MT371013; QJD25466.1; -; Genomic_RNA.
+DR   EMBL; MT371014; QJD25476.1; -; Genomic_RNA.
+DR   EMBL; MT371015; QJD25490.1; -; Genomic_RNA.
+DR   EMBL; MT371016; QJD25502.1; -; Genomic_RNA.
+DR   EMBL; MT371017; QJD25514.1; -; Genomic_RNA.
+DR   EMBL; MT371018; QJD25526.1; -; Genomic_RNA.
+DR   EMBL; MT371019; QJD25538.1; -; Genomic_RNA.
+DR   EMBL; MT371020; QJD25550.1; -; Genomic_RNA.
+DR   EMBL; MT371021; QJD25562.1; -; Genomic_RNA.
+DR   EMBL; MT371022; QJD25574.1; -; Genomic_RNA.
+DR   EMBL; MT371023; QJD25586.1; -; Genomic_RNA.
+DR   EMBL; MT371024; QJD25597.1; -; Genomic_RNA.
+DR   EMBL; MT371025; QJD25610.1; -; Genomic_RNA.
+DR   EMBL; MT371026; QJD25622.1; -; Genomic_RNA.
+DR   EMBL; MT371027; QJD25634.1; -; Genomic_RNA.
+DR   EMBL; MT371028; QJD25646.1; -; Genomic_RNA.
+DR   EMBL; MT371029; QJD25658.1; -; Genomic_RNA.
+DR   EMBL; MT371030; QJD25670.1; -; Genomic_RNA.
+DR   EMBL; MT371031; QJD25680.1; -; Genomic_RNA.
+DR   EMBL; MT371032; QJD25694.1; -; Genomic_RNA.
+DR   EMBL; MT371033; QJD25706.1; -; Genomic_RNA.
+DR   EMBL; MT371034; QJD25718.1; -; Genomic_RNA.
+DR   EMBL; MT371035; QJD25730.1; -; Genomic_RNA.
+DR   EMBL; MT371036; QJD25742.1; -; Genomic_RNA.
+DR   EMBL; MT371037; QJD25754.1; -; Genomic_RNA.
+DR   EMBL; MT371038; QJD25766.1; -; Genomic_RNA.
+DR   RefSeq; YP_009725255.1; NC_045512.2.
+DR   BioGRID; 4383867; 9.
+DR   IntAct; A0A663DJA2; 29.
+DR   GeneID; 43740576; -.
+DR   Proteomes; UP000464024; Genome.
+PE   4: Predicted;
+KW   Reference proteome {ECO:0000313|Proteomes:UP000464024}.
+SQ   SEQUENCE   38 AA;  4449 MW;  AE48AE9E0598073C CRC64;
+     MGYINVFAFP FTIYSLLLCR MNSRNYIAQV DVVNFNLT
+//


### PR DESCRIPTION
Optimise the `getDigit` method, and `isInNotWrapped` method's data structure (`Map<String, Set<Integer>> notWrapped`).

Time to write A0A663DJA2 gone from 83 seconds -> 1 second.

Also (first parsed then) used FF writer to write all of swiss-prot using old and new ways, and they are the same.