### PR TITLE
update UniRef

### DIFF
--- a/core-domain/src/main/java/org/uniprot/core/uniref/UniRefEntryLight.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/UniRefEntryLight.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.uniprot.core.cv.go.GeneOntologyEntry;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
 /**
  * Represents a "light-weight" {@link UniRefEntry}, containing less detailed information when
@@ -26,9 +27,7 @@ public interface UniRefEntryLight extends Serializable {
 
     UniRefType getEntryType();
 
-    long getCommonTaxonId();
-
-    String getCommonTaxon();
+    Organism getCommonTaxon();
 
     List<GeneOntologyEntry> getGoTerms();
 
@@ -36,9 +35,7 @@ public interface UniRefEntryLight extends Serializable {
 
     int getMemberCount();
 
-    LinkedHashSet<String> getOrganisms();
-
-    LinkedHashSet<Long> getOrganismIds();
+    LinkedHashSet<Organism> getOrganisms();
 
     int getOrganismCount();
 

--- a/core-domain/src/main/java/org/uniprot/core/uniref/UniRefUtils.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/UniRefUtils.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniref;
 
-import org.uniprot.core.uniprotkb.taxonomy.Organism;
-
 import java.util.Optional;
 import java.util.Set;
+
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
 /**
  * @author lgonzales

--- a/core-domain/src/main/java/org/uniprot/core/uniref/UniRefUtils.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/UniRefUtils.java
@@ -1,5 +1,7 @@
 package org.uniprot.core.uniref;
 
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,28 +31,34 @@ public class UniRefUtils {
         return type;
     }
 
-    public static void addOrganism(String organismValue, Set<String> organismTarget) {
-        // Add this logic do avoid duplicated organism names because
-        // UniParc organisms do not contains common name in brackets.
-        Optional<String> found =
+    public static void addOrganism(Organism newOrganism, Set<Organism> organismTarget) {
+        // Add this logic do avoid duplicated organism because
+        // UniParc organisms do not contain commonName.
+        Optional<Organism> foundInTarget =
                 organismTarget.stream()
-                        .map(UniRefUtils::getOrganismWithoutCommonName)
-                        .filter(
-                                value ->
-                                        value.equalsIgnoreCase(
-                                                getOrganismWithoutCommonName(organismValue)))
+                        .filter(value -> value.getTaxonId() == newOrganism.getTaxonId())
                         .findFirst();
-        if (!found.isPresent()) {
-            organismTarget.add(organismValue);
+        if (!foundInTarget.isPresent()) {
+            organismTarget.add(newOrganism);
         }
     }
 
-    public static String getOrganismWithoutCommonName(String value) {
+    public static String getOrganismScientificName(String value) {
         int bracketIndex = value.indexOf('(');
         if (bracketIndex >= 0) {
             return value.substring(0, bracketIndex).trim();
         } else {
             return value;
         }
+    }
+
+    public static String getOrganismCommonName(String value) {
+        String commonName = "";
+        int commonNameBegin = value.indexOf('(');
+        if (commonNameBegin >= 0) {
+            int commonNameEnd = value.indexOf(')');
+            return value.substring(commonNameBegin + 1, commonNameEnd).trim();
+        }
+        return commonName;
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightBuilder.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.Builder;
 import org.uniprot.core.cv.go.GeneOntologyEntry;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniref.*;
 import org.uniprot.core.util.Utils;
 
@@ -22,13 +23,11 @@ public class UniRefEntryLightBuilder implements Builder<UniRefEntryLight> {
     private String name;
     private LocalDate updated;
     private UniRefType entryType;
-    private long commonTaxonId;
-    private String commonTaxon;
+    private Organism commonTaxon;
     private String representativeId;
     private String sequence;
     private List<String> members = new ArrayList<>();
-    private LinkedHashSet<Long> organismIds = new LinkedHashSet<>();
-    private LinkedHashSet<String> organisms = new LinkedHashSet<>();
+    private LinkedHashSet<Organism> organisms = new LinkedHashSet<>();
     private Set<UniRefMemberIdType> memberIdTypes = new HashSet<>();
     private List<GeneOntologyEntry> goTerms = new ArrayList<>();
     private String seedId;
@@ -42,12 +41,10 @@ public class UniRefEntryLightBuilder implements Builder<UniRefEntryLight> {
                 name,
                 updated,
                 entryType,
-                commonTaxonId,
                 commonTaxon,
                 representativeId,
                 sequence,
                 members,
-                organismIds,
                 organisms,
                 memberCount,
                 organismCount,
@@ -62,12 +59,10 @@ public class UniRefEntryLightBuilder implements Builder<UniRefEntryLight> {
                 .name(instance.getName())
                 .updated(instance.getUpdated())
                 .entryType(instance.getEntryType())
-                .commonTaxonId(instance.getCommonTaxonId())
                 .commonTaxon(instance.getCommonTaxon())
                 .representativeId(instance.getRepresentativeId())
                 .sequence(instance.getSequence())
                 .membersSet(instance.getMembers())
-                .organismIdsSet(instance.getOrganismIds())
                 .organismsSet(instance.getOrganisms())
                 .memberCount(instance.getMemberCount())
                 .organismCount(instance.getOrganismCount())
@@ -101,12 +96,7 @@ public class UniRefEntryLightBuilder implements Builder<UniRefEntryLight> {
         return this;
     }
 
-    public @Nonnull UniRefEntryLightBuilder commonTaxonId(long commonTaxonId) {
-        this.commonTaxonId = commonTaxonId;
-        return this;
-    }
-
-    public @Nonnull UniRefEntryLightBuilder commonTaxon(String commonTaxon) {
+    public @Nonnull UniRefEntryLightBuilder commonTaxon(Organism commonTaxon) {
         this.commonTaxon = commonTaxon;
         return this;
     }
@@ -131,23 +121,13 @@ public class UniRefEntryLightBuilder implements Builder<UniRefEntryLight> {
         return this;
     }
 
-    public @Nonnull UniRefEntryLightBuilder organismIdsSet(LinkedHashSet<Long> ids) {
-        this.organismIds = ids;
+    public @Nonnull UniRefEntryLightBuilder organismsSet(LinkedHashSet<Organism> organisms) {
+        this.organisms = organisms;
         return this;
     }
 
-    public @Nonnull UniRefEntryLightBuilder organismIdsAdd(Long id) {
-        Utils.addOrIgnoreNull(id, this.organismIds);
-        return this;
-    }
-
-    public @Nonnull UniRefEntryLightBuilder organismsSet(LinkedHashSet<String> ids) {
-        this.organisms = ids;
-        return this;
-    }
-
-    public @Nonnull UniRefEntryLightBuilder organismsAdd(String organism) {
-        if (Utils.notNullNotEmpty(organism)) {
+    public @Nonnull UniRefEntryLightBuilder organismsAdd(Organism organism) {
+        if (Utils.notNull(organism)) {
             UniRefUtils.addOrganism(organism, this.organisms);
         }
         return this;

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.*;
 
 import org.uniprot.core.cv.go.GeneOntologyEntry;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniref.UniRefEntryId;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.UniRefMemberIdType;
@@ -24,8 +25,7 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
     private final String name;
     private final LocalDate updated;
     private final UniRefType entryType;
-    private final long commonTaxonId;
-    private final String commonTaxon;
+    private final Organism commonTaxon;
     private final String sequence;
     private int sequenceLength;
     private final int memberCount;
@@ -34,14 +34,13 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
     private final String seedId;
     private final Set<UniRefMemberIdType> memberIdTypes;
     private final List<String> members;
-    private final LinkedHashSet<Long> organismIds;
-    private final LinkedHashSet<String> organisms;
+    private final LinkedHashSet<Organism> organisms;
     private final List<GeneOntologyEntry> goTerms;
 
     // no arg constructor for JSON deserialization
     UniRefEntryLightImpl() {
         this(
-                null, null, null, null, 0L, null, null, null, null, null, null, 0, 0, null, null,
+                null, null, null, null, null, null, null, null, null, 0, 0, null, null,
                 null);
     }
 
@@ -50,13 +49,11 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
             String name,
             LocalDate updated,
             UniRefType entryType,
-            long commonTaxonId,
-            String commonTaxon,
+            Organism commonTaxon,
             String representativeId,
             String representativeSequence,
             List<String> members,
-            LinkedHashSet<Long> organismIds,
-            LinkedHashSet<String> organisms,
+            LinkedHashSet<Organism> organisms,
             int memberCount,
             int organismCount,
             Set<UniRefMemberIdType> memberIdTypes,
@@ -66,7 +63,6 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
         this.name = name;
         this.updated = updated;
         this.entryType = entryType;
-        this.commonTaxonId = commonTaxonId;
         this.commonTaxon = commonTaxon;
         this.representativeId = representativeId;
         this.sequence = representativeSequence;
@@ -74,7 +70,6 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
             this.sequenceLength = representativeSequence.length();
         }
         this.members = Utils.unmodifiableList(members);
-        this.organismIds = Utils.modifiableLinkedHashSet(organismIds);
         this.organisms = Utils.modifiableLinkedHashSet(organisms);
         this.memberIdTypes = Utils.unmodifiableSet(memberIdTypes);
         if (memberCount == 0) {
@@ -83,7 +78,7 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
             this.memberCount = memberCount;
         }
         if (organismCount == 0) {
-            this.organismCount = this.organismIds.size();
+            this.organismCount = this.organisms.size();
         } else {
             this.organismCount = organismCount;
         }
@@ -112,12 +107,7 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
     }
 
     @Override
-    public long getCommonTaxonId() {
-        return commonTaxonId;
-    }
-
-    @Override
-    public String getCommonTaxon() {
+    public Organism getCommonTaxon() {
         return commonTaxon;
     }
 
@@ -137,13 +127,8 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
     }
 
     @Override
-    public LinkedHashSet<String> getOrganisms() {
+    public LinkedHashSet<Organism> getOrganisms() {
         return organisms;
-    }
-
-    @Override
-    public LinkedHashSet<Long> getOrganismIds() {
-        return organismIds;
     }
 
     @Override
@@ -186,12 +171,10 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UniRefEntryLightImpl that = (UniRefEntryLightImpl) o;
-        return getCommonTaxonId() == that.getCommonTaxonId()
-                && getSequenceLength() == that.getSequenceLength()
+        return getSequenceLength() == that.getSequenceLength()
                 && getMemberCount() == that.getMemberCount()
                 && getOrganismCount() == that.getOrganismCount()
                 && Objects.equals(getMembers(), that.getMembers())
-                && Objects.equals(getOrganismIds(), that.getOrganismIds())
                 && Objects.equals(getOrganisms(), that.getOrganisms())
                 && Objects.equals(getMemberIdTypes(), that.getMemberIdTypes())
                 && Objects.equals(getGoTerms(), that.getGoTerms())
@@ -209,7 +192,6 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
     public int hashCode() {
         return Objects.hash(
                 getMembers(),
-                getOrganismIds(),
                 getOrganisms(),
                 getMemberIdTypes(),
                 getGoTerms(),
@@ -217,7 +199,6 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
                 getName(),
                 getUpdated(),
                 getEntryType(),
-                getCommonTaxonId(),
                 getCommonTaxon(),
                 getSequence(),
                 getSequenceLength(),

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/UniRefEntryLightImpl.java
@@ -39,9 +39,7 @@ public class UniRefEntryLightImpl implements UniRefEntryLight {
 
     // no arg constructor for JSON deserialization
     UniRefEntryLightImpl() {
-        this(
-                null, null, null, null, null, null, null, null, null, 0, 0, null, null,
-                null);
+        this(null, null, null, null, null, null, null, null, null, 0, 0, null, null, null);
     }
 
     UniRefEntryLightImpl(

--- a/core-domain/src/test/java/org/uniprot/core/uniref/UniRefUtilsTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniref/UniRefUtilsTest.java
@@ -31,15 +31,11 @@ class UniRefUtilsTest {
 
     @Test
     void addOrganismNewOrganism() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism newOrganism = new OrganismBuilder()
-                .taxonId(9607L)
-                .scientificName("new scientific")
-                .build();
+        Organism newOrganism =
+                new OrganismBuilder().taxonId(9607L).scientificName("new scientific").build();
 
         Set<Organism> target = new HashSet<>();
         target.add(organism);
@@ -52,10 +48,8 @@ class UniRefUtilsTest {
 
     @Test
     void doNotAddOrganismDuplicated() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
         Set<Organism> target = new HashSet<>();
         target.add(organism);
         UniRefUtils.addOrganism(organism, target);
@@ -65,16 +59,15 @@ class UniRefUtilsTest {
 
     @Test
     void ignoreOrganismWithCommonWhenAfter() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism organismWithCommon = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .commonName("common")
-                .build();
+        Organism organismWithCommon =
+                new OrganismBuilder()
+                        .taxonId(9606L)
+                        .scientificName("scientific")
+                        .commonName("common")
+                        .build();
         Set<Organism> target = new HashSet<>();
         target.add(organism);
         UniRefUtils.addOrganism(organismWithCommon, target);

--- a/core-domain/src/test/java/org/uniprot/core/uniref/UniRefUtilsTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniref/UniRefUtilsTest.java
@@ -8,6 +8,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
 /**
  * @author lgonzales
@@ -29,45 +31,85 @@ class UniRefUtilsTest {
 
     @Test
     void addOrganismNewOrganism() {
-        Set<String> target = new HashSet<>();
-        target.add("scientific");
-        UniRefUtils.addOrganism("scientific new", target);
+        Organism organism = new OrganismBuilder()
+                .taxonId(9606L)
+                .scientificName("scientific")
+                .build();
+
+        Organism newOrganism = new OrganismBuilder()
+                .taxonId(9607L)
+                .scientificName("new scientific")
+                .build();
+
+        Set<Organism> target = new HashSet<>();
+        target.add(organism);
+
+        UniRefUtils.addOrganism(newOrganism, target);
         assertEquals(2, target.size());
-        assertTrue(target.contains("scientific new"));
+        assertTrue(target.contains(organism));
+        assertTrue(target.contains(newOrganism));
     }
 
     @Test
     void doNotAddOrganismDuplicated() {
-        Set<String> target = new HashSet<>();
-        target.add("scientific");
-        UniRefUtils.addOrganism("scientific", target);
+        Organism organism = new OrganismBuilder()
+                .taxonId(9606L)
+                .scientificName("scientific")
+                .build();
+        Set<Organism> target = new HashSet<>();
+        target.add(organism);
+        UniRefUtils.addOrganism(organism, target);
         assertEquals(1, target.size());
-        assertTrue(target.contains("scientific"));
+        assertTrue(target.contains(organism));
     }
 
     @Test
     void ignoreOrganismWithCommonWhenAfter() {
-        Set<String> target = new HashSet<>();
-        target.add("scientific");
-        target.add("scientific other");
-        UniRefUtils.addOrganism("scientific (common)", target);
-        assertEquals(2, target.size());
-        assertTrue(target.contains("scientific"));
-        assertTrue(target.contains("scientific other"));
+        Organism organism = new OrganismBuilder()
+                .taxonId(9606L)
+                .scientificName("scientific")
+                .build();
+
+        Organism organismWithCommon = new OrganismBuilder()
+                .taxonId(9606L)
+                .scientificName("scientific")
+                .commonName("common")
+                .build();
+        Set<Organism> target = new HashSet<>();
+        target.add(organism);
+        UniRefUtils.addOrganism(organismWithCommon, target);
+        assertEquals(1, target.size());
+        assertTrue(target.contains(organism));
+        assertFalse(target.contains(organismWithCommon));
     }
 
     @Test
-    void cleanOrganismWithBrackets() {
-        String cleanedOrganism = UniRefUtils.getOrganismWithoutCommonName("scientific (common)");
-        assertNotNull(cleanedOrganism);
-        assertEquals("scientific", cleanedOrganism);
+    void canGetOrganismScientificName() {
+        String scientific = UniRefUtils.getOrganismScientificName("scientific (common)");
+        assertNotNull(scientific);
+        assertEquals("scientific", scientific);
     }
 
     @Test
-    void cleanOrganismWithoutBrackets() {
+    void canGetOrganismScientificNameWithoutCommon() {
         String organism = "scientific only";
-        String cleanedOrganism = UniRefUtils.getOrganismWithoutCommonName(organism);
-        assertNotNull(cleanedOrganism);
-        assertEquals(organism, cleanedOrganism);
+        String scientific = UniRefUtils.getOrganismScientificName(organism);
+        assertNotNull(scientific);
+        assertEquals(organism, scientific);
+    }
+
+    @Test
+    void canGetOrganismCommonName() {
+        String commonName = UniRefUtils.getOrganismCommonName("scientific (common)");
+        assertNotNull(commonName);
+        assertEquals("common", commonName);
+    }
+
+    @Test
+    void canGetOrganismCommonNameWithoutCommon() {
+        String organism = "scientific only";
+        String scientific = UniRefUtils.getOrganismCommonName(organism);
+        assertNotNull(scientific);
+        assertEquals("", scientific);
     }
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryLightBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryLightBuilderTest.java
@@ -49,10 +49,8 @@ class UniRefEntryLightBuilderTest {
 
     @Test
     void canSetCommonTaxon() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
         UniRefEntryLight entryLight = new UniRefEntryLightBuilder().commonTaxon(organism).build();
         assertThat(entryLight.getCommonTaxon(), is(organism));
     }
@@ -108,15 +106,11 @@ class UniRefEntryLightBuilderTest {
 
     @Test
     void canSetOrganisms() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism otherOrganism = new OrganismBuilder()
-                .taxonId(9607L)
-                .scientificName("new scientific")
-                .build();
+        Organism otherOrganism =
+                new OrganismBuilder().taxonId(9607L).scientificName("new scientific").build();
 
         LinkedHashSet<Organism> value = new LinkedHashSet<>(asList(organism, otherOrganism));
         UniRefEntryLight entryLight = new UniRefEntryLightBuilder().organismsSet(value).build();
@@ -125,18 +119,15 @@ class UniRefEntryLightBuilderTest {
 
     @Test
     void canAddOrganisms() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism newOrganism = new OrganismBuilder()
-                .taxonId(9607L)
-                .scientificName("new scientific")
-                .build();
+        Organism newOrganism =
+                new OrganismBuilder().taxonId(9607L).scientificName("new scientific").build();
 
         UniRefEntryLightBuilder entryLightBuilder =
-                new UniRefEntryLightBuilder().organismsSet(new LinkedHashSet<>(singletonList(organism)));
+                new UniRefEntryLightBuilder()
+                        .organismsSet(new LinkedHashSet<>(singletonList(organism)));
 
         entryLightBuilder.organismsAdd(newOrganism);
 
@@ -145,17 +136,14 @@ class UniRefEntryLightBuilderTest {
 
     @Test
     void doNotAddDuplicatedOrganisms() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism duplicated = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism duplicated =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
         UniRefEntryLightBuilder entryLightBuilder =
-                new UniRefEntryLightBuilder().organismsSet(new LinkedHashSet<>(singletonList(organism)));
+                new UniRefEntryLightBuilder()
+                        .organismsSet(new LinkedHashSet<>(singletonList(organism)));
 
         entryLightBuilder.organismsAdd(duplicated);
         LinkedHashSet<Organism> result = entryLightBuilder.build().getOrganisms();
@@ -234,15 +222,10 @@ class UniRefEntryLightBuilderTest {
 
     @Test
     void testFrom() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("scientific")
-                .build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606L).scientificName("scientific").build();
 
-        Organism commonTaxon = new OrganismBuilder()
-                .taxonId(10116L)
-                .scientificName("Rat")
-                .build();
+        Organism commonTaxon = new OrganismBuilder().taxonId(10116L).scientificName("Rat").build();
 
         UniRefEntryLight entry =
                 new UniRefEntryLightBuilder()

--- a/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryLightImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniref/impl/UniRefEntryLightImplTest.java
@@ -16,7 +16,6 @@ class UniRefEntryLightImplTest {
         assertNotNull(obj);
         assertTrue(obj.getMembers().isEmpty());
         assertTrue(obj.getMemberIdTypes().isEmpty());
-        assertTrue(obj.getOrganismIds().isEmpty());
         assertTrue(obj.getOrganisms().isEmpty());
     }
 }

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
@@ -29,14 +29,14 @@ public class UniRefFastaParser {
     public static String toFasta(UniRefEntry entry) {
         StringBuilder sb = new StringBuilder();
         sb.append(getHeader(entry)).append("\n");
-        int columnCounter = 0;
         String sequence = entry.getRepresentativeMember().getSequence().getValue();
+        int columnCounter = 0;
         for (char c : sequence.toCharArray()) {
             if (columnCounter % 60 == 0 && columnCounter > 0) {
                 sb.append("\n");
             }
-            sb.append(c);
             columnCounter++;
+            sb.append(c);
         }
         return sb.toString();
     }
@@ -50,11 +50,11 @@ public class UniRefFastaParser {
                 .append(" n=")
                 .append(entry.getMemberCount());
 
-        if (entry.getCommonTaxonId() != 1L) {
+        if (entry.getCommonTaxon() != null && entry.getCommonTaxon().getTaxonId() != 1L) {
             sb.append(" Tax=")
-                    .append(entry.getCommonTaxon())
+                    .append(entry.getCommonTaxon().getScientificName())
                     .append(" TaxID=")
-                    .append(entry.getCommonTaxonId());
+                    .append(entry.getCommonTaxon().getTaxonId());
         }
         sb.append(" RepID=").append(getRepresentativeId(entry));
         return sb.toString();

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
@@ -20,8 +20,14 @@ public class UniRefEntryLightValueMapper extends AbstractUniRefEntryMapper<UniRe
         Map<String, String> map = new HashMap<>();
         map.put(UNIREF_FIELDS.get(0), entry.getId().getValue());
         map.put(UNIREF_FIELDS.get(1), entry.getName());
-        map.put(UNIREF_FIELDS.get(2), EntryMapUtil.convertOrganism(entry.getCommonTaxon()));
-        map.put(UNIREF_FIELDS.get(3), Long.toString(entry.getCommonTaxon().getTaxonId()));
+        String organismCommon = "";
+        String organismCommonId = "";
+        if(entry.getCommonTaxon() != null) {
+            organismCommon = EntryMapUtil.convertOrganism(entry.getCommonTaxon());
+            organismCommonId = Long.toString(entry.getCommonTaxon().getTaxonId());
+        }
+        map.put(UNIREF_FIELDS.get(2), organismCommon);
+        map.put(UNIREF_FIELDS.get(3), organismCommonId);
         map.put(UNIREF_FIELDS.get(4), Integer.toString(entry.getMemberCount()));
         map.put(UNIREF_FIELDS.get(5), entry.getUpdated().toString());
         map.put(UNIREF_FIELDS.get(6), Integer.toString(entry.getSequenceLength()));

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
@@ -1,11 +1,11 @@
 package org.uniprot.core.parser.tsv.uniref;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import org.uniprot.core.parser.tsv.uniprot.EntryMapUtil;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.OrganismName;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.UniRefMemberIdType;
 
@@ -20,8 +20,8 @@ public class UniRefEntryLightValueMapper extends AbstractUniRefEntryMapper<UniRe
         Map<String, String> map = new HashMap<>();
         map.put(UNIREF_FIELDS.get(0), entry.getId().getValue());
         map.put(UNIREF_FIELDS.get(1), entry.getName());
-        map.put(UNIREF_FIELDS.get(2), entry.getCommonTaxon());
-        map.put(UNIREF_FIELDS.get(3), Long.toString(entry.getCommonTaxonId()));
+        map.put(UNIREF_FIELDS.get(2), EntryMapUtil.convertOrganism(entry.getCommonTaxon()));
+        map.put(UNIREF_FIELDS.get(3), Long.toString(entry.getCommonTaxon().getTaxonId()));
         map.put(UNIREF_FIELDS.get(4), Integer.toString(entry.getMemberCount()));
         map.put(UNIREF_FIELDS.get(5), entry.getUpdated().toString());
         map.put(UNIREF_FIELDS.get(6), Integer.toString(entry.getSequenceLength()));
@@ -33,13 +33,17 @@ public class UniRefEntryLightValueMapper extends AbstractUniRefEntryMapper<UniRe
 
     @Override
     String getOrganisms(UniRefEntryLight entry) {
-        return String.join(DELIMITER, entry.getOrganisms());
+        return entry.getOrganisms().stream()
+                .map(organism -> (OrganismName) organism)
+                .map(EntryMapUtil::convertOrganism)
+                .collect(Collectors.joining(DELIMITER));
     }
 
     @Override
     String getOrganismTaxId(UniRefEntryLight entry) {
-        return entry.getOrganismIds().stream()
-                .map(Object::toString)
+        return entry.getOrganisms().stream()
+                .map(Organism::getTaxonId)
+                .map(String::valueOf)
                 .collect(Collectors.joining(DELIMITER));
     }
 

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapper.java
@@ -22,7 +22,7 @@ public class UniRefEntryLightValueMapper extends AbstractUniRefEntryMapper<UniRe
         map.put(UNIREF_FIELDS.get(1), entry.getName());
         String organismCommon = "";
         String organismCommonId = "";
-        if(entry.getCommonTaxon() != null) {
+        if (entry.getCommonTaxon() != null) {
             organismCommon = EntryMapUtil.convertOrganism(entry.getCommonTaxon());
             organismCommonId = Long.toString(entry.getCommonTaxon().getTaxonId());
         }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
@@ -13,6 +13,8 @@ import org.uniprot.core.cv.go.impl.GeneOntologyEntryBuilder;
 import org.uniprot.core.impl.SequenceBuilder;
 import org.uniprot.core.uniparc.impl.UniParcIdBuilder;
 import org.uniprot.core.uniprotkb.impl.UniProtKBAccessionBuilder;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.uniref.*;
 import org.uniprot.core.uniref.impl.*;
 
@@ -54,7 +56,7 @@ class UniRefFastaParserTest {
         UniRefEntryLight entry = createEntryLight();
         String fasta = UniRefFastaParser.toFasta(entry);
         String expected =
-                ">UniRef50_P03923 protein n=3 Tax=tax TaxID=8 RepID=P03923_HUMAN\n"
+                ">UniRef50_P03923 protein n=3 Tax=organism 2 TaxID=2 RepID=P03923_HUMAN\n"
                         + "MVSWGRFICLVVVTMATLSLARPSFSLVEDDFSAGSADFAFWERDGDSDGFDSHSDJHET\n"
                         + "RHJREH";
         assertEquals(expected, fasta);
@@ -62,9 +64,14 @@ class UniRefFastaParserTest {
 
     @Test
     void testFastaEntryLight2() {
+        Organism organism = new OrganismBuilder()
+                .taxonId(1L)
+                .scientificName("root")
+                .build();
+
         UniRefEntryLight entry = createEntryLight();
         UniRefEntryLight entry2 =
-                UniRefEntryLightBuilder.from(entry).commonTaxonId(1L).commonTaxon("root").build();
+                UniRefEntryLightBuilder.from(entry).commonTaxon(organism).build();
 
         String fasta = UniRefFastaParser.toFasta(entry2);
 
@@ -76,16 +83,24 @@ class UniRefFastaParserTest {
     }
 
     private UniRefEntryLight createEntryLight() {
+        Organism organism = new OrganismBuilder()
+                .taxonId(1L)
+                .scientificName("organism 1")
+                .build();
+
+        Organism otherOrganism = new OrganismBuilder()
+                .taxonId(2L)
+                .scientificName("organism 2")
+                .build();
+
         UniRefEntry entry = createEntry();
         return new UniRefEntryLightBuilder()
                 .id("UniRef50_P03923")
                 .name("Cluster: protein")
                 .representativeId("P03923_HUMAN,P03923")
                 .sequence(entry.getRepresentativeMember().getSequence().getValue())
-                .organismsSet(new LinkedHashSet<>(asList("organism1", "organism2")))
-                .organismIdsSet(new LinkedHashSet<>(asList(1L, 2L)))
-                .commonTaxonId(8L)
-                .commonTaxon("tax")
+                .organismsSet(new LinkedHashSet<>(asList(organism, otherOrganism)))
+                .commonTaxon(otherOrganism)
                 .memberCount(3)
                 .build();
     }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/UniRefFastaParserTest.java
@@ -64,14 +64,10 @@ class UniRefFastaParserTest {
 
     @Test
     void testFastaEntryLight2() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(1L)
-                .scientificName("root")
-                .build();
+        Organism organism = new OrganismBuilder().taxonId(1L).scientificName("root").build();
 
         UniRefEntryLight entry = createEntryLight();
-        UniRefEntryLight entry2 =
-                UniRefEntryLightBuilder.from(entry).commonTaxon(organism).build();
+        UniRefEntryLight entry2 = UniRefEntryLightBuilder.from(entry).commonTaxon(organism).build();
 
         String fasta = UniRefFastaParser.toFasta(entry2);
 
@@ -83,15 +79,10 @@ class UniRefFastaParserTest {
     }
 
     private UniRefEntryLight createEntryLight() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(1L)
-                .scientificName("organism 1")
-                .build();
+        Organism organism = new OrganismBuilder().taxonId(1L).scientificName("organism 1").build();
 
-        Organism otherOrganism = new OrganismBuilder()
-                .taxonId(2L)
-                .scientificName("organism 2")
-                .build();
+        Organism otherOrganism =
+                new OrganismBuilder().taxonId(2L).scientificName("organism 2").build();
 
         UniRefEntry entry = createEntry();
         return new UniRefEntryLightBuilder()

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapperTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapperTest.java
@@ -16,6 +16,8 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.uniref.UniRefEntryId;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.UniRefMemberIdType;
@@ -47,8 +49,8 @@ class UniRefEntryLightValueMapperTest {
 
         assertEquals("UniRef50_P03923", entryMap.get("id"));
         assertEquals("Cluster: AMP-binding enzyme family protein", entryMap.get("name"));
-        assertEquals("Homo", entryMap.get("common_taxon"));
-        assertEquals("9605", entryMap.get("common_taxonid"));
+        assertEquals("organism 1", entryMap.get("common_taxon"));
+        assertEquals("1", entryMap.get("common_taxonid"));
         assertEquals(Integer.toString(MEMBER_COUNT), entryMap.get("count"));
         assertEquals("2018-06-21", entryMap.get("created"));
         assertEquals(Integer.toString(SEQUENCE.length()), entryMap.get("length"));
@@ -62,7 +64,7 @@ class UniRefEntryLightValueMapperTest {
     @Test
     void testGetOrganism() {
         String organsms = mapper.getOrganisms(ENTRY);
-        assertEquals("organism 1; organism 2", organsms);
+        assertEquals("organism 1; organism 2 (common)", organsms);
     }
 
     @Test
@@ -149,15 +151,25 @@ class UniRefEntryLightValueMapperTest {
         UniRefEntryId entryId = new UniRefEntryIdBuilder(id).build();
         LocalDate created = LocalDate.of(2018, 6, 21);
 
+        Organism organism = new OrganismBuilder()
+                .taxonId(1L)
+                .scientificName("organism 1")
+                .build();
+
+        Organism organismWithCommon = new OrganismBuilder()
+                .taxonId(2L)
+                .scientificName("organism 2")
+                .commonName("common")
+                .build();
+
         return new UniRefEntryLightBuilder()
                 .id(entryId)
                 .updated(created)
                 .entryType(type)
-                .commonTaxonId(9605L)
-                .commonTaxon("Homo")
+                .commonTaxon(organism)
                 .name(name)
-                .organismsSet(new LinkedHashSet<>(asList("organism 1", "organism 2")))
-                .organismIdsSet(new LinkedHashSet<>(asList(1L, 2L)))
+                .organismsAdd(organism)
+                .organismsAdd(organismWithCommon)
                 .sequence(SEQUENCE)
                 .memberCount(MEMBER_COUNT)
                 .membersSet(asList("P1", "P2", "P3", "P4", "P5"))

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapperTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniref/UniRefEntryLightValueMapperTest.java
@@ -8,7 +8,6 @@ import static org.uniprot.core.parser.tsv.uniref.AbstractUniRefEntryMapper.DELIM
 import static org.uniprot.core.uniref.UniRefMemberIdType.*;
 
 import java.time.LocalDate;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -151,16 +150,14 @@ class UniRefEntryLightValueMapperTest {
         UniRefEntryId entryId = new UniRefEntryIdBuilder(id).build();
         LocalDate created = LocalDate.of(2018, 6, 21);
 
-        Organism organism = new OrganismBuilder()
-                .taxonId(1L)
-                .scientificName("organism 1")
-                .build();
+        Organism organism = new OrganismBuilder().taxonId(1L).scientificName("organism 1").build();
 
-        Organism organismWithCommon = new OrganismBuilder()
-                .taxonId(2L)
-                .scientificName("organism 2")
-                .commonName("common")
-                .build();
+        Organism organismWithCommon =
+                new OrganismBuilder()
+                        .taxonId(2L)
+                        .scientificName("organism 2")
+                        .commonName("common")
+                        .build();
 
         return new UniRefEntryLightBuilder()
                 .id(entryId)

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfig.java
@@ -2,14 +2,20 @@ package org.uniprot.core.json.parser.uniref;
 
 import java.time.LocalDate;
 
+import org.uniprot.core.CrossReference;
 import org.uniprot.core.Value;
 import org.uniprot.core.cv.go.GeneOntologyEntry;
 import org.uniprot.core.cv.go.impl.GeneOntologyEntryImpl;
+import org.uniprot.core.impl.CrossReferenceImpl;
 import org.uniprot.core.impl.ValueImpl;
 import org.uniprot.core.json.parser.JsonConfig;
 import org.uniprot.core.json.parser.deserializer.LocalDateDeserializer;
 import org.uniprot.core.json.parser.serializer.LocalDateSerializer;
 import org.uniprot.core.json.parser.uniref.serialiser.UniRefEntryLightSerialiser;
+import org.uniprot.core.uniprotkb.evidence.Evidence;
+import org.uniprot.core.uniprotkb.evidence.impl.EvidenceImpl;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismImpl;
 import org.uniprot.core.uniref.*;
 import org.uniprot.core.uniref.impl.*;
 
@@ -59,6 +65,9 @@ public class UniRefEntryLightJsonConfig extends JsonConfig {
         mod.addAbstractTypeMapping(Value.class, ValueImpl.class);
         mod.addAbstractTypeMapping(UniRefEntryId.class, UniRefEntryIdImpl.class);
         mod.addAbstractTypeMapping(GeneOntologyEntry.class, GeneOntologyEntryImpl.class);
+        mod.addAbstractTypeMapping(Organism.class, OrganismImpl.class);
+        mod.addAbstractTypeMapping(Evidence.class, EvidenceImpl.class);
+        mod.addAbstractTypeMapping(CrossReference.class, CrossReferenceImpl.class);
         objMapper.registerModule(mod);
 
         return objMapper;

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.uniprot.core.cv.go.GoAspect;
 import org.uniprot.core.cv.go.impl.GeneOntologyEntryBuilder;
 import org.uniprot.core.json.parser.ValidateJson;
+import org.uniprot.core.json.parser.uniprot.CreateUtils;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.uniref.UniRefEntryLight;
 import org.uniprot.core.uniref.UniRefMemberIdType;
 import org.uniprot.core.uniref.UniRefType;
@@ -35,17 +38,31 @@ class UniRefEntryLightJsonConfigTest {
     */
     @Test
     void testFullUniRuleEntryJsonRoundTripOrganismOrder() {
+        Organism organism10 = new OrganismBuilder()
+                .taxonId(10L)
+                .scientificName("organism 10")
+                .build();
+
+        Organism organism30 = new OrganismBuilder()
+                .taxonId(30L)
+                .scientificName("organism 30")
+                .build();
+
+        Organism organism12 = new OrganismBuilder()
+                .taxonId(12L)
+                .scientificName("organism 12")
+                .build();
+
+        Organism organism11 = new OrganismBuilder()
+                .taxonId(11L)
+                .scientificName("organism 11")
+                .build();
         UniRefEntryLight entry =
                 new UniRefEntryLightBuilder()
-                        .organismIdsAdd(10L)
-                        .organismIdsAdd(30L)
-                        .organismIdsAdd(12L)
-                        .organismIdsAdd(11L)
-                        .organismsAdd("First organism")
-                        .organismsAdd("Second organism")
-                        .organismsAdd("Third organism")
-                        .organismsAdd("Other organism")
-                        .organismsAdd("Last organism")
+                        .organismsAdd(organism10)
+                        .organismsAdd(organism30)
+                        .organismsAdd(organism12)
+                        .organismsAdd(organism11)
                         .build();
         ValidateJson.verifyJsonRoundTripParser(
                 UniRefEntryLightJsonConfig.getInstance().getFullObjectMapper(), entry);
@@ -74,18 +91,25 @@ class UniRefEntryLightJsonConfigTest {
     }
 
     public static UniRefEntryLight getCompleteUniRefEntryLight() {
+        Organism organism = new OrganismBuilder()
+                .taxonId(9606L)
+                .scientificName("Human")
+                .commonName("common")
+                .synonymsAdd("syn")
+                .lineagesAdd("lineage")
+                .evidencesAdd(CreateUtils.createEvidence("ECO:0000255|PROSITE-ProRule:PRU10025"))
+                .build();
+
         return new UniRefEntryLightBuilder()
                 .id("UniRef50_P12345")
                 .membersAdd("P12345")
-                .organismsAdd("Human")
-                .organismIdsAdd(9606L)
+                .organismsAdd(organism)
                 .memberIdTypesAdd(UniRefMemberIdType.UNIPARC)
                 .representativeId("P12345_HUMAN,P12345")
                 .name("Cluster: protein")
                 .sequence("AAAAA")
                 .updated(LocalDate.now())
-                .commonTaxon("Rat")
-                .commonTaxonId(10116L)
+                .commonTaxon(organism)
                 .entryType(UniRefType.UniRef50)
                 .memberCount(5)
                 .seedId("P12345_HUMAN,P12345")

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniref/UniRefEntryLightJsonConfigTest.java
@@ -38,25 +38,17 @@ class UniRefEntryLightJsonConfigTest {
     */
     @Test
     void testFullUniRuleEntryJsonRoundTripOrganismOrder() {
-        Organism organism10 = new OrganismBuilder()
-                .taxonId(10L)
-                .scientificName("organism 10")
-                .build();
+        Organism organism10 =
+                new OrganismBuilder().taxonId(10L).scientificName("organism 10").build();
 
-        Organism organism30 = new OrganismBuilder()
-                .taxonId(30L)
-                .scientificName("organism 30")
-                .build();
+        Organism organism30 =
+                new OrganismBuilder().taxonId(30L).scientificName("organism 30").build();
 
-        Organism organism12 = new OrganismBuilder()
-                .taxonId(12L)
-                .scientificName("organism 12")
-                .build();
+        Organism organism12 =
+                new OrganismBuilder().taxonId(12L).scientificName("organism 12").build();
 
-        Organism organism11 = new OrganismBuilder()
-                .taxonId(11L)
-                .scientificName("organism 11")
-                .build();
+        Organism organism11 =
+                new OrganismBuilder().taxonId(11L).scientificName("organism 11").build();
         UniRefEntryLight entry =
                 new UniRefEntryLightBuilder()
                         .organismsAdd(organism10)
@@ -91,14 +83,16 @@ class UniRefEntryLightJsonConfigTest {
     }
 
     public static UniRefEntryLight getCompleteUniRefEntryLight() {
-        Organism organism = new OrganismBuilder()
-                .taxonId(9606L)
-                .scientificName("Human")
-                .commonName("common")
-                .synonymsAdd("syn")
-                .lineagesAdd("lineage")
-                .evidencesAdd(CreateUtils.createEvidence("ECO:0000255|PROSITE-ProRule:PRU10025"))
-                .build();
+        Organism organism =
+                new OrganismBuilder()
+                        .taxonId(9606L)
+                        .scientificName("Human")
+                        .commonName("common")
+                        .synonymsAdd("syn")
+                        .lineagesAdd("lineage")
+                        .evidencesAdd(
+                                CreateUtils.createEvidence("ECO:0000255|PROSITE-ProRule:PRU10025"))
+                        .build();
 
         return new UniRefEntryLightBuilder()
                 .id("UniRef50_P12345")

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverter.java
@@ -99,7 +99,8 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
         for (PropertyType property : jaxbEntry.getProperty()) {
             switch (property.getType()) {
                 case PROPERTY_COMMON_TAXON:
-                    commonOrganismBuilder.scientificName(getOrganismScientificName(property.getValue()));
+                    commonOrganismBuilder.scientificName(
+                            getOrganismScientificName(property.getValue()));
                     commonOrganismBuilder.commonName(getOrganismCommonName(property.getValue()));
                     break;
                 case PROPERTY_COMMON_TAXON_ID:
@@ -158,7 +159,7 @@ public class UniRefEntryLightConverter implements Converter<Entry, UniRefEntryLi
                     break;
             }
         }
-        if(hasOrganism) {
+        if (hasOrganism) {
             builder.organismsAdd(organismBuilder.build());
         }
         if (accession != null) {

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniref/UniRefEntryLightConverterTest.java
@@ -48,8 +48,8 @@ class UniRefEntryLightConverterTest {
         assertEquals("Pheromone receptor V3R6", entry.getRepresentativeProteinName());
         assertEquals("2014-11-26", entry.getUpdated().toString());
         assertEquals(UniRefType.UniRef50, entry.getEntryType());
-        assertEquals("Muroidea", entry.getCommonTaxon());
-        assertEquals(337687, entry.getCommonTaxonId());
+        assertEquals("Muroidea", entry.getCommonTaxon().getScientificName());
+        assertEquals(337687, entry.getCommonTaxon().getTaxonId());
         assertEquals("F6MB03_MOUSE,F6MB03", entry.getSeedId());
 
         assertEquals(3, entry.getGoTerms().size());
@@ -101,8 +101,8 @@ class UniRefEntryLightConverterTest {
                 entry.getRepresentativeProteinName());
         assertEquals("2018-09-12", entry.getUpdated().toString());
         assertEquals(UniRefType.UniRef100, entry.getEntryType());
-        assertEquals("Streptomyces viridosporus", entry.getCommonTaxon());
-        assertEquals(67581, entry.getCommonTaxonId());
+        assertEquals("Streptomyces viridosporus", entry.getCommonTaxon().getScientificName());
+        assertEquals(67581, entry.getCommonTaxon().getTaxonId());
         assertEquals("UPI0009BFC4AC", entry.getSeedId());
 
         assertTrue(entry.getGoTerms().isEmpty());


### PR DESCRIPTION
- add cluster solr search field and enable it in the search
- UniRefEntryLight  model change: commonOrganism id and name moved to Organism 

- add retry logic to datastore and solr index to try to avoid 11PM errors