### PR TITLE
use GAF code to find eco for missing ids

### DIFF
--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/EvidenceHelperTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/EvidenceHelperTest.java
@@ -1,16 +1,15 @@
 package org.uniprot.cv.evidence;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.util.Arrays;
-import java.util.List;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class EvidenceHelperTest {
 
@@ -23,7 +22,6 @@ class EvidenceHelperTest {
         assertEquals(2, evidences.size());
     }
 
-    @Disabled // enable once TRM-27027 is fixed
     @ParameterizedTest
     @ValueSource(strings = {"abc", " ", "abc|def", "|ab"})
     void illegalEvidenceWillThrowRte(String evd) {

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/EvidenceHelperTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/EvidenceHelperTest.java
@@ -1,15 +1,15 @@
 package org.uniprot.cv.evidence;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.uniprot.core.uniprotkb.evidence.Evidence;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.uniprot.core.uniprotkb.evidence.Evidence;
 
 class EvidenceHelperTest {
 

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/GOEvidencesTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/GOEvidencesTest.java
@@ -1,10 +1,16 @@
 package org.uniprot.cv.evidence;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class GOEvidencesTest {
     private static final String WRONG = "WRONG";
@@ -40,5 +46,16 @@ class GOEvidencesTest {
 
         gaf = GOEvidences.INSTANCE.convertECOToGAF("ECO:0000318");
         assertEquals("IBA", gaf.orElse(WRONG));
+    }
+
+    @ParameterizedTest(name = "[Code {0} exists?]")
+    @MethodSource("provideAllGAFCode")
+    void testGAFToECO(String gaf){
+        assertFalse(GOEvidences.INSTANCE.convertGAFToECO(gaf).isEmpty());
+    }
+
+    private static Stream<Arguments> provideAllGAFCode(){
+        return List.of("EXP", "HDA", "HEP", "HGI", "HMP", "IBA", "IC", "IDA", "IEP", "IGC",
+                "IGI", "IMP", "IPI", "ISA", "ISM", "ISO", "ISS", "NAS", "TAS").stream().map(Arguments::of);
     }
 }

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/GOEvidencesTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/evidence/GOEvidencesTest.java
@@ -50,12 +50,15 @@ class GOEvidencesTest {
 
     @ParameterizedTest(name = "[Code {0} exists?]")
     @MethodSource("provideAllGAFCode")
-    void testGAFToECO(String gaf){
+    void testGAFToECO(String gaf) {
         assertFalse(GOEvidences.INSTANCE.convertGAFToECO(gaf).isEmpty());
     }
 
-    private static Stream<Arguments> provideAllGAFCode(){
-        return List.of("EXP", "HDA", "HEP", "HGI", "HMP", "IBA", "IC", "IDA", "IEP", "IGC",
-                "IGI", "IMP", "IPI", "ISA", "ISM", "ISO", "ISS", "NAS", "TAS").stream().map(Arguments::of);
+    private static Stream<Arguments> provideAllGAFCode() {
+        return List.of(
+                        "EXP", "HDA", "HEP", "HGI", "HMP", "IBA", "IC", "IDA", "IEP", "IGC", "IGI",
+                        "IMP", "IPI", "ISA", "ISM", "ISO", "ISS", "NAS", "TAS")
+                .stream()
+                .map(Arguments::of);
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/EvidenceCode.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/EvidenceCode.java
@@ -312,10 +312,6 @@ public enum EvidenceCode implements EnumDisplay {
     }
 
     public static @Nonnull EvidenceCode typeOf(@Nonnull String code) {
-        try { // remove try catch block once TRM-27027 is resolved
-            return EnumDisplay.typeOf(code, EvidenceCode.class);
-        } catch (IllegalArgumentException ile) {
-            return EvidenceCode.ECO_0000269;
-        }
+        return EnumDisplay.typeOf(code, EvidenceCode.class);
     }
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/EvidenceCodeTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/EvidenceCodeTest.java
@@ -1,19 +1,20 @@
 package org.uniprot.core.uniprotkb.evidence;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.EnumSet;
-
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.uniprot.core.uniprotkb.evidence.EvidenceCode.Category;
 
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class EvidenceCodeTest {
 
-    @Disabled // enable once TRM-27027 is resolved
     @ParameterizedTest
     @ValueSource(strings = {"d", "", "PKJ", " "})
     void typeOfWillThrowIllegalArgument(String code) {
@@ -56,8 +57,4 @@ class EvidenceCodeTest {
         assertTrue(enm.getLabels().size() > 0);
     }
 
-    @Test
-    void testGetDefaultECOCode() {
-        assertEquals(EvidenceCode.ECO_0000269, EvidenceCode.typeOf("ECO:0001225"));
-    }
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/EvidenceCodeTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/EvidenceCodeTest.java
@@ -1,17 +1,17 @@
 package org.uniprot.core.uniprotkb.evidence;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.EnumSet;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.uniprot.core.uniprotkb.evidence.EvidenceCode.Category;
-
-import java.util.EnumSet;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EvidenceCodeTest {
 
@@ -56,5 +56,4 @@ class EvidenceCodeTest {
     void everyEnumShouldHaveAtLeastOneLabel(EvidenceCode enm) {
         assertTrue(enm.getLabels().size() > 0);
     }
-
 }


### PR DESCRIPTION
Implemented as per Jie's suggestion here https://www.ebi.ac.uk/panda/jira/browse/TRM-27031