### PR TITLE
Fix parse xml subcelllocation middle name issue

### DIFF
--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/antlr/CcLineSubCellCommentParserTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/antlr/CcLineSubCellCommentParserTest.java
@@ -285,6 +285,19 @@ class CcLineSubCellCommentParserTest {
         // LocationFlagEnum.By_similarity );
 
     }
+    @Test
+    void testWithComma() {
+    	String lines ="CC   -!- SUBCELLULAR LOCATION: Cell junction, adherens junction.\n";
+    	 UniprotKBLineParser<CcLineObject> parser =
+                 new DefaultUniprotKBLineParserFactory().createCcLineParser();
+         CcLineObject obj = parser.parse(lines);
+         assertEquals(1, obj.getCcs().size());
+         CC cc = obj.getCcs().get(0);
+         assertTrue(cc.getObject() instanceof SubcullarLocation);
+         SubcullarLocation sl = (SubcullarLocation) cc.getObject();
+         assertEquals(1, sl.getLocations().size());
+         assertEquals("Cell junction, adherens junction", sl.getLocations().get(0).getSubcellularLocation().getValue());
+    }
 
     @Test
     void testSublocatWithEvidence() {

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMap.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMap.java
@@ -1,0 +1,54 @@
+package org.uniprot.core.xml.uniprot.comment;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.uniprot.core.cv.subcell.SubcellularLocationEntry;
+import org.uniprot.core.util.Utils;
+import org.uniprot.cv.subcell.SubcellularLocationFileReader;
+
+/**
+ *
+ * @author jluo
+ * @date: 19-Nov-2020
+ * Create This map is used by SLCCommentConverter, use enum is not ideal. However, CommentConverter is called by entry converter,
+ *  each time, when we need to convert an entry, we create entry converter. We don't want to the map each time when we create a converter.
+ *  Maybe there is a better solution.
+ *  
+ */
+
+public enum SubcellLocationNameMap implements Serializable {
+	instance;
+
+	private static final long serialVersionUID = -9031742801112342533L;
+	private Map<String, String> subcellularLocationMap = new HashMap<>();
+	private static final String DEFAULT_FILE = "ftp://ftp.uniprot.org/pub/databases/uniprot/knowledgebase/docs/subcell.txt";
+
+	SubcellLocationNameMap() {
+		loadSubcellularLocationMap(DEFAULT_FILE);
+	}
+
+	public String getLocationName(String name) {
+		return subcellularLocationMap.getOrDefault(name.toLowerCase(), name);
+	}
+
+	public Map<String, String> getNameMap() {
+		return subcellularLocationMap;
+	}
+
+	private void loadSubcellularLocationMap(String filename) {
+		if (Utils.notNullNotEmpty(filename)) {
+			List<SubcellularLocationEntry> entries = new SubcellularLocationFileReader().parse(filename);
+			subcellularLocationMap = entries.stream()
+					.collect(Collectors.toMap(this::getLowercaseContent, SubcellularLocationEntry::getContent));
+		
+		}
+	}
+
+	private String getLowercaseContent(SubcellularLocationEntry entry) {
+		return entry.getContent().toLowerCase();
+	}
+}

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
@@ -21,7 +21,6 @@ public class SubcellularLocationConverter
     private static final Pattern COMMA = Pattern.compile(",");
     private final ObjectFactory xmlUniprotFactory;
     private final EvidenceIndexMapper evRefMapper;
-
     public SubcellularLocationConverter(EvidenceIndexMapper evRefMapper) {
         this(evRefMapper, new ObjectFactory());
     }
@@ -80,7 +79,12 @@ public class SubcellularLocationConverter
             isFirst = false;
             sb.append(val);
         }
-        return sb.toString();
+        String name= sb.toString();
+        if(values.size()>1) {
+        	return SubcellLocationNameMap.instance.getLocationName(name);
+        }else {
+        	return name;
+        }
         // Map<EvidencedStringType, String> map = transferCase(values);
         // return values.stream().map(val ->
         // val.getValue()).collect(Collectors.joining(", "));

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
@@ -85,9 +85,6 @@ public class SubcellularLocationConverter
         }else {
         	return name;
         }
-        // Map<EvidencedStringType, String> map = transferCase(values);
-        // return values.stream().map(val ->
-        // val.getValue()).collect(Collectors.joining(", "));
     }
 
     private String lowerCaseFirstLetter(String val) {

--- a/xml-parser/src/main/java/org/uniprot/core/xml/unirule/CommentConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/unirule/CommentConverter.java
@@ -8,6 +8,7 @@ import org.uniprot.core.xml.jaxb.uniprot.CommentType;
 import org.uniprot.core.xml.jaxb.uniprot.ObjectFactory;
 import org.uniprot.core.xml.uniprot.EvidenceIndexMapper;
 import org.uniprot.core.xml.uniprot.comment.CommentConverterFactory;
+import org.uniprot.core.xml.uniprot.comment.SubcellLocationNameMap;
 
 public class CommentConverter implements Converter<CommentType, Comment> {
     private final EvidenceIndexMapper evidenceIndexMapper;
@@ -16,6 +17,7 @@ public class CommentConverter implements Converter<CommentType, Comment> {
     public CommentConverter() {
         this.evidenceIndexMapper = new EvidenceIndexMapper();
         this.xmlUniprotFactory = new ObjectFactory();
+     
     }
 
     @Override
@@ -26,7 +28,7 @@ public class CommentConverter implements Converter<CommentType, Comment> {
                 org.uniprot.core.uniprotkb.comment.CommentType.typeOf(xmlObj.getType());
         Comment comment =
                 CommentConverterFactory.INSTANCE
-                        .createCommentConverter(type, evidenceIndexMapper, xmlUniprotFactory)
+                        .createCommentConverter(type, evidenceIndexMapper, xmlUniprotFactory )
                         .fromXml(xmlObj);
 
         return comment;

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SCLCommentConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SCLCommentConverterTest.java
@@ -69,7 +69,34 @@ class SCLCommentConverterTest {
         SubcellularLocationComment converted = converter.fromXml(xmlComment);
         assertEquals(comment, converted);
     }
-
+    @Test
+    void middlenameWithCapitalLetter() {
+        SubcellularLocationValue location =
+                create(
+                        "Golgi apparatus, Golgi stack",
+                        Arrays.asList(
+                                "ECO:0000256|PIRNR:PIRNR037393"));
+        SubcellularLocation subcelLocation =
+                createSubcellularLocation(location, null, null);
+        List<SubcellularLocation> subcelLocations = new ArrayList<>();
+        subcelLocations.add(subcelLocation);
+        SubcellularLocationValue location2 = create("Nucleus, Cajal body", Arrays.asList("ECO:0000250"));
+        SubcellularLocation subcelLocation2 = createSubcellularLocation(location2, null, null);
+        subcelLocations.add(subcelLocation2);
+        SubcellularLocationCommentBuilder builder = new SubcellularLocationCommentBuilder();
+        builder.molecule("Some mol")
+                .subcellularLocationsSet(subcelLocations);
+        SubcellularLocationComment comment = builder.build();
+        SCLCommentConverter converter = new SCLCommentConverter(new EvidenceIndexMapper());
+        CommentType xmlComment = converter.toXml(comment);
+        System.out.println(
+                UniProtXmlTestHelper.toXmlString(xmlComment, CommentType.class, "comment"));
+        SubcellularLocationComment converted = converter.fromXml(xmlComment);
+        assertEquals(comment, converted);
+        
+    }
+    
+    
     private SubcellularLocation createSubcellularLocation(
             SubcellularLocationValue location,
             SubcellularLocationValue topology,

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMapTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMapTest.java
@@ -1,0 +1,31 @@
+package org.uniprot.core.xml.uniprot.comment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ * @author jluo
+ * @date: 20-Nov-2020
+ *
+*/
+
+class SubcellLocationNameMapTest {
+
+	@Test
+	void middleNameStartWithCapital() {
+		 String name ="Golgi apparatus, golgi stack lumen";
+		 String validName = SubcellLocationNameMap.instance.getLocationName(name);
+		 assertEquals("Golgi apparatus, Golgi stack lumen", validName);
+		
+	}
+	@Test
+	void normalMiddleName() {		
+		String name ="Cell projection, attachment organelle membrane";
+		 String validName = SubcellLocationNameMap.instance.getLocationName(name);
+		 assertEquals(name, validName);
+	}
+	
+}
+


### PR DESCRIPTION
when subcell location name formed by two or more names. It separated by comma
Secreted, extracellular space, apoplast
Normally, in flatfile the  first letter of the first word of the first name is capital, other name do not capital the first letter of the first word.
In xml, all the names will be split. and the first letter of the first word will be capital.

There are other cases, flatfile does not follow this rule, such as 
Nucleus, Cajal body
But flatfile will follow the rules defined in subcelllocation vocabulary file 
ftp://ftp.uniprot.org/pub/databases/uniprot/knowledgebase/docs/subcell.txt
this file hardly changes
