### PR TITLE
for uniprotkb entries with UNKNOWN feature positions

### DIFF
--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/UniprotKBJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/UniprotKBJsonConfig.java
@@ -259,5 +259,6 @@ public class UniprotKBJsonConfig extends JsonConfig {
         prettyWriterModule.addSerializer(
                 FeatureDescriptionImpl.class, new FeatureDescriptionSerializer());
         prettyWriterModule.addSerializer(FeatureIdImpl.class, new FeatureIdSerializer());
+        prettyWriterModule.addSerializer(Position.class, new PositionSerializer());
     }
 }

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/PositionSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/PositionSerializer.java
@@ -1,0 +1,37 @@
+package org.uniprot.core.json.parser.uniprot.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.uniprot.core.Position;
+import org.uniprot.core.PositionModifier;
+
+import java.io.IOException;
+
+/**
+ * Created 04/11/2020
+ *
+ * @author Edd
+ */
+public class PositionSerializer extends StdSerializer<Position> {
+
+    public PositionSerializer() {
+        super(Position.class);
+    }
+
+    @Override
+    public void serialize(
+            Position position, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+        jsonGenerator.writeStartObject();
+        String valueFieldName = "value";
+        PositionModifier modifier = position.getModifier();
+        if (modifier == PositionModifier.UNKNOWN) {
+            jsonGenerator.writeNullField(valueFieldName);
+        } else {
+            jsonGenerator.writeObjectField(valueFieldName, position.getValue());
+        }
+        jsonGenerator.writeObjectField("modifier", modifier);
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/PositionSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/PositionSerializer.java
@@ -1,12 +1,13 @@
 package org.uniprot.core.json.parser.uniprot.serializer;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
 import org.uniprot.core.Position;
 import org.uniprot.core.PositionModifier;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 /**
  * Created 04/11/2020


### PR DESCRIPTION
As requested, only for the JSON format. Do not show feature positions as -1, but instead as null.