### PR TITLE
uniparc accession filtering

### DIFF
--- a/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcCrossReference.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcCrossReference.java
@@ -11,7 +11,6 @@ import org.uniprot.core.CrossReference;
 public interface UniParcCrossReference extends CrossReference<UniParcDatabase> {
     String PROPERTY_GENE_NAME = "gene_name";
     String PROPERTY_PROTEIN_NAME = "protein_name";
-    String PROPERTY_UNIPROT_KB_ACCESSION = "UniProtKB_accession";
     String PROPERTY_CHAIN = "chain";
     String PROPERTY_NCBI_GI = "NCBI_GI";
     String PROPERTY_PROTEOME_ID = "proteome_id";


### PR DESCRIPTION
changing test that mocked "UniProtKB_accession" property in uniparc json xrefs, which doesn't seem to exist.

done because front-end found that accession filtering on uniparc responses gave empty results.