### PR TITLE
fix isOrganismDiffer attribute

### DIFF
--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/Interaction.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/Interaction.java
@@ -11,7 +11,7 @@ public interface Interaction extends Serializable {
 
     int getNumberOfExperiments();
 
-    boolean isOrganismsDiffer();
+    boolean isOrganismDiffer();
 
     default boolean hasInteractantOne() {
         return Utils.notNull(getInteractantOne());

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/impl/InteractionBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/impl/InteractionBuilder.java
@@ -23,7 +23,7 @@ public final class InteractionBuilder implements Builder<Interaction> {
         builder.interactantOne(instance.getInteractantOne())
                 .interactantTwo(instance.getInteractantTwo())
                 .numberOfExperiments(instance.getNumberOfExperiments())
-                .isOrganismDiffer(instance.isOrganismsDiffer());
+                .isOrganismDiffer(instance.isOrganismDiffer());
         return builder;
     }
 

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/impl/InteractionImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/impl/InteractionImpl.java
@@ -42,7 +42,7 @@ public class InteractionImpl implements Interaction {
     }
 
     @Override
-    public boolean isOrganismsDiffer() {
+    public boolean isOrganismDiffer() {
         return this.organismDiffer;
     }
 

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/InteractionBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/InteractionBuilderTest.java
@@ -26,7 +26,7 @@ class InteractionBuilderTest {
         Interaction interaction = builder.numberOfExperiments(3).build();
 
         assertEquals(3, interaction.getNumberOfExperiments());
-        assertFalse(interaction.isOrganismsDiffer());
+        assertFalse(interaction.isOrganismDiffer());
         assertNull(interaction.getInteractantOne());
         assertNull(interaction.getInteractantTwo());
     }
@@ -42,7 +42,7 @@ class InteractionBuilderTest {
         assertEquals(3, interaction.getNumberOfExperiments());
         assertEquals(interactor1, interaction.getInteractantOne());
         assertNull(interaction.getInteractantTwo());
-        assertFalse(interaction.isOrganismsDiffer());
+        assertFalse(interaction.isOrganismDiffer());
     }
 
     @Test
@@ -62,7 +62,7 @@ class InteractionBuilderTest {
         assertEquals(interactor1, interaction.getInteractantOne());
 
         assertEquals(interactor2, interaction.getInteractantTwo());
-        assertFalse(interaction.isOrganismsDiffer());
+        assertFalse(interaction.isOrganismDiffer());
     }
 
     @Test
@@ -83,7 +83,7 @@ class InteractionBuilderTest {
         assertEquals(interactor1, interaction.getInteractantOne());
 
         assertEquals(interactor2, interaction.getInteractantTwo());
-        assertTrue(interaction.isOrganismsDiffer());
+        assertTrue(interaction.isOrganismDiffer());
     }
 
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/InteractionImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/InteractionImplTest.java
@@ -38,7 +38,7 @@ class InteractionImplTest {
         assertEquals(interactant1, interaction.getInteractantOne());
         assertEquals(interactant2, interaction.getInteractantTwo());
         assertEquals(3, interaction.getNumberOfExperiments());
-        assertFalse(interaction.isOrganismsDiffer());
+        assertFalse(interaction.isOrganismDiffer());
     }
 
     @Test
@@ -47,7 +47,7 @@ class InteractionImplTest {
         assertTrue(interaction.hasInteractantOne());
         assertTrue(interaction.hasInteractantTwo());
         assertTrue(interaction.hasNumberOfExperiments());
-        assertTrue(interaction.isOrganismsDiffer());
+        assertTrue(interaction.isOrganismDiffer());
     }
 
     @Test

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCInteractionCommentLineBuilder.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCInteractionCommentLineBuilder.java
@@ -49,7 +49,7 @@ public class CCInteractionCommentLineBuilder extends CCLineBuilderAbstr<Interact
         }
         sb.append("; ");
 
-        if (act.isOrganismsDiffer()) {
+        if (act.isOrganismDiffer()) {
             sb.append("Xeno; ");
         }
         sb.append("NbExp=");

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/converter/CcInteractionConverterTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/converter/CcInteractionConverterTest.java
@@ -87,17 +87,17 @@ class CcInteractionConverterTest {
         Interactant interactor31 = inter3.getInteractantOne();
         Interactant interactor32 = inter3.getInteractantTwo();
         assertEquals(4, inter1.getNumberOfExperiments());
-        assertFalse(inter1.isOrganismsDiffer());
+        assertFalse(inter1.isOrganismDiffer());
         verifyInteractor(interactor11, "PRO_0000033156", null, null, "EBI-20824092");
         verifyInteractor(interactor12, "PRO_0000000092", "P05067", "APP", "EBI-821758");
 
         assertEquals(3, inter2.getNumberOfExperiments());
-        assertFalse(inter2.isOrganismsDiffer());
+        assertFalse(inter2.isOrganismDiffer());
         verifyInteractor(interactor21, null, "D3ZAR1", null, "EBI-9250714");
         verifyInteractor(interactor22, "PRO_0000017322", "P98158", "Lrp2", "EBI-9251342");
 
         assertEquals(4, inter3.getNumberOfExperiments());
-        assertTrue(inter3.isOrganismsDiffer());
+        assertTrue(inter3.isOrganismDiffer());
         verifyInteractor(interactor31, null, "P12345", null, "EBI-356498");
         verifyInteractor(interactor32, null, "P84198-1", "VIM", "EBI-457639");
     }

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/transformer/InteractionCommentTransformerTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/transformer/InteractionCommentTransformerTest.java
@@ -24,13 +24,13 @@ class InteractionCommentTransformerTest {
 
         Interaction interaction1 = comment.getInteractions().get(0);
         assertEquals(1, interaction1.getNumberOfExperiments());
-        assertFalse(interaction1.isOrganismsDiffer());
+        assertFalse(interaction1.isOrganismDiffer());
         verifyInteractor(interaction1.getInteractantOne(), null, "P12345", null, "EBI-123485");
         verifyInteractor(interaction1.getInteractantTwo(), null, "Q9W158", "CG4612", "EBI-89895");
 
         Interaction interaction2 = comment.getInteractions().get(1);
         assertEquals(2, interaction2.getNumberOfExperiments());
-        assertTrue(interaction2.isOrganismsDiffer());
+        assertTrue(interaction2.isOrganismDiffer());
         verifyInteractor(interaction2.getInteractantOne(), null, "P12345", null, "EBI-123485");
         verifyInteractor(
                 interaction2.getInteractantTwo(), "PRO_0000037566", "P27958", null, "EBI-126770");
@@ -62,21 +62,21 @@ class InteractionCommentTransformerTest {
         assertEquals(3, comment.getInteractions().size());
         Interaction interaction1 = comment.getInteractions().get(0);
         assertEquals(1, interaction1.getNumberOfExperiments());
-        assertFalse(interaction1.isOrganismsDiffer());
+        assertFalse(interaction1.isOrganismDiffer());
         verifyInteractor(interaction1.getInteractantOne(), null, "P12345", null, "EBI-133844");
         verifyInteractor(
                 interaction1.getInteractantTwo(), null, "Q9W1K5-1", "CG11299", "EBI-212772");
 
         Interaction interaction2 = comment.getInteractions().get(1);
         assertEquals(4, interaction2.getNumberOfExperiments());
-        assertFalse(interaction2.isOrganismsDiffer());
+        assertFalse(interaction2.isOrganismDiffer());
         verifyInteractor(
                 interaction2.getInteractantOne(), "PRO_0000037566", null, null, "EBI-372428");
         verifyInteractor(interaction2.getInteractantTwo(), null, "O96017", "CHEK2", "EBI-1180783");
 
         Interaction interaction3 = comment.getInteractions().get(2);
         assertEquals(3, interaction3.getNumberOfExperiments());
-        assertTrue(interaction3.isOrganismsDiffer());
+        assertTrue(interaction3.isOrganismDiffer());
         verifyInteractor(interaction3.getInteractantOne(), null, "P12345", null, "EBI-372428");
         verifyInteractor(interaction3.getInteractantTwo(), null, "Q6ZWQ9", "Myl12a", "EBI-8034418");
     }
@@ -92,20 +92,20 @@ class InteractionCommentTransformerTest {
         assertEquals(3, comment.getInteractions().size());
         Interaction interaction1 = comment.getInteractions().get(0);
         assertEquals(1, interaction1.getNumberOfExperiments());
-        assertFalse(interaction1.isOrganismsDiffer());
+        assertFalse(interaction1.isOrganismDiffer());
         verifyInteractor(interaction1.getInteractantOne(), null, "P12345", null, "EBI-133844");
         verifyInteractor(
                 interaction1.getInteractantTwo(), null, "Q9W1K5-1", "CG11299", "EBI-212772");
 
         Interaction interaction2 = comment.getInteractions().get(1);
         assertEquals(4, interaction2.getNumberOfExperiments());
-        assertFalse(interaction2.isOrganismsDiffer());
+        assertFalse(interaction2.isOrganismDiffer());
         verifyInteractor(interaction2.getInteractantOne(), null, "P12345-1", null, "EBI-372428");
         verifyInteractor(interaction2.getInteractantTwo(), null, "O96017", "CHEK2", "EBI-1180783");
 
         Interaction interaction3 = comment.getInteractions().get(2);
         assertEquals(3, interaction3.getNumberOfExperiments());
-        assertTrue(interaction3.isOrganismsDiffer());
+        assertTrue(interaction3.isOrganismDiffer());
         verifyInteractor(interaction3.getInteractantOne(), null, "P12345", null, "EBI-372428");
         verifyInteractor(interaction3.getInteractantTwo(), null, "Q6ZWQ9", "Myl12a", "EBI-8034418");
     }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/InteractionConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/InteractionConverter.java
@@ -53,7 +53,7 @@ public class InteractionConverter implements Converter<CommentType, Interaction>
 
         commentType.getInteractant().add(interactantConverter.toXml(uniObj.getInteractantOne()));
         commentType.getInteractant().add(interactantConverter.toXml(uniObj.getInteractantTwo()));
-        commentType.setOrganismsDiffer(uniObj.isOrganismsDiffer());
+        commentType.setOrganismsDiffer(uniObj.isOrganismDiffer());
 
         commentType.setExperiments(uniObj.getNumberOfExperiments());
 


### PR DESCRIPTION
organismDiffer does not appear when use fields
With Fields, does not appear: https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/search?fields=accession%2Ccc_interaction&query=%28interactor%3AP05067%29%20AND%20%28accession%3AP05067%29

{
"interactantOne": {
"uniProtKBAccession": "P05067",
"intActId": "EBI-77613"
},
"interactantTwo": {
"uniProtKBAccession": "Q9NY61",
"geneName": "AATF",
"intActId": "EBI-372428"
},
"numberOfExperiments": 3
},

Without fields: it appears: https://www.ebi.ac.uk/uniprot/beta/api/uniprotkb/search?query=%28interactor%3AP05067%29%20AND%20%28accession%3AP05067%29

{
"interactantOne": {
"uniProtKBAccession": "P05067",
"intActId": "EBI-77613"
},
"interactantTwo": {
"uniProtKBAccession": "Q9NY61",
"geneName": "AATF",
"intActId": "EBI-372428"
},
"numberOfExperiments": 3,
"organismDiffer": false
},