### PR TITLE
add seedId to UniRefEntry

### DIFF
--- a/core-domain/src/main/java/org/uniprot/core/uniref/UniRefEntry.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/UniRefEntry.java
@@ -23,6 +23,8 @@ public interface UniRefEntry extends Serializable {
 
     String getCommonTaxon();
 
+    String getSeedId();
+
     List<GeneOntologyEntry> getGoTerms();
 
     RepresentativeMember getRepresentativeMember();

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryBuilder.java
@@ -27,6 +27,7 @@ public class UniRefEntryBuilder implements Builder<UniRefEntry> {
     private UniRefType entryType;
     private Long commonTaxonId;
     private String commonTaxon;
+    private String seedId;
     private List<GeneOntologyEntry> goTerms = new ArrayList<>();
     private RepresentativeMember representativeMember;
     private List<UniRefMember> members = new ArrayList<>();
@@ -41,6 +42,7 @@ public class UniRefEntryBuilder implements Builder<UniRefEntry> {
                 entryType,
                 commonTaxonId,
                 commonTaxon,
+                seedId,
                 goTerms,
                 representativeMember,
                 members);
@@ -54,6 +56,7 @@ public class UniRefEntryBuilder implements Builder<UniRefEntry> {
                 .entryType(instance.getEntryType())
                 .commonTaxonId(instance.getCommonTaxonId())
                 .commonTaxon(instance.getCommonTaxon())
+                .seedId(instance.getSeedId())
                 .goTermsSet(instance.getGoTerms())
                 .representativeMember(instance.getRepresentativeMember())
                 .membersSet(instance.getMembers());
@@ -91,6 +94,11 @@ public class UniRefEntryBuilder implements Builder<UniRefEntry> {
 
     public @Nonnull UniRefEntryBuilder commonTaxon(String commonTaxon) {
         this.commonTaxon = commonTaxon;
+        return this;
+    }
+
+    public @Nonnull UniRefEntryBuilder seedId(String seedId) {
+        this.seedId = seedId;
         return this;
     }
 

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryImpl.java
@@ -26,13 +26,14 @@ public class UniRefEntryImpl implements UniRefEntry {
     private final UniRefType entryType;
     private final Long commonTaxonId;
     private final String commonTaxon;
+    private final String seedId;
     private final List<GeneOntologyEntry> goTerms;
     private final RepresentativeMember representativeMember;
     private final List<UniRefMember> members;
 
     // no arg constructor for JSON deserialization
     UniRefEntryImpl() {
-        this(null, null, null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null, null, null);
     }
 
     UniRefEntryImpl(
@@ -43,6 +44,7 @@ public class UniRefEntryImpl implements UniRefEntry {
             UniRefType entryType,
             Long commonTaxonId,
             String commonTaxon,
+            String seedId,
             List<GeneOntologyEntry> goTerms,
             RepresentativeMember representativeMember,
             List<UniRefMember> members) {
@@ -52,6 +54,7 @@ public class UniRefEntryImpl implements UniRefEntry {
         this.entryType = entryType;
         this.commonTaxonId = commonTaxonId;
         this.commonTaxon = commonTaxon;
+        this.seedId = seedId;
         this.goTerms = Utils.unmodifiableList(goTerms);
         this.representativeMember = representativeMember;
         this.members = Utils.unmodifiableList(members);
@@ -89,6 +92,11 @@ public class UniRefEntryImpl implements UniRefEntry {
     }
 
     @Override
+    public String getSeedId() {
+        return seedId;
+    }
+
+    @Override
     public List<GeneOntologyEntry> getGoTerms() {
         return goTerms;
     }
@@ -112,6 +120,7 @@ public class UniRefEntryImpl implements UniRefEntry {
                 entryType,
                 commonTaxonId,
                 commonTaxon,
+                seedId,
                 goTerms,
                 representativeMember,
                 members,
@@ -131,6 +140,7 @@ public class UniRefEntryImpl implements UniRefEntry {
                 && Objects.equals(entryType, other.entryType)
                 && Objects.equals(commonTaxonId, other.commonTaxonId)
                 && Objects.equals(commonTaxon, other.commonTaxon)
+                && Objects.equals(seedId, other.seedId)
                 && Objects.equals(goTerms, other.goTerms)
                 && Objects.equals(representativeMember, other.representativeMember)
                 && Objects.equals(members, other.members);

--- a/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryBuilderTest.java
@@ -43,6 +43,7 @@ class UniRefEntryBuilderTest {
                         .updated(LocalDate.now())
                         .entryType(type)
                         .commonTaxonId(9606L)
+                        .seedId("seedId")
                         .commonTaxon("Homo sapiens")
                         .representativeMember(member)
                         .build();
@@ -91,6 +92,14 @@ class UniRefEntryBuilderTest {
 
         UniRefEntry entry = new UniRefEntryBuilder().commonTaxon(commonTax).build();
         assertEquals(commonTax, entry.getCommonTaxon());
+    }
+
+    @Test
+    void testSeedId() {
+        String seedId = "P21802";
+
+        UniRefEntry entry = new UniRefEntryBuilder().seedId(seedId).build();
+        assertEquals(seedId, entry.getSeedId());
     }
 
     @Test

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
@@ -9,8 +9,7 @@ import org.uniprot.core.uniref.UniRefEntryLight;
  */
 public class UniRefFastaParser {
 
-    private UniRefFastaParser(){
-    }
+    private UniRefFastaParser() {}
 
     public static String toFasta(UniRefEntryLight entry) {
         StringBuilder sb = new StringBuilder();

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
@@ -8,6 +8,10 @@ import org.uniprot.core.uniref.UniRefEntryLight;
  * @date: 22 Aug 2019
  */
 public class UniRefFastaParser {
+
+    private UniRefFastaParser(){
+    }
+
     public static String toFasta(UniRefEntryLight entry) {
         StringBuilder sb = new StringBuilder();
         sb.append(getHeader(entry)).append("\n");
@@ -53,8 +57,12 @@ public class UniRefFastaParser {
                     .append(" TaxID=")
                     .append(entry.getCommonTaxonId());
         }
-        sb.append(" RepID=").append(entry.getRepresentativeId());
+        sb.append(" RepID=").append(getRepresentativeId(entry));
         return sb.toString();
+    }
+
+    private static String getRepresentativeId(UniRefEntryLight entry) {
+        return entry.getRepresentativeId().split(",")[0];
     }
 
     private static String getHeader(UniRefEntry entry) {

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
@@ -54,7 +54,7 @@ class UniRefFastaParserTest {
         UniRefEntryLight entry = createEntryLight();
         String fasta = UniRefFastaParser.toFasta(entry);
         String expected =
-                ">UniRef50_P03923 protein n=3 Tax=tax TaxID=8 RepID=representativeId\n"
+                ">UniRef50_P03923 protein n=3 Tax=tax TaxID=8 RepID=P03923_HUMAN\n"
                         + "MVSWGRFICLVVVTMATLSLARPSFSLVEDDFSAGSADFAFWERDGDSDGFDSHSDJHET\n"
                         + "RHJREH";
         assertEquals(expected, fasta);
@@ -69,7 +69,7 @@ class UniRefFastaParserTest {
         String fasta = UniRefFastaParser.toFasta(entry2);
 
         String expected =
-                ">UniRef50_P03923 protein n=3 RepID=representativeId\n"
+                ">UniRef50_P03923 protein n=3 RepID=P03923_HUMAN\n"
                         + "MVSWGRFICLVVVTMATLSLARPSFSLVEDDFSAGSADFAFWERDGDSDGFDSHSDJHET\n"
                         + "RHJREH";
         assertEquals(expected, fasta);
@@ -80,7 +80,7 @@ class UniRefFastaParserTest {
         return new UniRefEntryLightBuilder()
                 .id("UniRef50_P03923")
                 .name("Cluster: protein")
-                .representativeId("representativeId")
+                .representativeId("P03923_HUMAN,P03923")
                 .sequence(entry.getRepresentativeMember().getSequence().getValue())
                 .organismsSet(new LinkedHashSet<>(asList("organism1", "organism2")))
                 .organismIdsSet(new LinkedHashSet<>(asList(1L, 2L)))

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfig.java
@@ -9,6 +9,7 @@ import org.uniprot.core.impl.ValueImpl;
 import org.uniprot.core.json.parser.JsonConfig;
 import org.uniprot.core.json.parser.deserializer.LocalDateDeserializer;
 import org.uniprot.core.json.parser.serializer.LocalDateSerializer;
+import org.uniprot.core.json.parser.uniref.serialiser.UniRefEntryLightSerialiser;
 import org.uniprot.core.uniref.*;
 import org.uniprot.core.uniref.impl.*;
 
@@ -66,8 +67,8 @@ public class UniRefEntryLightJsonConfig extends JsonConfig {
     private ObjectMapper initPrettyObjectMapper() {
         ObjectMapper prettyObjMapper = getDefaultSimpleObjectMapper();
         SimpleModule simpleMod = new SimpleModule();
+        simpleMod.addSerializer(UniRefEntryLightImpl.class, new UniRefEntryLightSerialiser());
         simpleMod.addSerializer(LocalDate.class, new LocalDateSerializer());
-
         simpleMod.addSerializer(UniRefEntryIdImpl.class, new UniRefEntryIdSerializer());
         prettyObjMapper.registerModule(simpleMod);
         return prettyObjMapper;

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/serialiser/UniRefEntryLightSerialiser.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/serialiser/UniRefEntryLightSerialiser.java
@@ -1,5 +1,11 @@
 package org.uniprot.core.json.parser.uniref.serialiser;
 
+import java.io.IOException;
+
+import org.uniprot.core.uniref.UniRefEntryLight;
+import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
+import org.uniprot.core.uniref.impl.UniRefEntryLightImpl;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
@@ -7,11 +13,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import org.uniprot.core.uniref.UniRefEntryLight;
-import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
-import org.uniprot.core.uniref.impl.UniRefEntryLightImpl;
-
-import java.io.IOException;
 
 /**
  * @author lgonzales
@@ -26,29 +27,32 @@ public class UniRefEntryLightSerialiser extends StdSerializer<UniRefEntryLightIm
     }
 
     @Override
-    public void serialize(UniRefEntryLightImpl value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        value = (UniRefEntryLightImpl) UniRefEntryLightBuilder.from(value)
-                .representativeId(getRepresentativeId(value))
-                .seedId(getSeedId(value))
-                .build();
+    public void serialize(
+            UniRefEntryLightImpl value, JsonGenerator jgen, SerializerProvider provider)
+            throws IOException {
+        value =
+                (UniRefEntryLightImpl)
+                        UniRefEntryLightBuilder.from(value)
+                                .representativeId(getRepresentativeId(value))
+                                .seedId(getSeedId(value))
+                                .build();
 
         jgen.writeStartObject();
         JavaType javaType = provider.constructType(UniRefEntryLightImpl.class);
         BeanDescription beanDesc = provider.getConfig().introspect(javaType);
-        JsonSerializer<Object> serializer = BeanSerializerFactory.instance.findBeanSerializer(provider,
-                javaType,
-                beanDesc);
+        JsonSerializer<Object> serializer =
+                BeanSerializerFactory.instance.findBeanSerializer(provider, javaType, beanDesc);
         serializer.unwrappingSerializer(null).serialize(value, jgen, provider);
         jgen.writeEndObject();
     }
 
     private String getSeedId(UniRefEntryLight entry) {
         String[] splitSeedId = entry.getSeedId().split(",");
-        return splitSeedId[splitSeedId.length -1];
+        return splitSeedId[splitSeedId.length - 1];
     }
 
     private String getRepresentativeId(UniRefEntryLight entry) {
         String[] splitRepId = entry.getRepresentativeId().split(",");
-        return splitRepId[splitRepId.length -1];
+        return splitRepId[splitRepId.length - 1];
     }
 }

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/serialiser/UniRefEntryLightSerialiser.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/serialiser/UniRefEntryLightSerialiser.java
@@ -1,0 +1,54 @@
+package org.uniprot.core.json.parser.uniref.serialiser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.uniprot.core.uniref.UniRefEntryLight;
+import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
+import org.uniprot.core.uniref.impl.UniRefEntryLightImpl;
+
+import java.io.IOException;
+
+/**
+ * @author lgonzales
+ * @since 06/11/2020
+ */
+public class UniRefEntryLightSerialiser extends StdSerializer<UniRefEntryLightImpl> {
+
+    private static final long serialVersionUID = 3723472187349283896L;
+
+    public UniRefEntryLightSerialiser() {
+        super(UniRefEntryLightImpl.class);
+    }
+
+    @Override
+    public void serialize(UniRefEntryLightImpl value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        value = (UniRefEntryLightImpl) UniRefEntryLightBuilder.from(value)
+                .representativeId(getRepresentativeId(value))
+                .seedId(getSeedId(value))
+                .build();
+
+        jgen.writeStartObject();
+        JavaType javaType = provider.constructType(UniRefEntryLightImpl.class);
+        BeanDescription beanDesc = provider.getConfig().introspect(javaType);
+        JsonSerializer<Object> serializer = BeanSerializerFactory.instance.findBeanSerializer(provider,
+                javaType,
+                beanDesc);
+        serializer.unwrappingSerializer(null).serialize(value, jgen, provider);
+        jgen.writeEndObject();
+    }
+
+    private String getSeedId(UniRefEntryLight entry) {
+        String[] splitSeedId = entry.getSeedId().split(",");
+        return splitSeedId[splitSeedId.length -1];
+    }
+
+    private String getRepresentativeId(UniRefEntryLight entry) {
+        String[] splitRepId = entry.getRepresentativeId().split(",");
+        return splitRepId[splitRepId.length -1];
+    }
+}

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
@@ -1,8 +1,5 @@
 package org.uniprot.core.json.parser.uniref;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +12,8 @@ import org.uniprot.core.uniref.UniRefType;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author lgonzales
@@ -66,6 +65,8 @@ class UniRefEntryLightJsonConfigTest {
             String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(entry);
             // uncomment the code to generate samplejson for UniRefEntryLight model.
             assertNotNull(json);
+            assertTrue(json.contains("\"representativeId\" : \"P12345\""));
+            assertTrue(json.contains("\"seedId\" : \"P12345\""));
             // System.out.println(json);
         } catch (Exception e) {
             fail(e.getMessage());
@@ -79,7 +80,7 @@ class UniRefEntryLightJsonConfigTest {
                 .organismsAdd("Human")
                 .organismIdsAdd(9606L)
                 .memberIdTypesAdd(UniRefMemberIdType.UNIPARC)
-                .representativeId("id")
+                .representativeId("P12345_HUMAN,P12345")
                 .name("Cluster: protein")
                 .sequence("AAAAA")
                 .updated(LocalDate.now())
@@ -87,7 +88,7 @@ class UniRefEntryLightJsonConfigTest {
                 .commonTaxonId(10116L)
                 .entryType(UniRefType.UniRef50)
                 .memberCount(5)
-                .seedId("P12345")
+                .seedId("P12345_HUMAN,P12345")
                 .goTermsAdd(
                         new GeneOntologyEntryBuilder()
                                 .id("GO1")

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
@@ -1,5 +1,7 @@
 package org.uniprot.core.json.parser.uniref;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
@@ -12,8 +14,6 @@ import org.uniprot.core.uniref.UniRefType;
 import org.uniprot.core.uniref.impl.UniRefEntryLightBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author lgonzales

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
@@ -56,13 +56,15 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
 
     private String getRepresentativeId(MemberType memberType) {
         String representativeId = memberType.getDbReference().getId();
-        Optional<String> accession = memberType.getDbReference().getProperty()
-                .stream()
-                .filter(propertyType -> propertyType.getType().equals(PROPERTY_UNIPROT_ACCESSION))
-                .map(PropertyType::getValue)
-                .findFirst();
-        if(accession.isPresent()){
-            representativeId += ","+accession.get();
+        Optional<String> accession =
+                memberType.getDbReference().getProperty().stream()
+                        .filter(
+                                propertyType ->
+                                        propertyType.getType().equals(PROPERTY_UNIPROT_ACCESSION))
+                        .map(PropertyType::getValue)
+                        .findFirst();
+        if (accession.isPresent()) {
+            representativeId += "," + accession.get();
         }
         return representativeId;
     }
@@ -152,9 +154,9 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
             builder.membersAdd(accession + "," + idType.getMemberIdTypeId());
             builder.memberIdTypesAdd(idType);
         }
-        if(seedId != null){
-            if(accession != null){
-                seedId += ","+accession;
+        if (seedId != null) {
+            if (accession != null) {
+                seedId += "," + accession;
             }
             builder.seedId(seedId);
         }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
@@ -4,6 +4,7 @@ import static org.uniprot.core.uniref.UniRefUtils.getUniProtKBIdType;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.uniprot.core.cv.go.GeneOntologyEntry;
 import org.uniprot.core.cv.go.GoAspect;
@@ -44,13 +45,26 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
                 .name(xmlObj.getName())
                 .updated(XmlConverterHelper.dateFromXml(xmlObj.getUpdated()))
                 .sequence(xmlObj.getRepresentativeMember().getSequence().getValue())
-                .representativeId(xmlObj.getRepresentativeMember().getDbReference().getId());
+                .representativeId(getRepresentativeId(xmlObj.getRepresentativeMember()));
 
         updateMemberValuesFromXml(
                 builder, Collections.singletonList(xmlObj.getRepresentativeMember()));
         updateCommonPropertiesFromXml(builder, xmlObj);
         updateMemberValuesFromXml(builder, xmlObj.getMember());
         return builder.build();
+    }
+
+    private String getRepresentativeId(MemberType memberType) {
+        String representativeId = memberType.getDbReference().getId();
+        Optional<String> accession = memberType.getDbReference().getProperty()
+                .stream()
+                .filter(propertyType -> propertyType.getType().equals(PROPERTY_UNIPROT_ACCESSION))
+                .map(PropertyType::getValue)
+                .findFirst();
+        if(accession.isPresent()){
+            representativeId += ","+accession.get();
+        }
+        return representativeId;
     }
 
     private void updateMemberValuesFromXml(
@@ -110,6 +124,7 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
     private void updateMemberPropertiesFromXml(
             UniRefEntryLightBuilder builder, List<PropertyType> properties, String id) {
         String accession = null;
+        String seedId = null;
         for (PropertyType property : properties) {
             switch (property.getType()) {
                 case PROPERTY_SOURCE_ORGANISM:
@@ -125,7 +140,7 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
                     break;
                 case PROPERTY_IS_SEED:
                     if (Boolean.parseBoolean(property.getValue())) {
-                        builder.seedId(id);
+                        seedId = id;
                     }
                     break;
                 default:
@@ -136,6 +151,12 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
             UniRefMemberIdType idType = getUniProtKBIdType(id, accession);
             builder.membersAdd(accession + "," + idType.getMemberIdTypeId());
             builder.memberIdTypesAdd(idType);
+        }
+        if(seedId != null){
+            if(accession != null){
+                seedId += ","+accession;
+            }
+            builder.seedId(seedId);
         }
     }
 

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
@@ -23,7 +23,7 @@ import org.uniprot.core.xml.jaxb.uniref.Entry;
 class UniRefEntryLightConverterTest {
 
     @Test
-    void testFromXml() throws Exception {
+    void testFromXml() {
         UniRefEntryLightConverter converter = new UniRefEntryLightConverter();
         String file = "/uniref/50_Q9EPS7_Q95604.xml";
         InputStream is = UniRefEntryLightConverterTest.class.getResourceAsStream(file);
@@ -42,7 +42,7 @@ class UniRefEntryLightConverterTest {
         UniRefEntryLight entry = converter.fromXml(xmlEntry);
         assertNotNull(entry);
         assertNotNull(entry.getId());
-        assertEquals("Q9EPS7_MOUSE", entry.getRepresentativeId());
+        assertEquals("Q9EPS7_MOUSE,Q9EPS7", entry.getRepresentativeId());
         assertEquals("UniRef50_Q9EPS7", entry.getId().getValue());
         assertEquals("Cluster: Pheromone receptor V3R6", entry.getName());
         assertEquals("Pheromone receptor V3R6", entry.getRepresentativeProteinName());
@@ -50,7 +50,7 @@ class UniRefEntryLightConverterTest {
         assertEquals(UniRefType.UniRef50, entry.getEntryType());
         assertEquals("Muroidea", entry.getCommonTaxon());
         assertEquals(337687, entry.getCommonTaxonId());
-        assertEquals("F6MB03_MOUSE", entry.getSeedId());
+        assertEquals("F6MB03_MOUSE,F6MB03", entry.getSeedId());
 
         assertEquals(3, entry.getGoTerms().size());
         GeneOntologyEntry goTerm = entry.getGoTerms().get(0);
@@ -73,7 +73,45 @@ class UniRefEntryLightConverterTest {
     }
 
     @Test
-    void testFromXmlInvalidId() throws Exception {
+    void testFromXmlWithUniParcRepresentativeAndSeed() {
+        UniRefEntryLightConverter converter = new UniRefEntryLightConverter();
+        String file = "/uniref/UniRef100_UPI0009BFC4AC.xml";
+        InputStream is = UniRefEntryLightConverterTest.class.getResourceAsStream(file);
+
+        assertNotNull(is);
+
+        List<InputStream> iss = Collections.singletonList(is);
+
+        XmlChainIterator<Entry, Entry> chainingIterators =
+                new XmlChainIterator<>(
+                        iss.iterator(), Entry.class, UNIREF_ROOT_ELEMENT, Function.identity());
+        assertNotNull(chainingIterators);
+        assertTrue(chainingIterators.hasNext());
+        Entry xmlEntry = chainingIterators.next();
+        assertNotNull(xmlEntry);
+        UniRefEntryLight entry = converter.fromXml(xmlEntry);
+        assertNotNull(entry);
+        assertNotNull(entry.getId());
+        assertEquals("UniRef100_UPI0009BFC4AC", entry.getId().getValue());
+        assertEquals("UPI0009BFC4AC", entry.getRepresentativeId());
+        assertEquals("Cluster: NAD-dependent epimerase/dehydratase family protein", entry.getName());
+        assertEquals("NAD-dependent epimerase/dehydratase family protein", entry.getRepresentativeProteinName());
+        assertEquals("2018-09-12", entry.getUpdated().toString());
+        assertEquals(UniRefType.UniRef100, entry.getEntryType());
+        assertEquals("Streptomyces viridosporus", entry.getCommonTaxon());
+        assertEquals(67581, entry.getCommonTaxonId());
+        assertEquals("UPI0009BFC4AC", entry.getSeedId());
+
+        assertTrue(entry.getGoTerms().isEmpty());
+
+        assertTrue(entry.getMembers().contains("UPI0009BFC4AC,3"));
+
+        assertEquals(entry.getMemberCount(), entry.getMembers().size());
+        assertFalse(chainingIterators.hasNext());
+    }
+
+    @Test
+    void testFromXmlInvalidId() {
         Entry xmlEntry = new Entry();
         xmlEntry.setId("INVALID");
         UniRefEntryLightConverter converter = new UniRefEntryLightConverter();

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
@@ -94,8 +94,11 @@ class UniRefEntryLightConverterTest {
         assertNotNull(entry.getId());
         assertEquals("UniRef100_UPI0009BFC4AC", entry.getId().getValue());
         assertEquals("UPI0009BFC4AC", entry.getRepresentativeId());
-        assertEquals("Cluster: NAD-dependent epimerase/dehydratase family protein", entry.getName());
-        assertEquals("NAD-dependent epimerase/dehydratase family protein", entry.getRepresentativeProteinName());
+        assertEquals(
+                "Cluster: NAD-dependent epimerase/dehydratase family protein", entry.getName());
+        assertEquals(
+                "NAD-dependent epimerase/dehydratase family protein",
+                entry.getRepresentativeProteinName());
         assertEquals("2018-09-12", entry.getUpdated().toString());
         assertEquals(UniRefType.UniRef100, entry.getEntryType());
         assertEquals("Streptomyces viridosporus", entry.getCommonTaxon());

--- a/xml-parser/src/test/resources/uniref/UniRef100_UPI0009BFC4AC.xml
+++ b/xml-parser/src/test/resources/uniref/UniRef100_UPI0009BFC4AC.xml
@@ -1,0 +1,20 @@
+<UniRef xmlns="http://uniprot.org/uniref" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://uniprot.org/uniref http://www.uniprot.org/docs/uniref.xsd" version="2020_05" releaseDate="2020-10-07">
+    <entry id="UniRef100_UPI0009BFC4AC" updated="2018-09-12">
+        <name>Cluster: NAD-dependent epimerase/dehydratase family protein</name>
+        <property type="member count" value="1"/>
+        <property type="common taxon" value="Streptomyces viridosporus"/>
+        <property type="common taxon ID" value="67581"/>
+        <representativeMember>
+            <dbReference type="UniParc ID" id="UPI0009BFC4AC">
+                <property type="UniRef90 ID" value="UniRef90_A0A003"/>
+                <property type="UniRef50 ID" value="UniRef50_A0A1A9J849"/>
+                <property type="protein name" value="NAD-dependent epimerase/dehydratase family protein"/>
+                <property type="source organism" value="Streptomyces viridosporus"/>
+                <property type="NCBI taxonomy" value="67581"/>
+                <property type="length" value="325"/>
+                <property type="isSeed" value="true"/>
+            </dbReference>
+            <sequence length="325" checksum="2D399FDEAF652EA2">MVTGAAGFIGSHLVTELRNSGRNVVAVDRRPLPDDPGSTSPPFTGSLREIRGDLNALNLVDRLKNISTVFHLAALPGVRPSWTQFPEYLRCNVLATQRLMEACVQAGVERVVVASSSSVYGGADGVMSEDDLPRPLSPYGVTKLAAERLALAFAARGDAELSVGALRFFTVYGPGQRPDMFISRLIRATLRGEPIEIYGDGTQLRDFTHVSDVVRALLLTASVRDRDSAVLNIGTGSAVSVNEVVSMTAELTGLRPCTAYGSARIGDVRSTTADVRQARNVLGFTARTGLREGLATQIEWTRRSLSGAEQDTVPVGGSSVSVPRL</sequence>
+        </representativeMember>
+    </entry>
+</UniRef>


### PR DESCRIPTION
- Add seedId to UniRefEntry. The seedId is storing UniprotKB accession or UniParcId if the member type is UniParc.
- Update seedId and ReferenceId values in UniRefEntryLight to accession, to make it consistent with seedId in UniRefEntry.

The idea is that we display accession for seedId in both entities (UniRefEntry and UniRefEntryLight) 