### PR TITLE
fix Lineage hidden field for Proteome Entry

### DIFF
--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/FileNodeIterator.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/FileNodeIterator.java
@@ -106,6 +106,7 @@ public class FileNodeIterator implements Iterator<TaxonomicNode> {
                 .withCommonName(commonName)
                 .withSynonymName(parseString(nodeElements[11]))
                 .withMnemonic(parseString(nodeElements[12]))
+                .withRank(parseString(nodeElements[4]))
                 .withHidden(isHidden)
                 .childOf(parentNode)
                 .build();

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/FileNodeIterator.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/FileNodeIterator.java
@@ -16,8 +16,8 @@ public class FileNodeIterator implements Iterator<TaxonomicNode> {
     private FileReader fileReader;
     private BufferedReader bufferedReader;
     private TaxonomicNode next;
-    private String fieldSeparator;
-    private String nullPlaceholder;
+    private final String fieldSeparator;
+    private final String nullPlaceholder;
 
     private static final String READER_ERROR_MSG = "An exception occurred when closing the reader.";
 
@@ -98,7 +98,7 @@ public class FileNodeIterator implements Iterator<TaxonomicNode> {
         if (commonName == null || commonName.equalsIgnoreCase("\\N")) {
             commonName = parseString(nodeElements[8]); // ncbi_common
         }
-
+        boolean isHidden = "1".equals(nodeElements[2]);
         Integer parentId = parseInteger(nodeElements[1]);
         TaxonomicNode parentNode = createParentNode(parentId);
 
@@ -106,6 +106,7 @@ public class FileNodeIterator implements Iterator<TaxonomicNode> {
                 .withCommonName(commonName)
                 .withSynonymName(parseString(nodeElements[11]))
                 .withMnemonic(parseString(nodeElements[12]))
+                .withHidden(isHidden)
                 .childOf(parentNode)
                 .build();
     }

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/TaxonomicNode.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/TaxonomicNode.java
@@ -14,6 +14,8 @@ public interface TaxonomicNode {
 
     boolean hidden();
 
+    String rank();
+
     /**
      * Returns a taxonomic node representing the parent of the current node
      *

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/TaxonomicNode.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/TaxonomicNode.java
@@ -12,6 +12,8 @@ public interface TaxonomicNode {
 
     String mnemonic();
 
+    boolean hidden();
+
     /**
      * Returns a taxonomic node representing the parent of the current node
      *

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImpl.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImpl.java
@@ -20,6 +20,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
     private final String synonymName;
     private final String mnemonic;
     private final boolean hidden;
+    private final String rank;
 
     private final TaxonomicNode parent;
 
@@ -30,6 +31,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
             String synonymName,
             String mnemonic,
             boolean hidden,
+            String rank,
             TaxonomicNode parent) {
         this.id = id;
         this.scientificName = scientificName;
@@ -37,6 +39,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
         this.synonymName = synonymName;
         this.mnemonic = mnemonic;
         this.hidden = hidden;
+        this.rank = rank;
         this.parent = parent;
     }
 
@@ -71,6 +74,11 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
     }
 
     @Override
+    public String rank() {
+        return this.rank;
+    }
+
+    @Override
     public TaxonomicNode parent() {
         return this.parent;
     }
@@ -86,6 +94,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
         private String synonymName;
         private String mnemonic;
         private boolean hidden;
+        private String rank;
         private TaxonomicNode parent;
 
         public Builder(int id, String scientificName) {
@@ -113,6 +122,11 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
             return this;
         }
 
+        public Builder withRank(String rank) {
+            this.rank = rank;
+            return this;
+        }
+
         public Builder childOf(TaxonomicNode parent) {
             this.parent = parent;
             return this;
@@ -120,7 +134,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
 
         public TaxonomicNodeImpl build() {
             return new TaxonomicNodeImpl(
-                    id, scientificName, commonName, synonymName, mnemonic, hidden, parent);
+                    id, scientificName, commonName, synonymName, mnemonic, hidden, rank, parent);
         }
     }
 
@@ -140,6 +154,8 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
                 && Objects.equals(this.parent, that.parent)
                 && Objects.equals(this.scientificName, that.scientificName)
                 && Objects.equals(this.synonymName, that.synonymName)
+                && Objects.equals(this.hidden, that.hidden)
+                && Objects.equals(this.rank, that.rank)
                 && Objects.equals(this.mnemonic, that.mnemonic);
     }
 
@@ -152,7 +168,8 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
                 this.scientificName,
                 this.synonymName,
                 this.mnemonic,
-                this.hidden);
+                this.hidden,
+                this.rank);
     }
 
     @Override
@@ -171,6 +188,9 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
                 + '\''
                 + ", hidden="
                 + hidden
+                + ", rank='"
+                + rank
+                + '\''
                 + ", parent="
                 + parent
                 + '}';

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImpl.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImpl.java
@@ -14,13 +14,14 @@ import org.uniprot.cv.taxonomy.TaxonomicNode;
 public class TaxonomicNodeImpl implements TaxonomicNode {
     public static final String UNDEFINED_SCIENTIFIC_NAME = "Undefined";
 
-    private int id;
-    private String scientificName;
-    private String commonName;
-    private String synonymName;
-    private String mnemonic;
+    private final int id;
+    private final String scientificName;
+    private final String commonName;
+    private final String synonymName;
+    private final String mnemonic;
+    private final boolean hidden;
 
-    private TaxonomicNode parent;
+    private final TaxonomicNode parent;
 
     private TaxonomicNodeImpl(
             int id,
@@ -28,12 +29,14 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
             String commonName,
             String synonymName,
             String mnemonic,
+            boolean hidden,
             TaxonomicNode parent) {
         this.id = id;
         this.scientificName = scientificName;
         this.commonName = commonName;
         this.synonymName = synonymName;
         this.mnemonic = mnemonic;
+        this.hidden = hidden;
         this.parent = parent;
     }
 
@@ -63,6 +66,11 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
     }
 
     @Override
+    public boolean hidden() {
+        return hidden;
+    }
+
+    @Override
     public TaxonomicNode parent() {
         return this.parent;
     }
@@ -72,11 +80,12 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
     }
 
     public static class Builder {
-        private int id;
-        private String scientificName;
+        private final int id;
+        private final String scientificName;
         private String commonName;
         private String synonymName;
         private String mnemonic;
+        private boolean hidden;
         private TaxonomicNode parent;
 
         public Builder(int id, String scientificName) {
@@ -99,6 +108,11 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
             return this;
         }
 
+        public Builder withHidden(boolean hidden) {
+            this.hidden = hidden;
+            return this;
+        }
+
         public Builder childOf(TaxonomicNode parent) {
             this.parent = parent;
             return this;
@@ -106,7 +120,7 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
 
         public TaxonomicNodeImpl build() {
             return new TaxonomicNodeImpl(
-                    id, scientificName, commonName, synonymName, mnemonic, parent);
+                    id, scientificName, commonName, synonymName, mnemonic, hidden, parent);
         }
     }
 
@@ -137,7 +151,8 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
                 this.parent,
                 this.scientificName,
                 this.synonymName,
-                this.mnemonic);
+                this.mnemonic,
+                this.hidden);
     }
 
     @Override
@@ -154,6 +169,8 @@ public class TaxonomicNodeImpl implements TaxonomicNode {
                 + ", synonymName='"
                 + synonymName
                 + '\''
+                + ", hidden="
+                + hidden
                 + ", parent="
                 + parent
                 + '}';

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepo.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepo.java
@@ -55,6 +55,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         proxyNode.synonymName = node.synonymName();
         proxyNode.mnemonic = node.mnemonic();
         proxyNode.hidden = node.hidden();
+        proxyNode.rank = node.rank();
 
         if (node.hasParent()) {
             proxyNode.parentTaxID = node.parent().id();
@@ -77,6 +78,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         String synonymName;
         String mnemonic;
         boolean hidden;
+        String rank;
 
         @Override
         public int id() {
@@ -106,6 +108,11 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         @Override
         public boolean hidden() {
             return hidden;
+        }
+
+        @Override
+        public String rank() {
+            return rank;
         }
 
         @Override
@@ -148,6 +155,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     && Objects.equals(this.scientificName, that.scientificName)
                     && Objects.equals(this.synonymName, that.synonymName)
                     && Objects.equals(this.hidden, that.hidden)
+                    && Objects.equals(this.rank, that.rank)
                     && Objects.equals(this.mnemonic, that.mnemonic);
         }
 
@@ -160,7 +168,8 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     this.commonName,
                     this.synonymName,
                     this.mnemonic,
-                    hidden);
+                    this.hidden,
+                    this.rank);
         }
 
         @Override
@@ -181,6 +190,9 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     + '\''
                     + ", hidden="
                     + hidden
+                    + ", rank='"
+                    + rank
+                    + '\''
                     + ", mnemonic='"
                     + mnemonic
                     + '\''

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepo.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepo.java
@@ -54,6 +54,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         proxyNode.commonName = node.commonName();
         proxyNode.synonymName = node.synonymName();
         proxyNode.mnemonic = node.mnemonic();
+        proxyNode.hidden = node.hidden();
 
         if (node.hasParent()) {
             proxyNode.parentTaxID = node.parent().id();
@@ -75,6 +76,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         String commonName;
         String synonymName;
         String mnemonic;
+        boolean hidden;
 
         @Override
         public int id() {
@@ -99,6 +101,11 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
         @Override
         public String mnemonic() {
             return mnemonic;
+        }
+
+        @Override
+        public boolean hidden() {
+            return hidden;
         }
 
         @Override
@@ -140,6 +147,7 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     && Objects.equals(this.parentTaxID, that.parentTaxID)
                     && Objects.equals(this.scientificName, that.scientificName)
                     && Objects.equals(this.synonymName, that.synonymName)
+                    && Objects.equals(this.hidden, that.hidden)
                     && Objects.equals(this.mnemonic, that.mnemonic);
         }
 
@@ -151,7 +159,8 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     this.scientificName,
                     this.commonName,
                     this.synonymName,
-                    this.mnemonic);
+                    this.mnemonic,
+                    hidden);
         }
 
         @Override
@@ -170,6 +179,8 @@ public class TaxonomyMapRepo implements TaxonomyRepo {
                     + ", synonymName='"
                     + synonymName
                     + '\''
+                    + ", hidden="
+                    + hidden
                     + ", mnemonic='"
                     + mnemonic
                     + '\''

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
@@ -3,12 +3,16 @@ package org.uniprot.cv.taxonomy;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class FileNodeIteratorTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileNodeIteratorTest {
     private static final String FIELD_SEPARATOR = "\t";
     private static final String NULL_PLACEHOLDER = "\\N";
 
@@ -18,14 +22,29 @@ public class FileNodeIteratorTest {
         File taxonomyFile = new File(url.toURI());
         FileNodeIterator iterator =
                 new FileNodeIterator(taxonomyFile, FIELD_SEPARATOR, NULL_PLACEHOLDER);
-        int nodeCount = 0;
+        Map<Integer, TaxonomicNode> resultMap = new HashMap<>();
         while (iterator.hasNext()) {
             TaxonomicNode node = iterator.next();
             verifyTaxonomicNode(node);
-            nodeCount++;
+            resultMap.put(node.id(), node);
         }
 
-        Assertions.assertEquals(66, nodeCount);
+        assertEquals(66, resultMap.size());
+        TaxonomicNode bacteria = resultMap.get(2);
+        assertNotNull(bacteria);
+        assertEquals(2, bacteria.id());
+        assertEquals("Bacteria", bacteria.scientificName());
+        assertEquals("eubacteria", bacteria.commonName());
+        assertNull(bacteria.synonymName());
+        assertFalse(bacteria.hidden());
+
+        TaxonomicNode avian = resultMap.get(269446);
+        assertNotNull(avian);
+        assertEquals(269446, avian.id());
+        assertEquals("Avian leukosis virus RSA", avian.scientificName());
+        assertEquals("RSV-SRA", avian.commonName());
+        assertEquals("Rous sarcoma virus (strain Schmidt-Ruppin A)", avian.synonymName());
+        assertTrue( avian.hidden());
     }
 
     @Test
@@ -39,7 +58,7 @@ public class FileNodeIteratorTest {
                                 new FileNodeIterator(
                                         taxonomyFile, FIELD_SEPARATOR, NULL_PLACEHOLDER));
 
-        Assertions.assertEquals(
+        assertEquals(
                 "An exception occurred whilst accessing the taxonomy file", thrown.getMessage());
     }
 
@@ -53,12 +72,13 @@ public class FileNodeIteratorTest {
 
         // try to call next
         NoSuchElementException thrown =
-                Assertions.assertThrows(NoSuchElementException.class, () -> iterator.next());
-        Assertions.assertEquals("No elements left in iterator", thrown.getMessage());
+                Assertions.assertThrows(NoSuchElementException.class, iterator::next);
+        assertEquals("No elements left in iterator", thrown.getMessage());
     }
 
     private void verifyTaxonomicNode(TaxonomicNode node) {
         Assertions.assertNotNull(node);
-        Assertions.assertNotNull(node.id());
+        Assertions.assertTrue(node.id() > 0);
+        Assertions.assertNotNull(node.scientificName());
     }
 }

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
@@ -37,6 +37,7 @@ class FileNodeIteratorTest {
         assertEquals("eubacteria", bacteria.commonName());
         assertNull(bacteria.synonymName());
         assertFalse(bacteria.hidden());
+        assertEquals("superkingdom", bacteria.rank());
 
         TaxonomicNode avian = resultMap.get(269446);
         assertNotNull(avian);
@@ -44,6 +45,7 @@ class FileNodeIteratorTest {
         assertEquals("Avian leukosis virus RSA", avian.scientificName());
         assertEquals("RSV-SRA", avian.commonName());
         assertEquals("Rous sarcoma virus (strain Schmidt-Ruppin A)", avian.synonymName());
+        assertEquals("no rank", avian.rank());
         assertTrue( avian.hidden());
     }
 

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
@@ -12,8 +12,6 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class FileNodeIteratorTest {
     private static final String FIELD_SEPARATOR = "\t";
     private static final String NULL_PLACEHOLDER = "\\N";

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImplTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImplTest.java
@@ -16,6 +16,7 @@ class TaxonomicNodeImplTest {
     private String synonymName;
     private String mnemonic;
     private boolean hidden;
+    private String rank;
     private TaxonomicNode parent;
 
     @BeforeEach
@@ -26,6 +27,7 @@ class TaxonomicNodeImplTest {
         this.commonName = "cn-" + this.random;
         this.synonymName = "syn-" + this.random;
         this.mnemonic = "mn-" + this.random;
+        this.rank = "rk-" + this.random;
         this.hidden = true;
         this.parent =
                 new TaxonomicNodeImpl.Builder(this.id - 1, this.scientificName + "parent").build();
@@ -41,6 +43,7 @@ class TaxonomicNodeImplTest {
                         this.synonymName,
                         this.mnemonic,
                         this.hidden,
+                        this.rank,
                         null);
         Assertions.assertNotNull(node);
         Assertions.assertEquals(this.id, node.id());
@@ -62,6 +65,7 @@ class TaxonomicNodeImplTest {
                         this.synonymName,
                         this.mnemonic,
                         this.hidden,
+                        this.rank,
                         this.parent);
         Assertions.assertNotNull(node);
         Assertions.assertEquals(this.id, node.id());
@@ -69,6 +73,8 @@ class TaxonomicNodeImplTest {
         Assertions.assertEquals(this.commonName, node.commonName());
         Assertions.assertEquals(this.synonymName, node.synonymName());
         Assertions.assertEquals(this.mnemonic, node.mnemonic());
+        Assertions.assertEquals(this.hidden, node.hidden());
+        Assertions.assertEquals(this.rank, node.rank());
         Assertions.assertNotNull(node.parent());
         Assertions.assertTrue(node.hasParent());
     }
@@ -83,6 +89,7 @@ class TaxonomicNodeImplTest {
                         this.synonymName,
                         this.mnemonic,
                         this.hidden,
+                        this.rank,
                         this.parent);
         String str =
                 "TaxonomicNodeImpl{"
@@ -99,6 +106,9 @@ class TaxonomicNodeImplTest {
                         + '\''
                         + ", hidden="
                         + this.hidden
+                        + ", rank='"
+                        + rank
+                        + '\''
                         + ", parent="
                         + this.parent
                         + '}';
@@ -142,16 +152,18 @@ class TaxonomicNodeImplTest {
                 this.synonymName,
                 this.mnemonic,
                 this.hidden,
+                this.rank,
                 this.parent);
     }
 
     public static TaxonomicNode createTaxonomicNode(
-            int id, String sn, String cn, String sy, String mn, boolean hidden, TaxonomicNode parent) {
+            int id, String sn, String cn, String sy, String mn, boolean hidden, String rank, TaxonomicNode parent) {
         TaxonomicNodeImpl.Builder builder = new TaxonomicNodeImpl.Builder(id, sn);
         builder.withCommonName(cn)
                 .withSynonymName(sy)
                 .withMnemonic(mn)
                 .withHidden(hidden)
+                .withRank(rank)
                 .childOf(parent);
         return builder.build();
     }

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImplTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomicNodeImplTest.java
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.uniprot.cv.taxonomy.TaxonomicNode;
 
-public class TaxonomicNodeImplTest {
+class TaxonomicNodeImplTest {
     private String random;
     private int id;
     private String scientificName;
     private String commonName;
     private String synonymName;
     private String mnemonic;
+    private boolean hidden;
     private TaxonomicNode parent;
 
     @BeforeEach
@@ -25,6 +26,7 @@ public class TaxonomicNodeImplTest {
         this.commonName = "cn-" + this.random;
         this.synonymName = "syn-" + this.random;
         this.mnemonic = "mn-" + this.random;
+        this.hidden = true;
         this.parent =
                 new TaxonomicNodeImpl.Builder(this.id - 1, this.scientificName + "parent").build();
     }
@@ -38,6 +40,7 @@ public class TaxonomicNodeImplTest {
                         this.commonName,
                         this.synonymName,
                         this.mnemonic,
+                        this.hidden,
                         null);
         Assertions.assertNotNull(node);
         Assertions.assertEquals(this.id, node.id());
@@ -58,6 +61,7 @@ public class TaxonomicNodeImplTest {
                         this.commonName,
                         this.synonymName,
                         this.mnemonic,
+                        this.hidden,
                         this.parent);
         Assertions.assertNotNull(node);
         Assertions.assertEquals(this.id, node.id());
@@ -78,6 +82,7 @@ public class TaxonomicNodeImplTest {
                         this.commonName,
                         this.synonymName,
                         this.mnemonic,
+                        this.hidden,
                         this.parent);
         String str =
                 "TaxonomicNodeImpl{"
@@ -92,6 +97,8 @@ public class TaxonomicNodeImplTest {
                         + ", synonymName='"
                         + this.synonymName
                         + '\''
+                        + ", hidden="
+                        + this.hidden
                         + ", parent="
                         + this.parent
                         + '}';
@@ -102,21 +109,21 @@ public class TaxonomicNodeImplTest {
     void testValueEqual() {
         TaxonomicNode n1 = createTaxonomicNode();
         TaxonomicNode n2 = createTaxonomicNode();
-        Assertions.assertTrue(n1.equals(n2));
-        Assertions.assertTrue(n1.hashCode() == n2.hashCode());
+        Assertions.assertEquals(n1, n2);
+        Assertions.assertEquals(n1.hashCode(), n2.hashCode());
     }
 
     @Test
     void testRefEqual() {
         TaxonomicNode n1 = createTaxonomicNode();
-        Assertions.assertTrue(n1.equals(n1));
-        Assertions.assertTrue(n1.hashCode() == n1.hashCode());
+        Assertions.assertEquals(n1, n1);
+        Assertions.assertEquals(n1.hashCode(), n1.hashCode());
     }
 
     @Test
     void testEqualWithNull() {
         TaxonomicNode n1 = createTaxonomicNode();
-        Assertions.assertFalse(n1.equals(null));
+        Assertions.assertNotEquals(null, n1);
     }
 
     @Test
@@ -124,7 +131,7 @@ public class TaxonomicNodeImplTest {
         TaxonomicNode n1 = createTaxonomicNode();
         this.parent = null;
         TaxonomicNode n2 = createTaxonomicNode();
-        Assertions.assertFalse(n1.equals(n2));
+        Assertions.assertNotEquals(n1, n2);
     }
 
     private TaxonomicNode createTaxonomicNode() {
@@ -134,13 +141,18 @@ public class TaxonomicNodeImplTest {
                 this.commonName,
                 this.synonymName,
                 this.mnemonic,
+                this.hidden,
                 this.parent);
     }
 
     public static TaxonomicNode createTaxonomicNode(
-            int id, String sn, String cn, String sy, String mn, TaxonomicNode parent) {
+            int id, String sn, String cn, String sy, String mn, boolean hidden, TaxonomicNode parent) {
         TaxonomicNodeImpl.Builder builder = new TaxonomicNodeImpl.Builder(id, sn);
-        builder.withCommonName(cn).withSynonymName(sy).withMnemonic(mn).childOf(parent);
+        builder.withCommonName(cn)
+                .withSynonymName(sy)
+                .withMnemonic(mn)
+                .withHidden(hidden)
+                .childOf(parent);
         return builder.build();
     }
 }

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepoTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepoTest.java
@@ -34,6 +34,7 @@ class TaxonomyMapRepoTest {
         Assertions.assertEquals("Eukaryota", node.get().scientificName());
         Assertions.assertEquals("eucaryotes", node.get().commonName());
         Assertions.assertEquals("9EUKA", node.get().mnemonic());
+        Assertions.assertEquals("superkingdom", node.get().rank());
         Assertions.assertFalse(node.get().hidden());
         Assertions.assertNull(node.get().synonymName());
     }
@@ -52,5 +53,6 @@ class TaxonomyMapRepoTest {
         Assertions.assertEquals("9ZZZZ", node.get().mnemonic());
         Assertions.assertNull(node.get().synonymName());
         Assertions.assertTrue(node.get().hidden());
+        Assertions.assertEquals("no rank", node.get().rank());
     }
 }

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepoTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/impl/TaxonomyMapRepoTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.uniprot.cv.taxonomy.FileNodeIterable;
 import org.uniprot.cv.taxonomy.TaxonomicNode;
 
-public class TaxonomyMapRepoTest {
+class TaxonomyMapRepoTest {
 
     private FileNodeIterable fileNodeIterable;
 
@@ -34,6 +34,7 @@ public class TaxonomyMapRepoTest {
         Assertions.assertEquals("Eukaryota", node.get().scientificName());
         Assertions.assertEquals("eucaryotes", node.get().commonName());
         Assertions.assertEquals("9EUKA", node.get().mnemonic());
+        Assertions.assertFalse(node.get().hidden());
         Assertions.assertNull(node.get().synonymName());
     }
 
@@ -50,5 +51,6 @@ public class TaxonomyMapRepoTest {
         Assertions.assertNull(node.get().commonName());
         Assertions.assertEquals("9ZZZZ", node.get().mnemonic());
         Assertions.assertNull(node.get().synonymName());
+        Assertions.assertTrue(node.get().hidden());
     }
 }


### PR DESCRIPTION
ProteomeEntry has a List of TaxonomyLineage objects, and TaxonomyLineage hidden field was always false because we were not loading it from taxonomy.data file. Now hidden is displayed properly