### PR TITLE
fix: Add missing slf4j static logger binder for tests.

### DIFF
--- a/.github/workflows/formatCodeSpotless.yml
+++ b/.github/workflows/formatCodeSpotless.yml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
           ref: ${{ github.head_ref }}
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
       with:
-        java-version: 11
+        distribution: 'temurin'
+        java-version: '17'
+        cache: 'maven'
 
     - name: Format code with Maven plugin
       run: mvn -P format compile

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/xdb/UniProtCrossReferenceDisplayOrder.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/xdb/UniProtCrossReferenceDisplayOrder.java
@@ -11,7 +11,9 @@ import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
 import org.uniprot.cv.common.AbstractFileReader;
 import org.uniprot.cv.common.CVSystemProperties;
 
-/** @author jieluo */
+/**
+ * @author jieluo
+ */
 public enum UniProtCrossReferenceDisplayOrder
         implements org.uniprot.core.uniprotkb.xdb.DatabaseDisplayOrder<UniProtDatabaseDetail> {
     INSTANCE;

--- a/controlled-vocabulary/src/main/java/org/uniprot/cv/xdb/UniProtDatabaseTypes.java
+++ b/controlled-vocabulary/src/main/java/org/uniprot/cv/xdb/UniProtDatabaseTypes.java
@@ -1,11 +1,6 @@
 package org.uniprot.cv.xdb;
 
-import org.uniprot.core.cv.xdb.UniProtDatabaseAttribute;
-import org.uniprot.core.cv.xdb.UniProtDatabaseCategory;
-import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
-import org.uniprot.core.util.Utils;
-import org.uniprot.core.util.property.Property;
-import org.uniprot.cv.common.AbstractFileReader;
+import static org.uniprot.cv.common.CVSystemProperties.getDrDatabaseTypesLocation;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -15,7 +10,12 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.uniprot.cv.common.CVSystemProperties.getDrDatabaseTypesLocation;
+import org.uniprot.core.cv.xdb.UniProtDatabaseAttribute;
+import org.uniprot.core.cv.xdb.UniProtDatabaseCategory;
+import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
+import org.uniprot.core.util.Utils;
+import org.uniprot.core.util.property.Property;
+import org.uniprot.cv.common.AbstractFileReader;
 
 public enum UniProtDatabaseTypes {
     INSTANCE;
@@ -23,8 +23,8 @@ public enum UniProtDatabaseTypes {
 
     private final List<UniProtDatabaseDetail> uniProtKBDbTypes = new ArrayList<>();
     private final List<UniProtDatabaseDetail> diseaseDbTypes = new ArrayList<>();
-    private final Map<String, List<UniProtDatabaseDetail>> databaseCollectionOperations = Map.of("UNIPROTKB", uniProtKBDbTypes,
-            "DISEASE", diseaseDbTypes);
+    private final Map<String, List<UniProtDatabaseDetail>> databaseCollectionOperations =
+            Map.of("UNIPROTKB", uniProtKBDbTypes, "DISEASE", diseaseDbTypes);
     private Map<String, UniProtDatabaseDetail> uniProtKBDbTypeMap;
 
     UniProtDatabaseTypes() {
@@ -77,7 +77,8 @@ public enum UniProtDatabaseTypes {
                     String category = item.getString("category");
                     String uriLink = item.getString("uriLink");
                     String uniProtDataTypeString = item.optString("uniProtDataTypes", "UNIPROTKB");
-                    List<String> uniProtDataTypes = Arrays.asList(uniProtDataTypeString.split(",", -1));
+                    List<String> uniProtDataTypes =
+                            Arrays.asList(uniProtDataTypeString.split(",", -1));
 
                     String implicit = item.optString("implicit", "false");
                     boolean isImplicit = Boolean.parseBoolean(implicit);

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/taxonomy/FileNodeIteratorTest.java
@@ -70,7 +70,8 @@ class FileNodeIteratorTest {
         File taxonomyFile = new File(url.toURI());
         FileNodeIterator iterator =
                 new FileNodeIterator(taxonomyFile, FIELD_SEPARATOR, NULL_PLACEHOLDER);
-        while (iterator.hasNext() && iterator.next() != null) ;
+        while (iterator.hasNext() && iterator.next() != null)
+            ;
 
         // try to call next
         NoSuchElementException thrown =

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/CrossReferenceValidatorIT.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/CrossReferenceValidatorIT.java
@@ -87,7 +87,8 @@ class CrossReferenceValidatorIT {
     @Test
     void testValidateEachDBXRef() {
         // check if all the drlineconfig.json is in sync with dbxref.txt
-        for (UniProtDatabaseDetail dbTypeDetail : UniProtDatabaseTypes.INSTANCE.getUniProtKBDbTypes()) {
+        for (UniProtDatabaseDetail dbTypeDetail :
+                UniProtDatabaseTypes.INSTANCE.getUniProtKBDbTypes()) {
             if (!NEW_DBS.contains(dbTypeDetail.getName())) {
                 System.out.println(dbTypeDetail.getName());
                 List<Pair<String, String>> mismatches =

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/UniProtKBCrossReferenceDisplayOrderTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/UniProtKBCrossReferenceDisplayOrderTest.java
@@ -1,18 +1,18 @@
 package org.uniprot.cv.xdb;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
 import org.uniprot.cv.common.CVSystemProperties;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 class UniProtKBCrossReferenceDisplayOrderTest {
     @BeforeAll
-    static void setSystemProperty(){
-        System.setProperty(CVSystemProperties.DR_ORD_LOCATION,"src/test/resources/xdb/dr_ord");
+    static void setSystemProperty() {
+        System.setProperty(CVSystemProperties.DR_ORD_LOCATION, "src/test/resources/xdb/dr_ord");
     }
 
     @Test

--- a/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/UniProtKBDatabaseTypesTest.java
+++ b/controlled-vocabulary/src/test/java/org/uniprot/cv/xdb/UniProtKBDatabaseTypesTest.java
@@ -1,17 +1,17 @@
 package org.uniprot.cv.xdb;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.cv.xdb.UniProtDatabaseCategory.*;
+import static org.uniprot.cv.common.CVSystemProperties.DR_DATABASE_TYPES_LOCATION;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.cv.xdb.UniProtDatabaseAttribute;
 import org.uniprot.core.cv.xdb.UniProtDatabaseCategory;
 import org.uniprot.core.cv.xdb.UniProtDatabaseDetail;
 import org.uniprot.core.util.property.Property;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.cv.xdb.UniProtDatabaseCategory.*;
-import static org.uniprot.cv.common.CVSystemProperties.DR_DATABASE_TYPES_LOCATION;
 
 class UniProtKBDatabaseTypesTest {
 
@@ -128,7 +128,9 @@ class UniProtKBDatabaseTypesTest {
 
     @Test
     void testSwiss2dpageType() {
-        assertThrows(IllegalArgumentException.class,()->UniProtDatabaseTypes.INSTANCE.getDbTypeByName("SWISS-2DPAGE"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> UniProtDatabaseTypes.INSTANCE.getDbTypeByName("SWISS-2DPAGE"));
     }
 
     @Test
@@ -185,9 +187,7 @@ class UniProtKBDatabaseTypesTest {
         assertEquals("eggNOG", opType.getName());
         assertEquals("eggNOG", opType.getDisplayName());
         assertEquals(PHYLOGENOMIC_DATABASES, opType.getCategory());
-        assertEquals(
-                "http://eggnog.embl.de/search/ogs/%id",
-                opType.getUriLink());
+        assertEquals("http://eggnog.embl.de/search/ogs/%id", opType.getUriLink());
         assertEquals(1, opType.getAttributes().size());
         verifyAttribute(opType.getAttributes().get(0), "ToxonomicScope", "taxonomic scope", null);
     }
@@ -236,8 +236,7 @@ class UniProtKBDatabaseTypesTest {
         assertEquals("PIRSF", opType.getName());
         assertEquals("PIRSF", opType.getDisplayName());
         assertEquals(FAMILY_AND_DOMAIN_DATABASES, opType.getCategory());
-        assertEquals(
-                "https://www.ebi.ac.uk/interpro/entry/pirsf/%id", opType.getUriLink());
+        assertEquals("https://www.ebi.ac.uk/interpro/entry/pirsf/%id", opType.getUriLink());
         assertEquals(2, opType.getAttributes().size());
         verifyAttribute(opType.getAttributes().get(0), "EntryName", "entry name", null);
         verifyAttribute(opType.getAttributes().get(1), "MatchStatus", "match status", null);
@@ -323,14 +322,15 @@ class UniProtKBDatabaseTypesTest {
     @Test
     void testWithExternalFileGetsPriority() {
         try {
-            System.setProperty(DR_DATABASE_TYPES_LOCATION, "src/test/resources/xref/drlineconfigurationexternal.json");
+            System.setProperty(
+                    DR_DATABASE_TYPES_LOCATION,
+                    "src/test/resources/xref/drlineconfigurationexternal.json");
 
-            String source =
-                    UniProtDatabaseTypes.INSTANCE.getSourceAsString();
+            String source = UniProtDatabaseTypes.INSTANCE.getSourceAsString();
             List<Property> jsonArray = Property.parseJsonArray(source);
             assertEquals(1, jsonArray.size());
             Property property = jsonArray.get(0);
-            assertEquals("EX",  property.getString("name"));
+            assertEquals("EX", property.getString("name"));
         } finally {
             System.clearProperty(DR_DATABASE_TYPES_LOCATION);
         }
@@ -338,17 +338,17 @@ class UniProtKBDatabaseTypesTest {
 
     @Test
     void testWithExternalWhenNotConfigured() {
-            String source =
-                    UniProtDatabaseTypes.INSTANCE.getSourceAsString();
-            List<Property> jsonArray = Property.parseJsonArray(source);
-            assertEquals(200, jsonArray.size());
-            Property property = jsonArray.get(0);
-            assertEquals("EMBL",  property.getString("name"));
+        String source = UniProtDatabaseTypes.INSTANCE.getSourceAsString();
+        List<Property> jsonArray = Property.parseJsonArray(source);
+        assertEquals(200, jsonArray.size());
+        Property property = jsonArray.get(0);
+        assertEquals("EMBL", property.getString("name"));
     }
 
     @Test
     void testWithDiseaseDbs() {
-        List<UniProtDatabaseDetail> diseaseDbTypes = UniProtDatabaseTypes.INSTANCE.getDiseaseDbTypes();
+        List<UniProtDatabaseDetail> diseaseDbTypes =
+                UniProtDatabaseTypes.INSTANCE.getDiseaseDbTypes();
         assertEquals(3, diseaseDbTypes.size());
         List<String> dbNames = diseaseDbTypes.stream().map(UniProtDatabaseDetail::getName).toList();
         assertTrue(dbNames.containsAll(List.of("MIM", "MedGen", "MeSH")));
@@ -356,7 +356,8 @@ class UniProtKBDatabaseTypesTest {
 
     @Test
     void testWithUniProtKBDbs() {
-        List<UniProtDatabaseDetail> diseaseDbTypes = UniProtDatabaseTypes.INSTANCE.getUniProtKBDbTypes();
+        List<UniProtDatabaseDetail> diseaseDbTypes =
+                UniProtDatabaseTypes.INSTANCE.getUniProtKBDbTypes();
         assertEquals(198, diseaseDbTypes.size());
         List<String> dbNames = diseaseDbTypes.stream().map(UniProtDatabaseDetail::getName).toList();
         assertTrue(dbNames.containsAll(List.of("EMBL", "EMDB", "CARD")));
@@ -364,7 +365,8 @@ class UniProtKBDatabaseTypesTest {
 
     @Test
     void testWithCatgeoryORG() {
-        List<UniProtDatabaseDetail> orDBTypes = UniProtDatabaseTypes.INSTANCE.getDBTypesByCategory(ORGANISM_SPECIFIC_DATABASES);
+        List<UniProtDatabaseDetail> orDBTypes =
+                UniProtDatabaseTypes.INSTANCE.getDBTypesByCategory(ORGANISM_SPECIFIC_DATABASES);
         assertEquals(42, orDBTypes.size());
         List<String> dbNames = orDBTypes.stream().map(UniProtDatabaseDetail::getName).toList();
         assertTrue(dbNames.contains("ClinPGx"));

--- a/core-common/src/main/java/org/uniprot/core/util/PairImpl.java
+++ b/core-common/src/main/java/org/uniprot/core/util/PairImpl.java
@@ -5,7 +5,7 @@ public class PairImpl<K, V> implements Pair<K, V> {
     private final K key;
     private final V value;
 
-    PairImpl(){ // do not use, just to make Jackson serializer happy
+    PairImpl() { // do not use, just to make Jackson serializer happy
         this(null, null);
     }
 

--- a/core-common/src/main/java/org/uniprot/core/util/Utils.java
+++ b/core-common/src/main/java/org/uniprot/core/util/Utils.java
@@ -106,7 +106,8 @@ public class Utils {
      * @param target list to add value, should be modifiable
      * @return true if collection changed
      */
-    public static boolean addOrIgnoreEmpty(@Nullable String value, @Nullable Collection<String> target) {
+    public static boolean addOrIgnoreEmpty(
+            @Nullable String value, @Nullable Collection<String> target) {
         if (notNull(target) && notNullNotEmpty(value)) {
             return target.add(value);
         }

--- a/core-common/src/test/java/org/uniprot/core/util/UtilsTest.java
+++ b/core-common/src/test/java/org/uniprot/core/util/UtilsTest.java
@@ -204,13 +204,15 @@ class UtilsTest {
             @Test
             void passingNullReturnEmptyList_unmodifiable() {
                 List<String> unmodifiableList = Utils.unmodifiableList(null);
-                assertThrows(UnsupportedOperationException.class, () -> unmodifiableList.add("abc"));
+                assertThrows(
+                        UnsupportedOperationException.class, () -> unmodifiableList.add("abc"));
             }
 
             @Test
             void passing_emptyList_returnEmptyList_unmodifiable() {
                 List<String> unmodifiableList = Utils.unmodifiableList(new ArrayList<>());
-                assertThrows(UnsupportedOperationException.class, () -> unmodifiableList.add("abc"));
+                assertThrows(
+                        UnsupportedOperationException.class, () -> unmodifiableList.add("abc"));
             }
 
             @Test
@@ -266,7 +268,7 @@ class UtilsTest {
                 list.add("d");
                 list.add("c");
                 Set<String> l = Utils.unmodifiableSet(list);
-                assertEquals(list,l);
+                assertEquals(list, l);
                 assertThrows(UnsupportedOperationException.class, () -> l.add("c"));
             }
         }

--- a/core-domain/src/main/java/org/uniprot/core/citation/Thesis.java
+++ b/core-domain/src/main/java/org/uniprot/core/citation/Thesis.java
@@ -1,6 +1,8 @@
 package org.uniprot.core.citation;
 
-/** @link uk.ac.ebi.kraken.interfaces.common.Value; */
+/**
+ * @link uk.ac.ebi.kraken.interfaces.common.Value;
+ */
 public interface Thesis extends Citation {
 
     String getInstitute();

--- a/core-domain/src/main/java/org/uniprot/core/cv/xdb/UniProtDatabaseDetail.java
+++ b/core-domain/src/main/java/org/uniprot/core/cv/xdb/UniProtDatabaseDetail.java
@@ -59,7 +59,17 @@ public class UniProtDatabaseDetail implements Serializable {
             String linkedReason,
             String idMappingName,
             String type) {
-        this(name, displayName, category, uriLink, attributes, implicit, linkedReason, idMappingName, type, List.of());
+        this(
+                name,
+                displayName,
+                category,
+                uriLink,
+                attributes,
+                implicit,
+                linkedReason,
+                idMappingName,
+                type,
+                List.of());
     }
 
     public UniProtDatabaseDetail(

--- a/core-domain/src/main/java/org/uniprot/core/interpro/InterProType.java
+++ b/core-domain/src/main/java/org/uniprot/core/interpro/InterProType.java
@@ -4,7 +4,9 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.util.EnumDisplay;
 
-/** @author jluo */
+/**
+ * @author jluo
+ */
 public enum InterProType implements EnumDisplay {
     ACTIVE_SITE("Active site", "A"),
     BINDING_SITE("Binding site", "B"),

--- a/core-domain/src/main/java/org/uniprot/core/interpro/MethodType.java
+++ b/core-domain/src/main/java/org/uniprot/core/interpro/MethodType.java
@@ -4,7 +4,9 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.util.EnumDisplay;
 
-/** @author jluo */
+/**
+ * @author jluo
+ */
 public enum MethodType implements EnumDisplay {
     GENE3D("GENE3D", "X"),
     MOBIDB_LITE("MOBIDBLT", "g"),

--- a/core-domain/src/main/java/org/uniprot/core/interpro/Status.java
+++ b/core-domain/src/main/java/org/uniprot/core/interpro/Status.java
@@ -4,7 +4,9 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.util.EnumDisplay;
 
-/** @author jluo */
+/**
+ * @author jluo
+ */
 public enum Status implements EnumDisplay {
     FALSE_NEGATIVE("N"),
     FALSE_POSITIVE("F"),

--- a/core-domain/src/main/java/org/uniprot/core/literature/LiteratureEntry.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/LiteratureEntry.java
@@ -5,7 +5,9 @@ import java.io.Serializable;
 import org.uniprot.core.citation.Citation;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface LiteratureEntry extends Serializable {
 
     Citation getCitation();

--- a/core-domain/src/main/java/org/uniprot/core/literature/LiteratureMappedReference.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/LiteratureMappedReference.java
@@ -6,7 +6,9 @@ import java.util.List;
 import org.uniprot.core.uniprotkb.UniProtKBAccession;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface LiteratureMappedReference extends Serializable {
 
     UniProtKBAccession getUniprotAccession();

--- a/core-domain/src/main/java/org/uniprot/core/literature/LiteratureStatistics.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/LiteratureStatistics.java
@@ -2,7 +2,9 @@ package org.uniprot.core.literature;
 
 import org.uniprot.core.Statistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface LiteratureStatistics extends Statistics {
 
     long getComputationallyMappedProteinCount();

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureEntryBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureEntryBuilder.java
@@ -7,7 +7,9 @@ import org.uniprot.core.citation.Citation;
 import org.uniprot.core.literature.LiteratureEntry;
 import org.uniprot.core.literature.LiteratureStatistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureEntryBuilder implements Builder<LiteratureEntry> {
 
     private Citation citation;

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureEntryImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureEntryImpl.java
@@ -6,7 +6,9 @@ import org.uniprot.core.citation.*;
 import org.uniprot.core.literature.LiteratureEntry;
 import org.uniprot.core.literature.LiteratureStatistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureEntryImpl implements LiteratureEntry {
 
     private static final long serialVersionUID = -1925700851366460681L;

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureMappedReferenceBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureMappedReferenceBuilder.java
@@ -11,7 +11,9 @@ import org.uniprot.core.uniprotkb.UniProtKBAccession;
 import org.uniprot.core.uniprotkb.impl.UniProtKBAccessionBuilder;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureMappedReferenceBuilder implements Builder<LiteratureMappedReference> {
 
     private UniProtKBAccession uniprotAccession;

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureMappedReferenceImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureMappedReferenceImpl.java
@@ -7,7 +7,9 @@ import org.uniprot.core.literature.LiteratureMappedReference;
 import org.uniprot.core.uniprotkb.UniProtKBAccession;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureMappedReferenceImpl implements LiteratureMappedReference {
 
     private static final long serialVersionUID = -1925700851366460682L;

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureStatisticsBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureStatisticsBuilder.java
@@ -5,7 +5,9 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.Builder;
 import org.uniprot.core.literature.LiteratureStatistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureStatisticsBuilder implements Builder<LiteratureStatistics> {
 
     private long reviewedProteinCount;

--- a/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureStatisticsImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/literature/impl/LiteratureStatisticsImpl.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import org.uniprot.core.impl.StatisticsImpl;
 import org.uniprot.core.literature.LiteratureStatistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureStatisticsImpl extends StatisticsImpl implements LiteratureStatistics {
 
     private long computationallyMappedProteinCount;

--- a/core-domain/src/main/java/org/uniprot/core/proteome/RelatedProteome.java
+++ b/core-domain/src/main/java/org/uniprot/core/proteome/RelatedProteome.java
@@ -1,11 +1,13 @@
 package org.uniprot.core.proteome;
 
-import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
-
 import java.io.Serializable;
+
+import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 
 public interface RelatedProteome extends Serializable {
     ProteomeId getId();
+
     Float getSimilarity();
+
     Taxonomy getTaxId();
 }

--- a/core-domain/src/main/java/org/uniprot/core/proteome/impl/ProteomeEntryBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/proteome/impl/ProteomeEntryBuilder.java
@@ -1,16 +1,17 @@
 package org.uniprot.core.proteome.impl;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.citation.Citation;
 import org.uniprot.core.proteome.*;
 import org.uniprot.core.taxonomy.TaxonomyLineage;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.util.Utils;
-
-import javax.annotation.Nonnull;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ProteomeEntryBuilder implements Builder<ProteomeEntry> {
     private ProteomeId id;
@@ -213,7 +214,8 @@ public class ProteomeEntryBuilder implements Builder<ProteomeEntry> {
         return this;
     }
 
-    public @Nonnull ProteomeEntryBuilder relatedProteomesSet(List<RelatedProteome> relatedProteomes) {
+    public @Nonnull ProteomeEntryBuilder relatedProteomesSet(
+            List<RelatedProteome> relatedProteomes) {
         this.relatedProteomes = Utils.modifiableList(relatedProteomes);
         return this;
     }

--- a/core-domain/src/main/java/org/uniprot/core/proteome/impl/RelatedProteomeBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/proteome/impl/RelatedProteomeBuilder.java
@@ -1,11 +1,11 @@
 package org.uniprot.core.proteome.impl;
 
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.proteome.ProteomeId;
 import org.uniprot.core.proteome.RelatedProteome;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
-
-import javax.annotation.Nonnull;
 
 public class RelatedProteomeBuilder implements Builder<RelatedProteome> {
     private ProteomeId proteomeId;
@@ -21,11 +21,11 @@ public class RelatedProteomeBuilder implements Builder<RelatedProteome> {
         this.similarity = similarity;
         return this;
     }
+
     public @Nonnull RelatedProteomeBuilder taxonomy(Taxonomy taxonomy) {
         this.taxonomy = taxonomy;
         return this;
     }
-
 
     @Nonnull
     @Override
@@ -35,7 +35,8 @@ public class RelatedProteomeBuilder implements Builder<RelatedProteome> {
 
     public static @Nonnull RelatedProteomeBuilder from(@Nonnull RelatedProteome instance) {
         RelatedProteomeBuilder builder = new RelatedProteomeBuilder();
-        return builder.proteomeId(instance.getId()).similarity(instance.getSimilarity())
+        return builder.proteomeId(instance.getId())
+                .similarity(instance.getSimilarity())
                 .taxonomy(instance.getTaxId());
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/proteome/impl/RelatedProteomeImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/proteome/impl/RelatedProteomeImpl.java
@@ -1,10 +1,10 @@
 package org.uniprot.core.proteome.impl;
 
+import java.util.Objects;
+
 import org.uniprot.core.proteome.ProteomeId;
 import org.uniprot.core.proteome.RelatedProteome;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
-
-import java.util.Objects;
 
 public class RelatedProteomeImpl implements RelatedProteome {
 
@@ -13,7 +13,7 @@ public class RelatedProteomeImpl implements RelatedProteome {
     private Float similarity;
     private Taxonomy taxonomy;
 
-    RelatedProteomeImpl(){}
+    RelatedProteomeImpl() {}
 
     public RelatedProteomeImpl(ProteomeId proteomeId, Float similarity, Taxonomy taxonomy) {
         this.proteomeId = proteomeId;
@@ -40,7 +40,8 @@ public class RelatedProteomeImpl implements RelatedProteome {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         RelatedProteomeImpl that = (RelatedProteomeImpl) o;
-        return Objects.equals(this.proteomeId, that.proteomeId) && Objects.equals(this.taxonomy, that.taxonomy)
+        return Objects.equals(this.proteomeId, that.proteomeId)
+                && Objects.equals(this.taxonomy, that.taxonomy)
                 && Objects.equals(this.similarity, that.getSimilarity());
     }
 

--- a/core-domain/src/main/java/org/uniprot/core/publication/impl/CommunityAnnotationBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/publication/impl/CommunityAnnotationBuilder.java
@@ -1,11 +1,11 @@
 package org.uniprot.core.publication.impl;
 
+import java.time.LocalDate;
+
 import javax.annotation.Nonnull;
 
 import org.uniprot.core.Builder;
 import org.uniprot.core.publication.CommunityAnnotation;
-
-import java.time.LocalDate;
 
 /**
  * Created 02/12/2020
@@ -52,7 +52,8 @@ public class CommunityAnnotationBuilder implements Builder<CommunityAnnotation> 
     @Nonnull
     @Override
     public CommunityAnnotation build() {
-        return new CommunityAnnotationImpl(proteinOrGene, function, disease, comment, submissionDate);
+        return new CommunityAnnotationImpl(
+                proteinOrGene, function, disease, comment, submissionDate);
     }
 
     public static CommunityAnnotationBuilder from(@Nonnull CommunityAnnotation instance) {

--- a/core-domain/src/main/java/org/uniprot/core/publication/impl/CommunityAnnotationImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/publication/impl/CommunityAnnotationImpl.java
@@ -24,7 +24,11 @@ public class CommunityAnnotationImpl implements CommunityAnnotation {
     }
 
     public CommunityAnnotationImpl(
-            String proteinOrGene, String function, String disease, String comment, LocalDate submissionDate) {
+            String proteinOrGene,
+            String function,
+            String disease,
+            String comment,
+            LocalDate submissionDate) {
         this.proteinOrGene = proteinOrGene;
         this.function = function;
         this.disease = disease;

--- a/core-domain/src/main/java/org/uniprot/core/publication/impl/MappedPublicationsBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/publication/impl/MappedPublicationsBuilder.java
@@ -1,15 +1,16 @@
 package org.uniprot.core.publication.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.publication.CommunityMappedReference;
 import org.uniprot.core.publication.ComputationallyMappedReference;
 import org.uniprot.core.publication.MappedPublications;
 import org.uniprot.core.publication.UniProtKBMappedReference;
 import org.uniprot.core.util.Utils;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author sahmad
@@ -60,7 +61,9 @@ public class MappedPublicationsBuilder implements Builder<MappedPublications> {
     @Override
     public MappedPublications build() {
         return new MappedPublicationsImpl(
-                uniProtKBMappedReferences, computationalMappedReferences, communityMappedReferences);
+                uniProtKBMappedReferences,
+                computationalMappedReferences,
+                communityMappedReferences);
     }
 
     public static @Nonnull MappedPublicationsBuilder from(@Nonnull MappedPublications instance) {

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyEntry.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyEntry.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface TaxonomyEntry extends Taxonomy, Serializable {
 
     Taxonomy getParent();

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyLineage.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyLineage.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 
 import org.uniprot.core.uniprotkb.taxonomy.OrganismName;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface TaxonomyLineage extends OrganismName, Serializable {
 
     long getTaxonId();

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyRank.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyRank.java
@@ -5,7 +5,6 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.util.EnumDisplay;
 
 public enum TaxonomyRank implements EnumDisplay {
-
     STRAIN("strain"),
     SEROTYPE("serotype"),
     SERIES("series"),

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyStrain.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/TaxonomyStrain.java
@@ -3,7 +3,9 @@ package org.uniprot.core.taxonomy;
 import java.io.Serializable;
 import java.util.List;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface TaxonomyStrain extends Serializable {
 
     String getName();

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyEntryImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyEntryImpl.java
@@ -8,7 +8,9 @@ import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyImpl;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class TaxonomyEntryImpl extends TaxonomyImpl implements TaxonomyEntry {
 
     private static final long serialVersionUID = -319775179301440773L;

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyInactiveReasonBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyInactiveReasonBuilder.java
@@ -6,7 +6,9 @@ import org.uniprot.core.Builder;
 import org.uniprot.core.taxonomy.TaxonomyInactiveReason;
 import org.uniprot.core.taxonomy.TaxonomyInactiveReasonType;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class TaxonomyInactiveReasonBuilder implements Builder<TaxonomyInactiveReason> {
 
     private TaxonomyInactiveReasonType inactiveReasonType;

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyInactiveReasonImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyInactiveReasonImpl.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import org.uniprot.core.taxonomy.TaxonomyInactiveReason;
 import org.uniprot.core.taxonomy.TaxonomyInactiveReasonType;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class TaxonomyInactiveReasonImpl implements TaxonomyInactiveReason {
 
     private static final long serialVersionUID = -154580848213747663L;

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyLineageImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyLineageImpl.java
@@ -7,7 +7,9 @@ import org.uniprot.core.taxonomy.TaxonomyLineage;
 import org.uniprot.core.taxonomy.TaxonomyRank;
 import org.uniprot.core.uniprotkb.taxonomy.impl.AbstractOrganismNameImpl;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class TaxonomyLineageImpl extends AbstractOrganismNameImpl implements TaxonomyLineage {
 
     private static final long serialVersionUID = -319775179301440774L;

--- a/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyStrainImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/taxonomy/impl/TaxonomyStrainImpl.java
@@ -6,7 +6,9 @@ import java.util.Objects;
 import org.uniprot.core.taxonomy.TaxonomyStrain;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class TaxonomyStrainImpl implements TaxonomyStrain {
 
     private static final long serialVersionUID = -319775179301440775L;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/CommonOrganism.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/CommonOrganism.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 
 public interface CommonOrganism extends Serializable {
     String getTopLevel();
+
     String getCommonTaxon();
+
     Long getCommonTaxonId();
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/SignatureDbType.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/SignatureDbType.java
@@ -1,8 +1,8 @@
 package org.uniprot.core.uniparc;
 
-import org.uniprot.core.util.EnumDisplay;
-
 import javax.annotation.Nonnull;
+
+import org.uniprot.core.util.EnumDisplay;
 
 public enum SignatureDbType implements EnumDisplay {
     CDD("CDD"),

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcCrossReference.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcCrossReference.java
@@ -1,10 +1,10 @@
 package org.uniprot.core.uniparc;
 
-import org.uniprot.core.CrossReference;
-import org.uniprot.core.uniprotkb.taxonomy.Organism;
-
 import java.time.LocalDate;
 import java.util.List;
+
+import org.uniprot.core.CrossReference;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
 /**
  * @author jluo
@@ -13,8 +13,8 @@ import java.util.List;
 public interface UniParcCrossReference extends CrossReference<UniParcDatabase> {
 
     /**
-     * sources property will store UniParcDatabaseName:sourceXrefId:ProteomeId:ComponentName
-     * For example: UniProtKB/Swiss-Prot:ABC01415:UP000005640:Chromosome 1
+     * sources property will store UniParcDatabaseName:sourceXrefId:ProteomeId:ComponentName For
+     * example: UniProtKB/Swiss-Prot:ABC01415:UP000005640:Chromosome 1
      */
     String PROPERTY_SOURCES = "sources";
 
@@ -39,5 +39,4 @@ public interface UniParcCrossReference extends CrossReference<UniParcDatabase> {
     String getNcbiGi();
 
     List<Proteome> getProteomes();
-
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcDatabase.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcDatabase.java
@@ -22,7 +22,7 @@ public enum UniParcDatabase implements Database, EnumDisplay {
     ENSEMBL_RAPID(1350, "EnsemblRapid", true, true, "https://rapid.ensembl.org/id/%id"),
 
     EPO(1400, "EPO", true, false, "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=epo_prt&id=%id"),
-    FLYBASE(1500, "FlyBase", true,false, "https://flybase.org/reports/%id.html"),
+    FLYBASE(1500, "FlyBase", true, false, "https://flybase.org/reports/%id.html"),
     FUSION_GDB(
             1550,
             "FusionGDB",
@@ -30,12 +30,17 @@ public enum UniParcDatabase implements Database, EnumDisplay {
             false,
             "https://compbio.uth.edu/FusionGDB2/gene_search_result.cgi?type=quick_search&quick_search=%id"),
 
-    H_INV(1600, "H-InvDB",false, false),
-    IPI(1700, "IPI",false, false),
+    H_INV(1600, "H-InvDB", false, false),
+    IPI(1700, "IPI", false, false),
 
-    JPO(1800, "JPO", true,false, "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=jpo_prt&id=%id"),
-    KIPO(1900, "KIPO", true,false, "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=kipo_prt&id=%id"),
-    PATRIC(2000, "PATRIC", true,false, "https://www.patricbrc.org/view/Feature/%id"),
+    JPO(1800, "JPO", true, false, "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=jpo_prt&id=%id"),
+    KIPO(
+            1900,
+            "KIPO",
+            true,
+            false,
+            "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=kipo_prt&id=%id"),
+    PATRIC(2000, "PATRIC", true, false, "https://www.patricbrc.org/view/Feature/%id"),
     PDB(
             2100,
             "PDB",
@@ -43,12 +48,12 @@ public enum UniParcDatabase implements Database, EnumDisplay {
             false,
             "https://www.ebi.ac.uk/pdbe/entry/pdb/%id"), // need to remove the chain, eg "4q8n_A",
     // just use "4q8n" as id
-    PIR(2200, "PIR",false, false),
+    PIR(2200, "PIR", false, false),
 
-    PIRARC(2300, "PIRARC",false, false),
-    PRF(2400, "PRF",false, false, "http://www.prf.or.jp/cgi-bin/seqget.pl?id=%id"),
-    REFSEQ(2500, "RefSeq", true, true,"https://www.ncbi.nlm.nih.gov/protein/%id"),
-    REMTREMBL(2600, "REMTREMBL",false, false),
+    PIRARC(2300, "PIRARC", false, false),
+    PRF(2400, "PRF", false, false, "http://www.prf.or.jp/cgi-bin/seqget.pl?id=%id"),
+    REFSEQ(2500, "RefSeq", true, true, "https://www.ncbi.nlm.nih.gov/protein/%id"),
+    REMTREMBL(2600, "REMTREMBL", false, false),
     SEED(
             2700,
             "SEED",
@@ -56,8 +61,8 @@ public enum UniParcDatabase implements Database, EnumDisplay {
             false,
             "https://pubseed.theseed.org/seedviewer.cgi?page=Annotation&feature=%id"),
 
-    SGD(2800, "SGD", true, false,"https://www.yeastgenome.org/locus/%id"),
-    SWISSPROT(100, "UniProtKB/Swiss-Prot", true, false,"https://www.uniprot.org/uniprot/%id"),
+    SGD(2800, "SGD", true, false, "https://www.yeastgenome.org/locus/%id"),
+    SWISSPROT(100, "UniProtKB/Swiss-Prot", true, false, "https://www.uniprot.org/uniprot/%id"),
     SWISSPROT_VARSPLIC(
             200,
             "UniProtKB/Swiss-Prot protein isoforms",
@@ -76,12 +81,18 @@ public enum UniParcDatabase implements Database, EnumDisplay {
     TREMBL_VARSPLIC(3100, "TREMBL_VARSPLIC", false, false),
     TROME(3200, "TROME", true, false), // no link
     UNIMES(3300, "UNIMES", false, false),
-    USPTO(3400, "USPTO", true,  false, "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=uspto_prt&id=%id"),
+    USPTO(
+            3400,
+            "USPTO",
+            true,
+            false,
+            "https://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=uspto_prt&id=%id"),
 
     VECTORBASE(3500, "VectorBase", false, false),
-    VEGA(3600, "VEGA", true, false,  "https://vega.sanger.ac.uk/id/%id"),
+    VEGA(3600, "VEGA", true, false, "https://vega.sanger.ac.uk/id/%id"),
     WORMBASE_PARASITE(3700, "WBParaSite", true, true, "https://parasite.wormbase.org/id/%id"),
-    WORMBASE(3800, "WormBase", true, true,"https://wormbase.org/db/seq/protein?name=%id;class=CDS");
+    WORMBASE(
+            3800, "WormBase", true, true, "https://wormbase.org/db/seq/protein?name=%id;class=CDS");
 
     private final String displayName;
     private final boolean alive;
@@ -93,7 +104,7 @@ public enum UniParcDatabase implements Database, EnumDisplay {
         this(index, displayName, alive, source, "");
     }
 
-    UniParcDatabase(int index, String displayName, boolean alive, boolean source,String url) {
+    UniParcDatabase(int index, String displayName, boolean alive, boolean source, String url) {
         this.index = index;
         this.displayName = displayName;
         this.alive = alive;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcEntryLight.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/UniParcEntryLight.java
@@ -1,13 +1,13 @@
 package org.uniprot.core.uniparc;
 
-import org.uniprot.core.Sequence;
-import org.uniprot.core.uniprotkb.taxonomy.Organism;
-
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.uniprot.core.Sequence;
+import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
 public interface UniParcEntryLight extends Serializable {
     String getUniParcId();
@@ -29,7 +29,7 @@ public interface UniParcEntryLight extends Serializable {
     Map<String, Object> getExtraAttributes();
 
     // lazily loaded fields
-    Set<Organism> getOrganisms();// organism id and name pair
+    Set<Organism> getOrganisms(); // organism id and name pair
 
     Set<String> getProteinNames();
 

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/CommonOrganismBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/CommonOrganismBuilder.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.uniparc.CommonOrganism;
-
-import javax.annotation.Nonnull;
 
 public class CommonOrganismBuilder implements Builder<CommonOrganism> {
 
@@ -22,7 +22,6 @@ public class CommonOrganismBuilder implements Builder<CommonOrganism> {
         this.topLevel = topLevel;
         return this;
     }
-
 
     public CommonOrganismBuilder commonTaxon(String commonTaxon) {
         this.commonTaxon = commonTaxon;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/CommonOrganismImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/CommonOrganismImpl.java
@@ -1,8 +1,8 @@
 package org.uniprot.core.uniparc.impl;
 
-import org.uniprot.core.uniparc.CommonOrganism;
-
 import java.util.Objects;
+
+import org.uniprot.core.uniparc.CommonOrganism;
 
 public class CommonOrganismImpl implements CommonOrganism {
 
@@ -13,8 +13,7 @@ public class CommonOrganismImpl implements CommonOrganism {
 
     private Long commonTaxonId;
 
-    CommonOrganismImpl(){
-    }
+    CommonOrganismImpl() {}
 
     CommonOrganismImpl(String topLevel, String commonTaxon, Long commonTaxonId) {
         this.topLevel = topLevel;
@@ -42,7 +41,8 @@ public class CommonOrganismImpl implements CommonOrganism {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CommonOrganismImpl that = (CommonOrganismImpl) o;
-        return Objects.equals(topLevel, that.topLevel) && Objects.equals(commonTaxon, that.commonTaxon)
+        return Objects.equals(topLevel, that.topLevel)
+                && Objects.equals(commonTaxon, that.commonTaxon)
                 && Objects.equals(this.commonTaxonId, that.commonTaxonId);
     }
 

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/ProteomeBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/ProteomeBuilder.java
@@ -1,11 +1,11 @@
 package org.uniprot.core.uniparc.impl;
 
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.uniparc.Proteome;
 
-import javax.annotation.Nonnull;
-
-public class ProteomeBuilder  implements Builder<Proteome> {
+public class ProteomeBuilder implements Builder<Proteome> {
 
     private String id;
     private String component;
@@ -21,15 +21,12 @@ public class ProteomeBuilder  implements Builder<Proteome> {
         return this;
     }
 
-
     public ProteomeBuilder component(String component) {
         this.component = component;
         return this;
     }
 
     public static @Nonnull ProteomeBuilder from(@Nonnull Proteome instance) {
-        return new ProteomeBuilder()
-                .id(instance.getId())
-                .component(instance.getComponent());
+        return new ProteomeBuilder().id(instance.getId()).component(instance.getComponent());
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/ProteomeImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/ProteomeImpl.java
@@ -1,8 +1,8 @@
 package org.uniprot.core.uniparc.impl;
 
-import org.uniprot.core.uniparc.Proteome;
-
 import java.util.Objects;
+
+import org.uniprot.core.uniparc.Proteome;
 
 public class ProteomeImpl implements Proteome {
 
@@ -11,8 +11,7 @@ public class ProteomeImpl implements Proteome {
     private String id;
     private String component;
 
-    ProteomeImpl() {
-    }
+    ProteomeImpl() {}
 
     ProteomeImpl(String id, String component) {
         this.id = id;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureImpl.java
@@ -29,7 +29,10 @@ public class SequenceFeatureImpl implements SequenceFeature {
     }
 
     SequenceFeatureImpl(
-            InterProGroup domain, SignatureDbType dbType, String dbId, List<SequenceFeatureLocation> locations) {
+            InterProGroup domain,
+            SignatureDbType dbType,
+            String dbId,
+            List<SequenceFeatureLocation> locations) {
         super();
         this.interproGroup = domain;
         this.database = dbType;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationBuilder.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.uniparc.SequenceFeatureLocation;
-
-import javax.annotation.Nonnull;
 
 public class SequenceFeatureLocationBuilder implements Builder<SequenceFeatureLocation> {
 
@@ -14,7 +14,7 @@ public class SequenceFeatureLocationBuilder implements Builder<SequenceFeatureLo
     @Nonnull
     @Override
     public SequenceFeatureLocation build() {
-        return new SequenceFeatureLocationImpl(start,end,alignment);
+        return new SequenceFeatureLocationImpl(start, end, alignment);
     }
 
     public @Nonnull SequenceFeatureLocationBuilder range(int start, int end) {
@@ -38,7 +38,8 @@ public class SequenceFeatureLocationBuilder implements Builder<SequenceFeatureLo
         return this;
     }
 
-    public static @Nonnull SequenceFeatureLocationBuilder from(@Nonnull SequenceFeatureLocation instance) {
+    public static @Nonnull SequenceFeatureLocationBuilder from(
+            @Nonnull SequenceFeatureLocation instance) {
         return new SequenceFeatureLocationBuilder()
                 .start(instance.getStart())
                 .end(instance.getEnd())

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationImpl.java
@@ -1,16 +1,16 @@
 package org.uniprot.core.uniparc.impl;
 
+import java.util.Objects;
+
 import org.uniprot.core.Location;
 import org.uniprot.core.uniparc.SequenceFeatureLocation;
 
-import java.util.Objects;
-
-public class SequenceFeatureLocationImpl extends Location implements SequenceFeatureLocation{
+public class SequenceFeatureLocationImpl extends Location implements SequenceFeatureLocation {
 
     private static final long serialVersionUID = -4804406936471873484L;
     private String alignment;
 
-    SequenceFeatureLocationImpl(){
+    SequenceFeatureLocationImpl() {
         super(0, 0);
     }
 
@@ -23,7 +23,6 @@ public class SequenceFeatureLocationImpl extends Location implements SequenceFea
     public String getAlignment() {
         return alignment;
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceBuilder.java
@@ -1,18 +1,19 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.uniprot.core.util.Utils.addOrIgnoreNull;
+import static org.uniprot.core.util.Utils.modifiableList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.impl.AbstractCrossReferenceBuilder;
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
-
-import javax.annotation.Nonnull;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.uniprot.core.util.Utils.addOrIgnoreNull;
-import static org.uniprot.core.util.Utils.modifiableList;
 
 /**
  * @author jluo
@@ -20,7 +21,7 @@ import static org.uniprot.core.util.Utils.modifiableList;
  */
 public class UniParcCrossReferenceBuilder
         extends AbstractCrossReferenceBuilder<
-        UniParcCrossReferenceBuilder, UniParcDatabase, UniParcCrossReference> {
+                UniParcCrossReferenceBuilder, UniParcDatabase, UniParcCrossReference> {
     private int versionI;
     private Integer version;
     private boolean active;

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceImpl.java
@@ -1,16 +1,16 @@
 package org.uniprot.core.uniparc.impl;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 import org.uniprot.core.Property;
 import org.uniprot.core.impl.CrossReferenceImpl;
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
-
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * @author jluo
@@ -33,8 +33,20 @@ public class UniParcCrossReferenceImpl extends CrossReferenceImpl<UniParcDatabas
 
     UniParcCrossReferenceImpl() {
         this(
-                null, null, null, 0, null, false, null,
-                null, null, null, null, null, null, Collections.emptyList());
+                null,
+                null,
+                null,
+                0,
+                null,
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Collections.emptyList());
     }
 
     UniParcCrossReferenceImpl(

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferencePair.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcCrossReferencePair.java
@@ -1,20 +1,18 @@
 package org.uniprot.core.uniparc.impl;
 
-import org.uniprot.core.uniparc.UniParcCrossReference;
-import org.uniprot.core.util.Pair;
-
 import java.io.Serial;
 import java.util.List;
 import java.util.Objects;
 
+import org.uniprot.core.uniparc.UniParcCrossReference;
+import org.uniprot.core.util.Pair;
+
 public class UniParcCrossReferencePair implements Pair<String, List<UniParcCrossReference>> {
-    @Serial
-    private static final long serialVersionUID = 7906365717659009263L;
+    @Serial private static final long serialVersionUID = 7906365717659009263L;
     private String key;
     private List<UniParcCrossReference> value;
 
-    UniParcCrossReferencePair() {
-    }
+    UniParcCrossReferencePair() {}
 
     public UniParcCrossReferencePair(String key, List<UniParcCrossReference> value) {
         this.key = key;
@@ -36,7 +34,8 @@ public class UniParcCrossReferencePair implements Pair<String, List<UniParcCross
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UniParcCrossReferencePair that = (UniParcCrossReferencePair) o;
-        return Objects.equals(getKey(), that.getKey()) && Objects.equals(getValue(), that.getValue());
+        return Objects.equals(getKey(), that.getKey())
+                && Objects.equals(getValue(), that.getValue());
     }
 
     @Override

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcEntryLightBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcEntryLightBuilder.java
@@ -1,5 +1,12 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.uniprot.core.util.Utils.putOrIgnoreNull;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import javax.annotation.Nonnull;
+
 import org.uniprot.core.Builder;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.uniparc.CommonOrganism;
@@ -8,12 +15,6 @@ import org.uniprot.core.uniparc.SequenceFeature;
 import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.util.Utils;
-
-import javax.annotation.Nonnull;
-import java.time.LocalDate;
-import java.util.*;
-
-import static org.uniprot.core.util.Utils.putOrIgnoreNull;
 
 public class UniParcEntryLightBuilder implements Builder<UniParcEntryLight> {
     public static final String HAS_ACTIVE_CROSS_REF = "hasActiveCrossRef";
@@ -43,39 +44,50 @@ public class UniParcEntryLightBuilder implements Builder<UniParcEntryLight> {
     @Nonnull
     @Override
     public UniParcEntryLight build() {
-        return new UniParcEntryLightImpl(uniParcId, crossReferenceCount, commonTaxons, uniProtKBAccessions,
-                sequence, sequenceFeatures, oldestCrossRefCreated,
-                mostRecentCrossRefUpdated, organisms, proteinNames,
-                geneNames, proteomes, extraAttributes);
+        return new UniParcEntryLightImpl(
+                uniParcId,
+                crossReferenceCount,
+                commonTaxons,
+                uniProtKBAccessions,
+                sequence,
+                sequenceFeatures,
+                oldestCrossRefCreated,
+                mostRecentCrossRefUpdated,
+                organisms,
+                proteinNames,
+                geneNames,
+                proteomes,
+                extraAttributes);
     }
 
-    public  @Nonnull UniParcEntryLightBuilder uniParcId(String uniParcId) {
+    public @Nonnull UniParcEntryLightBuilder uniParcId(String uniParcId) {
         this.uniParcId = uniParcId;
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder crossReferenceCount(int crossReferenceCount){
+    public @Nonnull UniParcEntryLightBuilder crossReferenceCount(int crossReferenceCount) {
         this.crossReferenceCount = crossReferenceCount;
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder commonTaxonsSet(List<CommonOrganism> commonTaxons){
+    public @Nonnull UniParcEntryLightBuilder commonTaxonsSet(List<CommonOrganism> commonTaxons) {
         this.commonTaxons = Utils.modifiableList(commonTaxons);
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder commonTaxonsAdd(CommonOrganism commonTaxon){
+    public @Nonnull UniParcEntryLightBuilder commonTaxonsAdd(CommonOrganism commonTaxon) {
         Utils.addOrIgnoreNull(commonTaxon, this.commonTaxons);
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder uniProtKBAccessionsSet(LinkedHashSet<String> uniProtKBAccessions){
+    public @Nonnull UniParcEntryLightBuilder uniProtKBAccessionsSet(
+            LinkedHashSet<String> uniProtKBAccessions) {
         this.uniProtKBAccessions = Utils.modifiableLinkedHashSet(uniProtKBAccessions);
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder uniProtKBAccessionsAdd(String uniProtKBAccession){
-         Utils.addOrIgnoreNull(uniProtKBAccession, this.uniProtKBAccessions);
+    public @Nonnull UniParcEntryLightBuilder uniProtKBAccessionsAdd(String uniProtKBAccession) {
+        Utils.addOrIgnoreNull(uniProtKBAccession, this.uniProtKBAccessions);
         return this;
     }
 
@@ -84,7 +96,8 @@ public class UniParcEntryLightBuilder implements Builder<UniParcEntryLight> {
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder sequenceFeaturesSet(List<SequenceFeature> sequenceFeatures) {
+    public @Nonnull UniParcEntryLightBuilder sequenceFeaturesSet(
+            List<SequenceFeature> sequenceFeatures) {
         this.sequenceFeatures = Utils.modifiableList(sequenceFeatures);
         return this;
     }
@@ -94,12 +107,14 @@ public class UniParcEntryLightBuilder implements Builder<UniParcEntryLight> {
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder oldestCrossRefCreated(LocalDate oldestCrossRefCreated) {
+    public @Nonnull UniParcEntryLightBuilder oldestCrossRefCreated(
+            LocalDate oldestCrossRefCreated) {
         this.oldestCrossRefCreated = oldestCrossRefCreated;
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder mostRecentCrossRefUpdated(LocalDate mostRecentCrossRefUpdated) {
+    public @Nonnull UniParcEntryLightBuilder mostRecentCrossRefUpdated(
+            LocalDate mostRecentCrossRefUpdated) {
         this.mostRecentCrossRefUpdated = mostRecentCrossRefUpdated;
         return this;
     }
@@ -149,15 +164,18 @@ public class UniParcEntryLightBuilder implements Builder<UniParcEntryLight> {
         return this;
     }
 
-    public @Nonnull UniParcEntryLightBuilder extraAttributesSet(Map<String, Object> extraAttributes) {
+    public @Nonnull UniParcEntryLightBuilder extraAttributesSet(
+            Map<String, Object> extraAttributes) {
         this.extraAttributes = new LinkedHashMap<>(extraAttributes);
         return this;
     }
 
-    public static @Nonnull UniParcEntryLightBuilder from(UniParcEntryLight uniParcEntryLight){
-        LinkedHashSet<String> uniProtKBAccessions = new LinkedHashSet<>(uniParcEntryLight.getUniProtKBAccessions());
+    public static @Nonnull UniParcEntryLightBuilder from(UniParcEntryLight uniParcEntryLight) {
+        LinkedHashSet<String> uniProtKBAccessions =
+                new LinkedHashSet<>(uniParcEntryLight.getUniProtKBAccessions());
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(uniParcEntryLight.getOrganisms());
-        LinkedHashSet<String> proteinNames = new LinkedHashSet<>(uniParcEntryLight.getProteinNames());
+        LinkedHashSet<String> proteinNames =
+                new LinkedHashSet<>(uniParcEntryLight.getProteinNames());
         LinkedHashSet<String> geneNames = new LinkedHashSet<>(uniParcEntryLight.getGeneNames());
         LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(uniParcEntryLight.getProteomes());
         UniParcEntryLightBuilder builder = new UniParcEntryLightBuilder();

--- a/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcEntryLightImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniparc/impl/UniParcEntryLightImpl.java
@@ -1,5 +1,8 @@
 package org.uniprot.core.uniparc.impl;
 
+import java.time.LocalDate;
+import java.util.*;
+
 import org.uniprot.core.Sequence;
 import org.uniprot.core.uniparc.CommonOrganism;
 import org.uniprot.core.uniparc.Proteome;
@@ -8,9 +11,6 @@ import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.util.Utils;
 
-import java.time.LocalDate;
-import java.util.*;
-
 public class UniParcEntryLightImpl implements UniParcEntryLight {
 
     private static final long serialVersionUID = 6932484977764108673L;
@@ -18,8 +18,8 @@ public class UniParcEntryLightImpl implements UniParcEntryLight {
     private final int crossReferenceCount;
     private final List<CommonOrganism> commonTaxons;
     private final Set<String> uniProtKBAccessions;
-    private final  Sequence sequence;
-    private final  List<SequenceFeature> sequenceFeatures;
+    private final Sequence sequence;
+    private final List<SequenceFeature> sequenceFeatures;
     private final LocalDate oldestCrossRefCreated;
     private final LocalDate mostRecentCrossRefUpdated;
 
@@ -34,20 +34,45 @@ public class UniParcEntryLightImpl implements UniParcEntryLight {
         this(null, 0, null, null, null, null, null, null);
     }
 
-    UniParcEntryLightImpl(String uniParcId, int crossReferenceCount,
-                          List<CommonOrganism> commonTaxons, LinkedHashSet<String> uniProtKBAccessions,
-                                  Sequence sequence, List<SequenceFeature> sequenceFeatures,
-                                 LocalDate oldestCrossRefCreated, LocalDate mostRecentCrossRefUpdated) {
-        this(uniParcId, crossReferenceCount, commonTaxons, uniProtKBAccessions,
-                sequence, sequenceFeatures, oldestCrossRefCreated, mostRecentCrossRefUpdated,
-                null, null, null, null, null);
+    UniParcEntryLightImpl(
+            String uniParcId,
+            int crossReferenceCount,
+            List<CommonOrganism> commonTaxons,
+            LinkedHashSet<String> uniProtKBAccessions,
+            Sequence sequence,
+            List<SequenceFeature> sequenceFeatures,
+            LocalDate oldestCrossRefCreated,
+            LocalDate mostRecentCrossRefUpdated) {
+        this(
+                uniParcId,
+                crossReferenceCount,
+                commonTaxons,
+                uniProtKBAccessions,
+                sequence,
+                sequenceFeatures,
+                oldestCrossRefCreated,
+                mostRecentCrossRefUpdated,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
-    UniParcEntryLightImpl(String uniParcId, int crossReferenceCount,
-                          List<CommonOrganism> commonTaxons, Set<String> uniProtKBAccessions,
-                                  Sequence sequence, List<SequenceFeature> sequenceFeatures,
-                                 LocalDate oldestCrossRefCreated, LocalDate mostRecentCrossRefUpdated,
-                          Set<Organism> organisms, Set<String> proteinNames, Set<String> geneNames,
-                          Set<Proteome> proteomes, Map<String, Object> extraAttributes) {
+
+    UniParcEntryLightImpl(
+            String uniParcId,
+            int crossReferenceCount,
+            List<CommonOrganism> commonTaxons,
+            Set<String> uniProtKBAccessions,
+            Sequence sequence,
+            List<SequenceFeature> sequenceFeatures,
+            LocalDate oldestCrossRefCreated,
+            LocalDate mostRecentCrossRefUpdated,
+            Set<Organism> organisms,
+            Set<String> proteinNames,
+            Set<String> geneNames,
+            Set<Proteome> proteomes,
+            Map<String, Object> extraAttributes) {
         this.uniParcId = uniParcId;
         this.crossReferenceCount = crossReferenceCount;
         this.commonTaxons = Utils.unmodifiableList(commonTaxons);
@@ -133,25 +158,37 @@ public class UniParcEntryLightImpl implements UniParcEntryLight {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UniParcEntryLightImpl that = (UniParcEntryLightImpl) o;
-        return Objects.equals(getUniParcId(), that.getUniParcId()) && Objects.equals(getCrossReferenceCount(),
-                that.getCrossReferenceCount()) && Objects.equals(getCommonTaxons(), that.getCommonTaxons()) &&
-                Objects.equals(getUniProtKBAccessions(), that.getUniProtKBAccessions()) &&
-                Objects.equals(getSequence(), that.getSequence()) &&
-                Objects.equals(getSequenceFeatures(), that.getSequenceFeatures()) &&
-                Objects.equals(getOldestCrossRefCreated(), that.getOldestCrossRefCreated()) &&
-                Objects.equals(getMostRecentCrossRefUpdated(), that.getMostRecentCrossRefUpdated()) &&
-                Objects.equals(getOrganisms(), that.getOrganisms()) &&
-                Objects.equals(getProteinNames(), that.getProteinNames()) &&
-                Objects.equals(getGeneNames(), that.getGeneNames()) &&
-                Objects.equals(getProteomes(), that.getProteomes()) &&
-                Objects.equals(getExtraAttributes(), that.getExtraAttributes());
+        return Objects.equals(getUniParcId(), that.getUniParcId())
+                && Objects.equals(getCrossReferenceCount(), that.getCrossReferenceCount())
+                && Objects.equals(getCommonTaxons(), that.getCommonTaxons())
+                && Objects.equals(getUniProtKBAccessions(), that.getUniProtKBAccessions())
+                && Objects.equals(getSequence(), that.getSequence())
+                && Objects.equals(getSequenceFeatures(), that.getSequenceFeatures())
+                && Objects.equals(getOldestCrossRefCreated(), that.getOldestCrossRefCreated())
+                && Objects.equals(
+                        getMostRecentCrossRefUpdated(), that.getMostRecentCrossRefUpdated())
+                && Objects.equals(getOrganisms(), that.getOrganisms())
+                && Objects.equals(getProteinNames(), that.getProteinNames())
+                && Objects.equals(getGeneNames(), that.getGeneNames())
+                && Objects.equals(getProteomes(), that.getProteomes())
+                && Objects.equals(getExtraAttributes(), that.getExtraAttributes());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUniParcId(), getCrossReferenceCount(), getCommonTaxons(), getUniProtKBAccessions(),
-                 getSequence(), getSequenceFeatures(), getOldestCrossRefCreated(),
-                getMostRecentCrossRefUpdated(), getOrganisms(), getProteinNames(), getGeneNames(), getProteomes(),
+        return Objects.hash(
+                getUniParcId(),
+                getCrossReferenceCount(),
+                getCommonTaxons(),
+                getUniProtKBAccessions(),
+                getSequence(),
+                getSequenceFeatures(),
+                getOldestCrossRefCreated(),
+                getMostRecentCrossRefUpdated(),
+                getOrganisms(),
+                getProteinNames(),
+                getGeneNames(),
+                getProteomes(),
                 getExtraAttributes());
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/DeletedReason.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/DeletedReason.java
@@ -1,32 +1,32 @@
 package org.uniprot.core.uniprotkb;
 
-import org.uniprot.core.util.EnumDisplay;
-
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
-public enum DeletedReason implements EnumDisplay {
+import javax.annotation.Nonnull;
 
-    UNKNOWN( "", 0, 7, 9, 10, 12),
-    UNDEFINED( "Undefined", -1),
-    SOURCE_DELETION_EMBL( "Deleted from sequence source (EMBL)", 1),
-    SOURCE_DELETION_TAIR( "Deleted from sequence source (TAIR)", 4),
-    SOURCE_DELETION_SGD( "Deleted from sequence source (SGD)", 5),
-    SOURCE_DELETION_ENSEMBL( "Deleted from sequence source (ENSEMBL)", 6),
-    SOURCE_DELETION_PDB( "Deleted from sequence source (PDB)", 8),
-    SOURCE_DELETION_REFSEQ( "Deleted from sequence source (RefSeq)", 11),
-    SWISSPROT_DELETION( "Deleted from Swiss-Prot", 2),
-    REDUNDANCY( "Redundant sequence", 3),
-    PROTEOME_REDUNDANCY( "Redundant proteome", 13),
-    PROTEOME_EXCLUSION( "Excluded proteome", 14),
-    OVERREPRESENTED( "Over-represented sequence", 15),
-    REFERENCE_PROTEOME_EXCLUSION( "Not part of a reference proteome", 16);
+import org.uniprot.core.util.EnumDisplay;
+
+public enum DeletedReason implements EnumDisplay {
+    UNKNOWN("", 0, 7, 9, 10, 12),
+    UNDEFINED("Undefined", -1),
+    SOURCE_DELETION_EMBL("Deleted from sequence source (EMBL)", 1),
+    SOURCE_DELETION_TAIR("Deleted from sequence source (TAIR)", 4),
+    SOURCE_DELETION_SGD("Deleted from sequence source (SGD)", 5),
+    SOURCE_DELETION_ENSEMBL("Deleted from sequence source (ENSEMBL)", 6),
+    SOURCE_DELETION_PDB("Deleted from sequence source (PDB)", 8),
+    SOURCE_DELETION_REFSEQ("Deleted from sequence source (RefSeq)", 11),
+    SWISSPROT_DELETION("Deleted from Swiss-Prot", 2),
+    REDUNDANCY("Redundant sequence", 3),
+    PROTEOME_REDUNDANCY("Redundant proteome", 13),
+    PROTEOME_EXCLUSION("Excluded proteome", 14),
+    OVERREPRESENTED("Over-represented sequence", 15),
+    REFERENCE_PROTEOME_EXCLUSION("Not part of a reference proteome", 16);
 
     private final List<Integer> ids;
     private final String description;
 
-    DeletedReason(String description,Integer ... id) {
+    DeletedReason(String description, Integer... id) {
         this.ids = Arrays.asList(id);
         this.description = description;
     }
@@ -42,9 +42,9 @@ public enum DeletedReason implements EnumDisplay {
     }
 
     public static DeletedReason fromId(String id) {
-            return Arrays.stream(DeletedReason.values())
-                    .filter(reason -> reason.getIds().contains(Integer.parseInt(id)))
-                    .findFirst()
-                    .orElse(DeletedReason.UNDEFINED);
+        return Arrays.stream(DeletedReason.values())
+                .filter(reason -> reason.getIds().contains(Integer.parseInt(id)))
+                .findFirst()
+                .orElse(DeletedReason.UNDEFINED);
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/CofactorComment.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/CofactorComment.java
@@ -38,10 +38,14 @@ import java.util.List;
  */
 public interface CofactorComment extends Comment, HasMolecule {
 
-    /** @return list of cofactor */
+    /**
+     * @return list of cofactor
+     */
     List<Cofactor> getCofactors();
 
-    /** @return cofactor note */
+    /**
+     * @return cofactor note
+     */
     Note getNote();
 
     boolean hasCofactors();

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/Disease.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/Disease.java
@@ -53,12 +53,16 @@ import org.uniprot.core.uniprotkb.evidence.HasEvidences;
  * @see DiseaseComment
  */
 public interface Disease extends HasEvidences {
-    /** @return disease id (ID) */
+    /**
+     * @return disease id (ID)
+     */
     String getDiseaseId();
 
     String getDiseaseAccession();
 
-    /** @return disease acronym (AR) */
+    /**
+     * @return disease acronym (AR)
+     */
     String getAcronym();
 
     String getDescription();
@@ -71,7 +75,9 @@ public interface Disease extends HasEvidences {
 
     boolean hasDiseaseAccession();
 
-    /** @return disease acronym (AR) */
+    /**
+     * @return disease acronym (AR)
+     */
     boolean hasAcronym();
 
     boolean hasDescription();

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/DiseaseComment.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/comment/DiseaseComment.java
@@ -37,7 +37,9 @@ package org.uniprot.core.uniprotkb.comment;
  * @see Comment
  */
 public interface DiseaseComment extends Comment, HasMolecule {
-    /** @return the definition of the disease */
+    /**
+     * @return the definition of the disease
+     */
     Disease getDisease();
 
     /**

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/description/impl/ECBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/description/impl/ECBuilder.java
@@ -5,7 +5,9 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.uniprotkb.description.EC;
 import org.uniprot.core.uniprotkb.evidence.impl.AbstractEvidencedValueBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ECBuilder extends AbstractEvidencedValueBuilder<ECBuilder, EC> {
 
     @Override

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/description/impl/ProteinDescriptionBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/description/impl/ProteinDescriptionBuilder.java
@@ -11,7 +11,9 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.Builder;
 import org.uniprot.core.uniprotkb.description.*;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ProteinDescriptionBuilder implements Builder<ProteinDescription> {
 
     private ProteinName recommendedName;

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/EvidenceDatabaseTypes.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/EvidenceDatabaseTypes.java
@@ -99,7 +99,13 @@ public enum EvidenceDatabaseTypes {
                 "JaponicusDB",
                 evd("JaponicusDB", "JaponicusDB", "I", "https://www.japonicusdb.org/gene/%value"));
         typeMap.put("MGI", evd("MGI", "MGI", "I", "http://www.informatics.jax.org/marker/%value"));
-        typeMap.put("NCBIfam", evd("NCBIfam", "NCBIfam", "A", "https://www.ebi.ac.uk/interpro/entry/ncbifam/%value"));
+        typeMap.put(
+                "NCBIfam",
+                evd(
+                        "NCBIfam",
+                        "NCBIfam",
+                        "A",
+                        "https://www.ebi.ac.uk/interpro/entry/ncbifam/%value"));
         typeMap.put(
                 "PDB", evd("PDB", "PDB", "I", "https://www.ebi.ac.uk/pdbe-srv/view/entry/%value"));
         typeMap.put(

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceBuilder.java
@@ -23,7 +23,7 @@ public class EvidenceBuilder implements Builder<Evidence> {
 
     @Override
     public @Nonnull Evidence build() {
-        if(crossReference != null){
+        if (crossReference != null) {
             return new EvidenceImpl(evidenceCode, crossReference);
         } else if (databaseName == null && databaseId == null) {
             return new EvidenceImpl(evidenceCode, null);
@@ -55,7 +55,9 @@ public class EvidenceBuilder implements Builder<Evidence> {
         this.databaseId = databaseId;
         return this;
     }
-    public @Nonnull EvidenceBuilder crossReference(CrossReference<EvidenceDatabase> crossReference) {
+
+    public @Nonnull EvidenceBuilder crossReference(
+            CrossReference<EvidenceDatabase> crossReference) {
         this.crossReference = crossReference;
         return this;
     }

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonBuilder.java
@@ -13,7 +13,9 @@ import org.uniprot.core.uniprotkb.EntryInactiveReason;
 import org.uniprot.core.uniprotkb.InactiveReasonType;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class EntryInactiveReasonBuilder implements Builder<EntryInactiveReason> {
     private InactiveReasonType inactiveReasonType;
     private List<String> mergeDemergeTos = new ArrayList<>();

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonImpl.java
@@ -18,7 +18,10 @@ public class EntryInactiveReasonImpl implements EntryInactiveReason {
         this.mergeDemergeTo = Collections.emptyList();
     }
 
-    EntryInactiveReasonImpl(InactiveReasonType inactiveReasonType, List<String> mergeDemergeTo, DeletedReason deletedReason) {
+    EntryInactiveReasonImpl(
+            InactiveReasonType inactiveReasonType,
+            List<String> mergeDemergeTo,
+            DeletedReason deletedReason) {
         this.inactiveReasonType = inactiveReasonType;
         this.mergeDemergeTo = Utils.unmodifiableList(mergeDemergeTo);
         this.deletedReason = deletedReason;

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/GeneBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/GeneBuilder.java
@@ -11,7 +11,9 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.Builder;
 import org.uniprot.core.gene.*;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class GeneBuilder implements Builder<Gene> {
 
     private GeneName geneName = null;

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/GeneNameSynonymBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/GeneNameSynonymBuilder.java
@@ -10,7 +10,9 @@ import org.uniprot.core.gene.GeneNameSynonym;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.evidence.impl.AbstractEvidencedValueBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class GeneNameSynonymBuilder
         extends AbstractEvidencedValueBuilder<GeneNameSynonymBuilder, GeneNameSynonym> {
 

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/ORFNameBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/ORFNameBuilder.java
@@ -10,7 +10,9 @@ import org.uniprot.core.gene.ORFName;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.evidence.impl.AbstractEvidencedValueBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ORFNameBuilder extends AbstractEvidencedValueBuilder<ORFNameBuilder, ORFName> {
 
     public ORFNameBuilder() {}

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/OrderedLocusNameBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/OrderedLocusNameBuilder.java
@@ -10,7 +10,9 @@ import org.uniprot.core.gene.OrderedLocusName;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.evidence.impl.AbstractEvidencedValueBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class OrderedLocusNameBuilder
         extends AbstractEvidencedValueBuilder<OrderedLocusNameBuilder, OrderedLocusName> {
 

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/UniProtKBEntryImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/UniProtKBEntryImpl.java
@@ -98,8 +98,8 @@ public class UniProtKBEntryImpl implements UniProtKBEntry {
         } else if (Objects.isNull(primaryAccession) || nullOrEmpty(primaryAccession.getValue())) {
             throw new IllegalArgumentException("primaryAccession is Mandatory for uniprot entry.");
         } else if ((Objects.isNull(uniProtkbId) || nullOrEmpty(uniProtkbId.getValue()))
-                && 
-                (entryType != UniProtKBEntryType.INACTIVE && entryType != UniProtKBEntryType.AA)) {
+                && (entryType != UniProtKBEntryType.INACTIVE
+                        && entryType != UniProtKBEntryType.AA)) {
             throw new IllegalArgumentException("uniProtkbId is Mandatory for uniprot entry.");
         } else if (notNull(inactiveReason) && entryType != UniProtKBEntryType.INACTIVE) {
             throw new IllegalArgumentException("Inactive entry must have type INACTIVE");

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/UniProtKBReferenceImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/impl/UniProtKBReferenceImpl.java
@@ -112,6 +112,7 @@ public class UniProtKBReferenceImpl implements UniProtKBReference {
 
     @Override
     public int hashCode() {
-        return Objects.hash(referenceNumber, citation, referencePositions, referenceComments, evidences);
+        return Objects.hash(
+                referenceNumber, citation, referencePositions, referenceComments, evidences);
     }
 }

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/OrganismHost.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/OrganismHost.java
@@ -2,7 +2,9 @@ package org.uniprot.core.uniprotkb.taxonomy;
 
 import java.io.Serializable;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public interface OrganismHost extends OrganismName, Serializable {
 
     long getTaxonId();

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/AbstractOrganismNameBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/AbstractOrganismNameBuilder.java
@@ -1,5 +1,7 @@
 package org.uniprot.core.uniprotkb.taxonomy.impl;
 
+import static org.uniprot.core.util.Utils.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,8 +9,6 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.Builder;
 import org.uniprot.core.uniprotkb.taxonomy.OrganismName;
-
-import static org.uniprot.core.util.Utils.*;
 
 public abstract class AbstractOrganismNameBuilder<
                 B extends AbstractOrganismNameBuilder<B, T>, T extends OrganismName>

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/AbstractOrganismNameImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/AbstractOrganismNameImpl.java
@@ -9,7 +9,9 @@ import java.util.Objects;
 import org.uniprot.core.uniprotkb.taxonomy.OrganismName;
 import org.uniprot.core.util.Utils;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public abstract class AbstractOrganismNameImpl implements OrganismName {
 
     private static final long serialVersionUID = -4054471655650420667L;

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/OrganismBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/OrganismBuilder.java
@@ -11,7 +11,9 @@ import javax.annotation.Nonnull;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class OrganismBuilder extends AbstractOrganismNameBuilder<OrganismBuilder, Organism> {
     private long taxonId;
     private List<Evidence> evidences = new ArrayList<>();

--- a/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/OrganismHostImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniprotkb/taxonomy/impl/OrganismHostImpl.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 
 import org.uniprot.core.uniprotkb.taxonomy.OrganismHost;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class OrganismHostImpl extends AbstractOrganismNameImpl implements OrganismHost {
 
     private static final long serialVersionUID = 6516703868320522667L;

--- a/core-domain/src/main/java/org/uniprot/core/uniref/impl/AbstractUniRefMemberBuilder.java
+++ b/core-domain/src/main/java/org/uniprot/core/uniref/impl/AbstractUniRefMemberBuilder.java
@@ -29,7 +29,8 @@ public abstract class AbstractUniRefMemberBuilder<
     protected long organismTaxId;
     protected int sequenceLength;
     protected String proteinName;
-    protected List<UniProtKBAccession> accessions = new ArrayList<>();;
+    protected List<UniProtKBAccession> accessions = new ArrayList<>();
+    ;
     protected UniRefEntryId uniref50Id;
     protected UniRefEntryId uniref90Id;
     protected UniRefEntryId uniref100Id;

--- a/core-domain/src/main/java/org/uniprot/core/unirule/Annotation.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/Annotation.java
@@ -6,7 +6,9 @@ import org.uniprot.core.uniprotkb.comment.Comment;
 import org.uniprot.core.uniprotkb.description.ProteinDescription;
 import org.uniprot.core.uniprotkb.xdb.UniProtKBCrossReference;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface Annotation extends RuleExceptionAnnotation {
     Comment getComment();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/CaseRule.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/CaseRule.java
@@ -1,6 +1,8 @@
 package org.uniprot.core.unirule;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface CaseRule extends Rule {
     boolean isOverallStatsExempted();
 }

--- a/core-domain/src/main/java/org/uniprot/core/unirule/Condition.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/Condition.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.uniprot.core.Range;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface Condition extends Serializable {
     List<ConditionValue> getConditionValues();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/ConditionSet.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/ConditionSet.java
@@ -3,7 +3,9 @@ package org.uniprot.core.unirule;
 import java.io.Serializable;
 import java.util.List;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface ConditionSet extends Serializable {
     List<Condition> getConditions();
 }

--- a/core-domain/src/main/java/org/uniprot/core/unirule/ConditionValue.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/ConditionValue.java
@@ -2,7 +2,9 @@ package org.uniprot.core.unirule;
 
 import org.uniprot.core.Value;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface ConditionValue extends Value {
     String getCvId();
 }

--- a/core-domain/src/main/java/org/uniprot/core/unirule/DataClassType.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/DataClassType.java
@@ -4,7 +4,9 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.util.EnumDisplay;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public enum DataClassType implements EnumDisplay {
     PROTEIN("Protein"),
     DOMAIN("Domain");

--- a/core-domain/src/main/java/org/uniprot/core/unirule/Fusion.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/Fusion.java
@@ -3,7 +3,9 @@ package org.uniprot.core.unirule;
 import java.io.Serializable;
 import java.util.List;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface Fusion extends Serializable {
     List<String> getCters();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/Information.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/Information.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.uniprot.core.uniprotkb.UniProtKBAccession;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface Information extends Serializable {
     String getVersion();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/PositionFeatureSet.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/PositionFeatureSet.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.uniprot.core.uniprotkb.UniProtKBAccession;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface PositionFeatureSet extends Serializable {
     List<Condition> getConditions();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/PositionalFeature.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/PositionalFeature.java
@@ -4,7 +4,9 @@ import org.uniprot.core.Range;
 import org.uniprot.core.uniprotkb.feature.Ligand;
 import org.uniprot.core.uniprotkb.feature.LigandPart;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface PositionalFeature extends RuleExceptionAnnotation {
     Range getPosition();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/Rule.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/Rule.java
@@ -3,7 +3,9 @@ package org.uniprot.core.unirule;
 import java.io.Serializable;
 import java.util.List;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface Rule extends Serializable {
     List<ConditionSet> getConditionSets();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/RuleException.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/RuleException.java
@@ -5,7 +5,9 @@ import java.util.List;
 
 import org.uniprot.core.uniprotkb.UniProtKBAccession;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface RuleException extends Serializable {
     String getNote();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/SamFeatureSet.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/SamFeatureSet.java
@@ -3,7 +3,9 @@ package org.uniprot.core.unirule;
 import java.io.Serializable;
 import java.util.List;
 
-/** @author sahmad SAM - Sequence Analysis Method */
+/**
+ * @author sahmad SAM - Sequence Analysis Method
+ */
 public interface SamFeatureSet extends Serializable {
     List<Condition> getConditions();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/SamTrigger.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/SamTrigger.java
@@ -4,7 +4,9 @@ import java.io.Serializable;
 
 import org.uniprot.core.Range;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface SamTrigger extends Serializable {
     SamTriggerType getSamTriggerType();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/SamTriggerType.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/SamTriggerType.java
@@ -4,7 +4,9 @@ import javax.annotation.Nonnull;
 
 import org.uniprot.core.util.EnumDisplay;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public enum SamTriggerType implements EnumDisplay {
     TRANSMEMBRANE("transmembrane"),
     SIGNAL("signal"),

--- a/core-domain/src/main/java/org/uniprot/core/unirule/UniRuleEntry.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/UniRuleEntry.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import org.uniprot.core.Statistics;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface UniRuleEntry extends Serializable {
     UniRuleId getUniRuleId();
 

--- a/core-domain/src/main/java/org/uniprot/core/unirule/UniRuleId.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/UniRuleId.java
@@ -2,7 +2,9 @@ package org.uniprot.core.unirule;
 
 import org.uniprot.core.EntryId;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public interface UniRuleId extends EntryId {
     boolean isValidId();
 }

--- a/core-domain/src/main/java/org/uniprot/core/unirule/impl/UniRuleEntryImpl.java
+++ b/core-domain/src/main/java/org/uniprot/core/unirule/impl/UniRuleEntryImpl.java
@@ -15,7 +15,9 @@ import org.uniprot.core.unirule.UniRuleEntry;
 import org.uniprot.core.unirule.UniRuleId;
 import org.uniprot.core.util.Utils;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public class UniRuleEntryImpl implements UniRuleEntry {
     private static final long serialVersionUID = 656822574542548594L;
     private UniRuleId uniRuleId;

--- a/core-domain/src/test/java/org/uniprot/core/ObjectsForTests.java
+++ b/core-domain/src/test/java/org/uniprot/core/ObjectsForTests.java
@@ -1,5 +1,14 @@
 package org.uniprot.core;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.uniprot.core.citation.Citation;
 import org.uniprot.core.citation.CitationDatabase;
 import org.uniprot.core.citation.impl.AbstractCitationBuilder;
@@ -35,15 +44,6 @@ import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 
 public class ObjectsForTests {
     public static Reaction createReaction() {
@@ -221,7 +221,10 @@ public class ObjectsForTests {
     }
 
     public static List<SequenceFeature> sequenceFeatures() {
-        List<SequenceFeatureLocation> locations = Arrays.asList(new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(), new SequenceFeatureLocationBuilder().range(45, 89).build());
+        List<SequenceFeatureLocation> locations =
+                Arrays.asList(
+                        new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(),
+                        new SequenceFeatureLocationBuilder().range(45, 89).build());
         InterProGroup domain = new InterProGroupBuilder().name("name1").id("id1").build();
         SequenceFeature sf =
                 new SequenceFeatureBuilder()
@@ -238,7 +241,8 @@ public class ObjectsForTests {
     public static List<UniParcCrossReference> uniParcDBCrossReferences() {
         List<Property> properties = new ArrayList<>();
         properties.add(new Property("propertyOne", "some pname"));
-        Proteome proteomeIdComponent = new ProteomeBuilder().component("componentValue").id("proteomeId").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().component("componentValue").id("proteomeId").build();
         UniParcCrossReference xref =
                 new UniParcCrossReferenceBuilder()
                         .versionI(3)
@@ -259,7 +263,8 @@ public class ObjectsForTests {
 
         List<Property> properties2 = new ArrayList<>();
         properties.add(new Property("propertyTwo", "some pname"));
-        Proteome proteomeIdComponent2 = new ProteomeBuilder().component("componentValue2").id("proteomeId2").build();
+        Proteome proteomeIdComponent2 =
+                new ProteomeBuilder().component("componentValue2").id("proteomeId2").build();
 
         UniParcCrossReference xref2 =
                 new UniParcCrossReferenceBuilder()

--- a/core-domain/src/test/java/org/uniprot/core/cv/xdb/UniProtKBDatabaseDetailTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/cv/xdb/UniProtKBDatabaseDetailTest.java
@@ -96,22 +96,27 @@ class UniProtKBDatabaseDetailTest {
 
     @Test
     void testEqualWithUniProtDataTypeValue() {
-        UniProtDatabaseDetail uniProtKB0 = createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
-        UniProtDatabaseDetail uniProtKB1 = createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
+        UniProtDatabaseDetail uniProtKB0 =
+                createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
+        UniProtDatabaseDetail uniProtKB1 =
+                createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
         assertEquals(uniProtKB0, uniProtKB1);
     }
 
     @Test
     void testNotEqualWithUniProtDataTypeValue() {
-        UniProtDatabaseDetail uniProtKB = createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
-        UniProtDatabaseDetail disease = createUniProtDatabaseDetailWithUniProtDataType(List.of("disease"));
+        UniProtDatabaseDetail uniProtKB =
+                createUniProtDatabaseDetailWithUniProtDataType(List.of("uniProtKB"));
+        UniProtDatabaseDetail disease =
+                createUniProtDatabaseDetailWithUniProtDataType(List.of("disease"));
         assertNotEquals(uniProtKB, disease);
     }
 
     @Test
     void testCreateWithUniProtDataTypeReturnsSameValue() {
         List<String> uniProtKBTypes = List.of("uniProtKB");
-        UniProtDatabaseDetail uniProtKB = createUniProtDatabaseDetailWithUniProtDataType(uniProtKBTypes);
+        UniProtDatabaseDetail uniProtKB =
+                createUniProtDatabaseDetailWithUniProtDataType(uniProtKBTypes);
         assertSame(uniProtKB.getUniProtDataTypes(), uniProtKBTypes);
     }
 
@@ -162,9 +167,19 @@ class UniProtKBDatabaseDetailTest {
         }
     }
 
-    private UniProtDatabaseDetail createUniProtDatabaseDetailWithUniProtDataType(List<String> uniProtDatabaseDetail) {
+    private UniProtDatabaseDetail createUniProtDatabaseDetailWithUniProtDataType(
+            List<String> uniProtDatabaseDetail) {
         return new UniProtDatabaseDetail(
-                name, displayName, category, uriLink, attributes, false, null, idMappingName, null, uniProtDatabaseDetail);
+                name,
+                displayName,
+                category,
+                uriLink,
+                attributes,
+                false,
+                null,
+                idMappingName,
+                null,
+                uniProtDatabaseDetail);
     }
 
     static UniProtDatabaseDetail createUniProtDatabaseDetail(

--- a/core-domain/src/test/java/org/uniprot/core/literature/impl/LiteratureEntryBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/literature/impl/LiteratureEntryBuilderTest.java
@@ -8,7 +8,9 @@ import static org.uniprot.core.ObjectsForTests.createCompleteLiteratureStatistic
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.literature.LiteratureEntry;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class LiteratureEntryBuilderTest {
 
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/literature/impl/LiteratureStatisticsBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/literature/impl/LiteratureStatisticsBuilderTest.java
@@ -6,7 +6,9 @@ import static org.uniprot.core.ObjectsForTests.createCompleteLiteratureStatistic
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.literature.LiteratureStatistics;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class LiteratureStatisticsBuilderTest {
 
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/proteome/impl/ProteomeEntryBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/proteome/impl/ProteomeEntryBuilderTest.java
@@ -1,5 +1,15 @@
 package org.uniprot.core.proteome.impl;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.ObjectsForTests.updateCitationBuilderWithCommonAttributes;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.citation.Citation;
 import org.uniprot.core.citation.JournalArticle;
@@ -12,16 +22,6 @@ import org.uniprot.core.taxonomy.TaxonomyLineage;
 import org.uniprot.core.taxonomy.impl.TaxonomyLineageBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.ObjectsForTests.updateCitationBuilderWithCommonAttributes;
 
 class ProteomeEntryBuilderTest {
 

--- a/core-domain/src/test/java/org/uniprot/core/proteome/impl/RelatedProteomeBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/proteome/impl/RelatedProteomeBuilderTest.java
@@ -1,12 +1,12 @@
 package org.uniprot.core.proteome.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.proteome.ProteomeId;
 import org.uniprot.core.proteome.RelatedProteome;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RelatedProteomeBuilderTest {
 
@@ -33,15 +33,17 @@ public class RelatedProteomeBuilderTest {
         assertEquals(taxonomy, proteome.getTaxId());
     }
 
-
     @Test
     void testFromProteome() {
         String id = "UP000004340";
         ProteomeId proteomeId = new ProteomeIdBuilder(id).build();
         Taxonomy taxonomy =
                 new TaxonomyBuilder().taxonId(9606).scientificName("Homo sapiens").build();
-        RelatedProteomeBuilder builder = new RelatedProteomeBuilder().proteomeId(proteomeId).similarity(0.2f)
-                .taxonomy(taxonomy);
+        RelatedProteomeBuilder builder =
+                new RelatedProteomeBuilder()
+                        .proteomeId(proteomeId)
+                        .similarity(0.2f)
+                        .taxonomy(taxonomy);
         RelatedProteome proteome = builder.build();
         RelatedProteome proteome1 = RelatedProteomeBuilder.from(proteome).build();
         assertEquals(proteome1, proteome);

--- a/core-domain/src/test/java/org/uniprot/core/proteome/impl/RelatedProteomeImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/proteome/impl/RelatedProteomeImplTest.java
@@ -1,11 +1,11 @@
 package org.uniprot.core.proteome.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.proteome.RelatedProteome;
 import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class RelatedProteomeImplTest {
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/publication/impl/MappedPublicationsBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/publication/impl/MappedPublicationsBuilderTest.java
@@ -2,7 +2,6 @@ package org.uniprot.core.publication.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/UniParcDatabaseTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/UniParcDatabaseTest.java
@@ -66,12 +66,12 @@ class UniParcDatabaseTest {
 
     @Test
     void isSource() {
-        assertTrue( UniParcDatabase.EMBL.isSource());
+        assertTrue(UniParcDatabase.EMBL.isSource());
     }
 
     @Test
     void isNotSource() {
-        assertFalse( UniParcDatabase.FLYBASE.isSource());
+        assertFalse(UniParcDatabase.FLYBASE.isSource());
     }
 
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/CommonOrganismBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/CommonOrganismBuilderTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.CommonOrganism;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class CommonOrganismBuilderTest {
     @Test
@@ -26,7 +26,12 @@ class CommonOrganismBuilderTest {
 
     @Test
     void testFrom() {
-        CommonOrganism common = new CommonOrganismBuilder().topLevel("toLevel1").commonTaxon("common1").commonTaxonId(987L).build();
+        CommonOrganism common =
+                new CommonOrganismBuilder()
+                        .topLevel("toLevel1")
+                        .commonTaxon("common1")
+                        .commonTaxonId(987L)
+                        .build();
         CommonOrganism common1 = CommonOrganismBuilder.from(common).build();
         assertEquals(common, common1);
         CommonOrganism common3 = CommonOrganismBuilder.from(common).commonTaxon("common3").build();

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/CommonOrganismImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/CommonOrganismImplTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.CommonOrganism;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class CommonOrganismImplTest {
 

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/ProteomeBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/ProteomeBuilderTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.Proteome;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class ProteomeBuilderTest {
     @Test

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/ProteomeImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/ProteomeImplTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.Proteome;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class ProteomeImplTest {
 

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureBuilderTest.java
@@ -52,7 +52,10 @@ class SequenceFeatureBuilderTest {
 
     @Test
     void testLocations() {
-        List<SequenceFeatureLocation> locations = Arrays.asList(new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(), new SequenceFeatureLocationBuilder().range(45, 89).build());
+        List<SequenceFeatureLocation> locations =
+                Arrays.asList(
+                        new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(),
+                        new SequenceFeatureLocationBuilder().range(45, 89).build());
         InterProGroup domain = new InterProGroupBuilder().name("name1").id("id1").build();
         SequenceFeature sf =
                 new SequenceFeatureBuilder()
@@ -69,7 +72,10 @@ class SequenceFeatureBuilderTest {
 
     @Test
     void testAddLocation() {
-        List<SequenceFeatureLocation> locations = Arrays.asList(new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(), new SequenceFeatureLocationBuilder().range(45, 89).build());
+        List<SequenceFeatureLocation> locations =
+                Arrays.asList(
+                        new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(),
+                        new SequenceFeatureLocationBuilder().range(45, 89).build());
         InterProGroup domain = new InterProGroupBuilder().name("name1").id("id1").build();
         SequenceFeature sf =
                 new SequenceFeatureBuilder()
@@ -87,7 +93,10 @@ class SequenceFeatureBuilderTest {
 
     @Test
     void testFrom() {
-        List<SequenceFeatureLocation> locations = Arrays.asList(new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(), new SequenceFeatureLocationBuilder().range(45, 89).build());
+        List<SequenceFeatureLocation> locations =
+                Arrays.asList(
+                        new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(),
+                        new SequenceFeatureLocationBuilder().range(45, 89).build());
         InterProGroup domain = new InterProGroupBuilder().name("name1").id("id1").build();
         SequenceFeature sf =
                 new SequenceFeatureBuilder()

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationBuilderTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.SequenceFeatureLocation;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class SequenceFeatureLocationBuilderTest {
     @Test
@@ -17,8 +17,7 @@ class SequenceFeatureLocationBuilderTest {
     @Test
     void testEnd() {
         int end = 20;
-        SequenceFeatureLocation location =
-                new SequenceFeatureLocationBuilder().end(end).build();
+        SequenceFeatureLocation location = new SequenceFeatureLocationBuilder().end(end).build();
         assertEquals(end, location.getEnd());
     }
 
@@ -39,10 +38,12 @@ class SequenceFeatureLocationBuilderTest {
                 new SequenceFeatureLocationBuilder().alignment(alignment).build();
         assertEquals(alignment, location.getAlignment());
     }
+
     @Test
     void testFromSequenceFeatureLocation() {
         SequenceFeatureLocation location = new SequenceFeatureLocationImpl(10, 20, "VALUE");
-        SequenceFeatureLocation fromLocation = SequenceFeatureLocationBuilder.from(location).build();
+        SequenceFeatureLocation fromLocation =
+                SequenceFeatureLocationBuilder.from(location).build();
         assertEquals(location, fromLocation);
     }
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/SequenceFeatureLocationImplTest.java
@@ -1,9 +1,9 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.SequenceFeatureLocation;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class SequenceFeatureLocationImplTest {
 
@@ -15,8 +15,7 @@ class SequenceFeatureLocationImplTest {
 
     @Test
     void builderFrom_constructorImp_shouldCreate_equalObject() {
-        SequenceFeatureLocationImpl impl =
-                new SequenceFeatureLocationImpl(10,20, "component");
+        SequenceFeatureLocationImpl impl = new SequenceFeatureLocationImpl(10, 20, "component");
         SequenceFeatureLocation obj = SequenceFeatureLocationBuilder.from(impl).build();
         assertTrue(impl.equals(obj) && obj.equals(impl));
         assertEquals(impl.hashCode(), obj.hashCode());

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceBuilderTest.java
@@ -1,5 +1,11 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.uniparc.Proteome;
@@ -7,12 +13,6 @@ import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author jluo
@@ -108,7 +108,8 @@ class UniParcCrossReferenceBuilderTest {
     void testProteomeIdComponentsSet() {
         String proteomeId = "proteomeId value";
         String component = "component value";
-        List<Proteome> proteomeIdComponents = List.of(new ProteomeBuilder().id(proteomeId).component(component).build());
+        List<Proteome> proteomeIdComponents =
+                List.of(new ProteomeBuilder().id(proteomeId).component(component).build());
         UniParcCrossReference xref =
                 new UniParcCrossReferenceBuilder().proteomesSet(proteomeIdComponents).build();
         assertEquals(proteomeIdComponents, xref.getProteomes());
@@ -120,12 +121,14 @@ class UniParcCrossReferenceBuilderTest {
         String component = "component value";
         List<Proteome> proteomeIdComponents = new ArrayList<>();
         proteomeIdComponents.add(new ProteomeBuilder().id(proteomeId).component(component).build());
-        UniParcCrossReferenceBuilder builder = new UniParcCrossReferenceBuilder().proteomesSet(proteomeIdComponents);
+        UniParcCrossReferenceBuilder builder =
+                new UniParcCrossReferenceBuilder().proteomesSet(proteomeIdComponents);
         UniParcCrossReference xref = builder.build();
         assertEquals(proteomeIdComponents, xref.getProteomes());
         String proteomeId2 = "proteomeId value2";
         String component2 = "component value2";
-        Proteome proteomeIdComponent2 = new ProteomeBuilder().id(proteomeId2).component(component2).build();
+        Proteome proteomeIdComponent2 =
+                new ProteomeBuilder().id(proteomeId2).component(component2).build();
         builder.proteomesAdd(proteomeIdComponent2);
         xref = builder.build();
         assertEquals(2, xref.getProteomes().size());

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferenceImplTest.java
@@ -1,15 +1,15 @@
 package org.uniprot.core.uniparc.impl;
 
-import org.junit.jupiter.api.Test;
-import org.uniprot.core.uniparc.UniParcCrossReference;
-import org.uniprot.core.uniparc.UniParcDatabase;
-import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.uniprot.core.uniparc.UniParcCrossReference;
+import org.uniprot.core.uniparc.UniParcDatabase;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
 class UniParcCrossReferenceImplTest {
     @Test
@@ -35,7 +35,11 @@ class UniParcCrossReferenceImplTest {
                         new OrganismBuilder().taxonId(10L).scientificName("sName").build(),
                         "chain",
                         "ncbiGi",
-                        List.of(new ProteomeBuilder().id("proteomeId").component("component").build()));
+                        List.of(
+                                new ProteomeBuilder()
+                                        .id("proteomeId")
+                                        .component("component")
+                                        .build()));
         UniParcCrossReference obj = UniParcCrossReferenceBuilder.from(impl).build();
         assertTrue(impl.equals(obj) && obj.equals(impl));
         assertEquals(impl.hashCode(), obj.hashCode());

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferencePairTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcCrossReferencePairTest.java
@@ -1,17 +1,17 @@
 package org.uniprot.core.uniparc.impl;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.uniprot.core.uniparc.UniParcCrossReference;
-import org.uniprot.core.uniparc.UniParcDatabase;
-import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.uniprot.core.uniparc.UniParcCrossReference;
+import org.uniprot.core.uniparc.UniParcDatabase;
+import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
 class UniParcCrossReferencePairTest {
 
@@ -42,13 +42,15 @@ class UniParcCrossReferencePairTest {
                         new OrganismBuilder().taxonId(10L).scientificName("sName").build(),
                         "chain",
                         "ncbiGi",
-                        List.of(new ProteomeBuilder().id("proteomeId").component("component").build())
-                );
+                        List.of(
+                                new ProteomeBuilder()
+                                        .id("proteomeId")
+                                        .component("component")
+                                        .build()));
         String key = "Sample";
         UniParcCrossReferencePair pair1 = new UniParcCrossReferencePair(key, List.of(xref1));
         UniParcCrossReferencePair pair2 = new UniParcCrossReferencePair(key, List.of(xref1));
         assertTrue(pair1.equals(pair2) && pair2.equals(pair1));
         assertEquals(pair1.hashCode(), pair2.hashCode());
     }
-
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcEntryLightBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcEntryLightBuilderTest.java
@@ -1,5 +1,13 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.ObjectsForTests.sequenceFeatures;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
@@ -11,23 +19,11 @@ import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.ObjectsForTests.sequenceFeatures;
-
-
 class UniParcEntryLightBuilderTest {
 
     @Test
     void testUniParcIdString() {
-        UniParcEntryLight entry =
-                new UniParcEntryLightBuilder()
-                        .uniParcId("UPI0000083A08")
-                        .build();
+        UniParcEntryLight entry = new UniParcEntryLightBuilder().uniParcId("UPI0000083A08").build();
         assertEquals("UPI0000083A08", entry.getUniParcId());
         assertNull(entry.getOldestCrossRefCreated());
         assertNull(entry.getMostRecentCrossRefUpdated());
@@ -36,24 +32,31 @@ class UniParcEntryLightBuilderTest {
     @Test
     void testCrossReferenceCount() {
         int crossReferenceCount = 20;
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().crossReferenceCount(crossReferenceCount).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().crossReferenceCount(crossReferenceCount).build();
         assertEquals(crossReferenceCount, entry.getCrossReferenceCount());
     }
 
     @Test
     void testCommonTaxonsSet() {
-        List<CommonOrganism> commonTaxons = List.of(
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
-                new CommonOrganismBuilder().topLevel("unclassified").commonTaxon("Mus musculus").build()
-        );
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().commonTaxonsSet(commonTaxons).build();
+        List<CommonOrganism> commonTaxons =
+                List.of(
+                        new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
+                        new CommonOrganismBuilder()
+                                .topLevel("unclassified")
+                                .commonTaxon("Mus musculus")
+                                .build());
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().commonTaxonsSet(commonTaxons).build();
         assertEquals(commonTaxons, entry.getCommonTaxons());
     }
 
     @Test
     void testCommonTaxonsAdd() {
-        CommonOrganism commonTaxon = new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("Homo sapiens").build();
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().commonTaxonsAdd(commonTaxon).build();
+        CommonOrganism commonTaxon =
+                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("Homo sapiens").build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().commonTaxonsAdd(commonTaxon).build();
         assertTrue(entry.getCommonTaxons().contains(commonTaxon));
     }
 
@@ -65,40 +68,53 @@ class UniParcEntryLightBuilderTest {
 
     @Test
     void testCommonTaxonsSetThenAdd() {
-        List<CommonOrganism> commonTaxons = List.of(
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build());
-        CommonOrganism additionalCommonTaxon = new CommonOrganismBuilder()
-                .topLevel("Other type")
-                .commonTaxon("Mus musculus")
-                .build();
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .commonTaxonsSet(commonTaxons)
-                .commonTaxonsAdd(additionalCommonTaxon)
-                .build();
+        List<CommonOrganism> commonTaxons =
+                List.of(new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build());
+        CommonOrganism additionalCommonTaxon =
+                new CommonOrganismBuilder()
+                        .topLevel("Other type")
+                        .commonTaxon("Mus musculus")
+                        .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .commonTaxonsSet(commonTaxons)
+                        .commonTaxonsAdd(additionalCommonTaxon)
+                        .build();
         assertEquals(2, entry.getCommonTaxons().size());
-        assertTrue(entry.getCommonTaxons().containsAll(List.of(
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
-                new CommonOrganismBuilder().topLevel("Other type").commonTaxon("Mus musculus").build()
-        )));
+        assertTrue(
+                entry.getCommonTaxons()
+                        .containsAll(
+                                List.of(
+                                        new CommonOrganismBuilder()
+                                                .topLevel("Viruses")
+                                                .commonTaxon("HIV")
+                                                .build(),
+                                        new CommonOrganismBuilder()
+                                                .topLevel("Other type")
+                                                .commonTaxon("Mus musculus")
+                                                .build())));
     }
 
     @Test
     void testUniProtKBAccessionsSet() {
         LinkedHashSet<String> accessions = new LinkedHashSet<>(List.of("P12345", "Q67890"));
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().uniProtKBAccessionsSet(accessions).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().uniProtKBAccessionsSet(accessions).build();
         assertEquals(accessions, entry.getUniProtKBAccessions());
     }
 
     @Test
     void testUniProtKBAccessionsAdd() {
         String accession = "P12345";
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().uniProtKBAccessionsAdd(accession).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().uniProtKBAccessionsAdd(accession).build();
         assertTrue(entry.getUniProtKBAccessions().contains(accession));
     }
 
     @Test
     void testUniProtKBAccessionsAddNull() {
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().uniProtKBAccessionsAdd(null).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().uniProtKBAccessionsAdd(null).build();
         assertTrue(entry.getUniProtKBAccessions().isEmpty());
     }
 
@@ -106,10 +122,11 @@ class UniParcEntryLightBuilderTest {
     void testUniProtKBAccessionsSetThenAdd() {
         LinkedHashSet<String> accessions = new LinkedHashSet<>(List.of("P12345"));
         String additionalAccession = "Q67890";
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .uniProtKBAccessionsSet(accessions)
-                .uniProtKBAccessionsAdd(additionalAccession)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .uniProtKBAccessionsSet(accessions)
+                        .uniProtKBAccessionsAdd(additionalAccession)
+                        .build();
         assertEquals(2, entry.getUniProtKBAccessions().size());
         assertTrue(entry.getUniProtKBAccessions().containsAll(List.of("P12345", "Q67890")));
     }
@@ -125,14 +142,16 @@ class UniParcEntryLightBuilderTest {
     @Test
     void testSequenceFeaturesSet() {
         List<SequenceFeature> sequenceFeatures = sequenceFeatures();
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().sequenceFeaturesSet(sequenceFeatures).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().sequenceFeaturesSet(sequenceFeatures).build();
         assertEquals(sequenceFeatures, entry.getSequenceFeatures());
     }
 
     @Test
     void testSequenceFeaturesAdd() {
         SequenceFeature sequenceFeature = sequenceFeatures().get(0);
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().sequenceFeaturesAdd(sequenceFeature).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().sequenceFeaturesAdd(sequenceFeature).build();
         assertTrue(entry.getSequenceFeatures().contains(sequenceFeature));
     }
 
@@ -146,31 +165,36 @@ class UniParcEntryLightBuilderTest {
     void testSequenceFeaturesSetThenAdd() {
         List<SequenceFeature> sequenceFeatures = sequenceFeatures();
         SequenceFeature feature2 = sequenceFeatures().get(0);
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .sequenceFeaturesSet(sequenceFeatures)
-                .sequenceFeaturesAdd(feature2)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .sequenceFeaturesSet(sequenceFeatures)
+                        .sequenceFeaturesAdd(feature2)
+                        .build();
         assertEquals(sequenceFeatures.size() + 1, entry.getSequenceFeatures().size());
     }
 
     @Test
     void testOldestCrossRefCreated() {
         LocalDate date = LocalDate.of(2022, 1, 1);
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().oldestCrossRefCreated(date).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().oldestCrossRefCreated(date).build();
         assertEquals(date, entry.getOldestCrossRefCreated());
     }
 
     @Test
     void testMostRecentCrossRefUpdated() {
         LocalDate date = LocalDate.of(2023, 1, 1);
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().mostRecentCrossRefUpdated(date).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().mostRecentCrossRefUpdated(date).build();
         assertEquals(date, entry.getMostRecentCrossRefUpdated());
     }
 
     @Test
     void testOrganismsSet() {
-        Organism organism1 = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
-        Organism organism2 = new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
+        Organism organism1 =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism2 =
+                new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism1, organism2));
         UniParcEntryLight entry = new UniParcEntryLightBuilder().organismsSet(organisms).build();
         assertEquals(organisms, entry.getOrganisms());
@@ -178,7 +202,8 @@ class UniParcEntryLightBuilderTest {
 
     @Test
     void testOrganismsAdd() {
-        Organism organism = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
         UniParcEntryLight entry = new UniParcEntryLightBuilder().organismsAdd(organism).build();
         assertTrue(entry.getOrganisms().contains(organism));
     }
@@ -186,14 +211,16 @@ class UniParcEntryLightBuilderTest {
     @Test
     void testProteinNamesSet() {
         LinkedHashSet<String> proteinNames = new LinkedHashSet<>(List.of("Protein1", "Protein2"));
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().proteinNamesSet(proteinNames).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().proteinNamesSet(proteinNames).build();
         assertEquals(proteinNames, entry.getProteinNames());
     }
 
     @Test
     void testProteinNamesAdd() {
         String proteinName = "Protein1";
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().proteinNamesAdd(proteinName).build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder().proteinNamesAdd(proteinName).build();
         assertTrue(entry.getProteinNames().contains(proteinName));
     }
 
@@ -213,7 +240,11 @@ class UniParcEntryLightBuilderTest {
 
     @Test
     void testProteomesSet() {
-        LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(new ProteomeBuilder().id("UP000005640").component("C1").build(), new ProteomeBuilder().id("UP000002494").component("C2").build()));
+        LinkedHashSet<Proteome> proteomes =
+                new LinkedHashSet<>(
+                        List.of(
+                                new ProteomeBuilder().id("UP000005640").component("C1").build(),
+                                new ProteomeBuilder().id("UP000002494").component("C2").build()));
         UniParcEntryLight entry = new UniParcEntryLightBuilder().proteomesSet(proteomes).build();
         assertEquals(proteomes, entry.getProteomes());
     }
@@ -227,27 +258,33 @@ class UniParcEntryLightBuilderTest {
 
     @Test
     void testProteomesSetThenAdd() {
-        Proteome proteome1 = new ProteomeBuilder().id("UP000005640").component("chromosome").build();
+        Proteome proteome1 =
+                new ProteomeBuilder().id("UP000005640").component("chromosome").build();
         LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(proteome1));
-        Proteome proteome2 = new ProteomeBuilder().id("UP000002494").component("chromosome").build();
+        Proteome proteome2 =
+                new ProteomeBuilder().id("UP000002494").component("chromosome").build();
 
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .proteomesSet(proteomes)
-                .proteomesAdd(proteome2)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .proteomesSet(proteomes)
+                        .proteomesAdd(proteome2)
+                        .build();
         assertEquals(2, entry.getProteomes().size());
         assertTrue(entry.getProteomes().containsAll(List.of(proteome1, proteome2)));
     }
 
     @Test
     void testOrganismsSetThenAdd() {
-        Organism organism1 = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
-        Organism organism2 = new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
+        Organism organism1 =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism2 =
+                new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism1));
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .organismsSet(organisms)
-                .organismsAdd(organism2)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .organismsSet(organisms)
+                        .organismsAdd(organism2)
+                        .build();
         assertEquals(2, entry.getOrganisms().size());
         assertTrue(entry.getOrganisms().containsAll(List.of(organism1, organism2)));
     }
@@ -256,10 +293,11 @@ class UniParcEntryLightBuilderTest {
     void testProteinNamesSetThenAdd() {
         LinkedHashSet<String> proteinNames = new LinkedHashSet<>(List.of("Protein1"));
         String proteinName = "Protein2";
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .proteinNamesSet(proteinNames)
-                .proteinNamesAdd(proteinName)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .proteinNamesSet(proteinNames)
+                        .proteinNamesAdd(proteinName)
+                        .build();
         assertEquals(2, entry.getProteinNames().size());
         assertTrue(entry.getProteinNames().containsAll(List.of("Protein1", "Protein2")));
     }
@@ -268,49 +306,60 @@ class UniParcEntryLightBuilderTest {
     void testGeneNamesSetThenAdd() {
         LinkedHashSet<String> geneNames = new LinkedHashSet<>(List.of("Gene1"));
         String geneName = "Gene2";
-        UniParcEntryLight entry = new UniParcEntryLightBuilder()
-                .geneNamesSet(geneNames)
-                .geneNamesAdd(geneName)
-                .build();
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .geneNamesSet(geneNames)
+                        .geneNamesAdd(geneName)
+                        .build();
         assertEquals(2, entry.getGeneNames().size());
         assertTrue(entry.getGeneNames().containsAll(List.of("Gene1", "Gene2")));
     }
-
 
     @Test
     void testFrom() {
         String uniParcId = "UPI0000000001";
         int crossReferenceCount = 18;
-        List<CommonOrganism> commonTaxons = List.of(
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
-                new CommonOrganismBuilder().topLevel("unclassified").commonTaxon("Mus musculus").build());
+        List<CommonOrganism> commonTaxons =
+                List.of(
+                        new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
+                        new CommonOrganismBuilder()
+                                .topLevel("unclassified")
+                                .commonTaxon("Mus musculus")
+                                .build());
         String seq = "MVSWGRFICLVVVTMATLSLARPSFSLVED";
         Sequence sequence = new SequenceBuilder(seq).build();
         List<SequenceFeature> sequenceFeatures = sequenceFeatures();
         LocalDate oldestCrossRefCreated = LocalDate.of(2022, 1, 1);
         LocalDate mostRecentCrossRefUpdated = LocalDate.of(2023, 1, 1);
 
-        Organism organism1 = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
-        Organism organism2 = new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
+        Organism organism1 =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism2 =
+                new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism1, organism2));
 
         LinkedHashSet<String> proteinNames = new LinkedHashSet(List.of("Protein1", "Protein2"));
         LinkedHashSet<String> geneNames = new LinkedHashSet(List.of("Gene1", "Gene2"));
-        LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(new ProteomeBuilder().id("UP000005640").component("C1").build(), new ProteomeBuilder().id("UP000002494").component("C2").build()));
+        LinkedHashSet<Proteome> proteomes =
+                new LinkedHashSet<>(
+                        List.of(
+                                new ProteomeBuilder().id("UP000005640").component("C1").build(),
+                                new ProteomeBuilder().id("UP000002494").component("C2").build()));
 
-        UniParcEntryLight originalEntry = new UniParcEntryLightBuilder()
-                .uniParcId(uniParcId)
-                .crossReferenceCount(crossReferenceCount)
-                .commonTaxonsSet(commonTaxons)
-                .sequence(sequence)
-                .sequenceFeaturesSet(sequenceFeatures)
-                .oldestCrossRefCreated(oldestCrossRefCreated)
-                .mostRecentCrossRefUpdated(mostRecentCrossRefUpdated)
-                .organismsSet(organisms)
-                .proteinNamesSet(proteinNames)
-                .geneNamesSet(geneNames)
-                .proteomesSet(proteomes)
-                .build();
+        UniParcEntryLight originalEntry =
+                new UniParcEntryLightBuilder()
+                        .uniParcId(uniParcId)
+                        .crossReferenceCount(crossReferenceCount)
+                        .commonTaxonsSet(commonTaxons)
+                        .sequence(sequence)
+                        .sequenceFeaturesSet(sequenceFeatures)
+                        .oldestCrossRefCreated(oldestCrossRefCreated)
+                        .mostRecentCrossRefUpdated(mostRecentCrossRefUpdated)
+                        .organismsSet(organisms)
+                        .proteinNamesSet(proteinNames)
+                        .geneNamesSet(geneNames)
+                        .proteomesSet(proteomes)
+                        .build();
 
         UniParcEntryLight newEntry = UniParcEntryLightBuilder.from(originalEntry).build();
 
@@ -318,7 +367,7 @@ class UniParcEntryLightBuilderTest {
     }
 
     @Test
-    void testFromWithEmptyAccessions(){
+    void testFromWithEmptyAccessions() {
         UniParcEntryLight entry =
                 new UniParcEntryLightBuilder()
                         .uniParcId("UPI0000083A08")
@@ -331,53 +380,63 @@ class UniParcEntryLightBuilderTest {
     }
 
     @Test
-    void testExtraAttributes(){
-        UniParcEntryLight entry = new UniParcEntryLightBuilder().uniParcId("UPI0000083A08")
-                .extraAttributesAdd("hasActiveCrossRef", true).build();
+    void testExtraAttributes() {
+        UniParcEntryLight entry =
+                new UniParcEntryLightBuilder()
+                        .uniParcId("UPI0000083A08")
+                        .extraAttributesAdd("hasActiveCrossRef", true)
+                        .build();
         assertEquals("UPI0000083A08", entry.getUniParcId());
         assertEquals(1, entry.getExtraAttributes().size());
         assertEquals(true, entry.getExtraAttributes().get("hasActiveCrossRef"));
     }
+
     @Test
-    void testAddExtraAttributes(){
+    void testAddExtraAttributes() {
         UniParcEntryLight entry = new UniParcEntryLightBuilder().uniParcId("UPI0000083A08").build();
         assertEquals("UPI0000083A08", entry.getUniParcId());
         assertTrue(entry.getExtraAttributes().isEmpty());
         // add extra attribute
-        UniParcEntryLight updatedEntry = UniParcEntryLightBuilder.from(entry)
-                .extraAttributesAdd("hasActiveCrossRef", false).build();
+        UniParcEntryLight updatedEntry =
+                UniParcEntryLightBuilder.from(entry)
+                        .extraAttributesAdd("hasActiveCrossRef", false)
+                        .build();
         assertEquals("UPI0000083A08", updatedEntry.getUniParcId());
         assertEquals(1, updatedEntry.getExtraAttributes().size());
         assertEquals(false, updatedEntry.getExtraAttributes().get("hasActiveCrossRef"));
     }
 
     @Test
-    void testSetExtraAttributes(){
+    void testSetExtraAttributes() {
         UniParcEntryLight entry = new UniParcEntryLightBuilder().uniParcId("UPI0000083A08").build();
         assertEquals("UPI0000083A08", entry.getUniParcId());
         assertTrue(entry.getExtraAttributes().isEmpty());
         // set extra attribute
-        UniParcEntryLight updatedEntry = UniParcEntryLightBuilder.from(entry)
-                .extraAttributesSet(Map.of("hasActiveCrossRef", false, "another", "random")).build();
+        UniParcEntryLight updatedEntry =
+                UniParcEntryLightBuilder.from(entry)
+                        .extraAttributesSet(Map.of("hasActiveCrossRef", false, "another", "random"))
+                        .build();
         assertEquals("UPI0000083A08", updatedEntry.getUniParcId());
         assertEquals(2, updatedEntry.getExtraAttributes().size());
         assertEquals(false, updatedEntry.getExtraAttributes().get("hasActiveCrossRef"));
         assertEquals("random", updatedEntry.getExtraAttributes().get("another"));
     }
 
-    private void verifyOriginalAndNewEntry(UniParcEntryLight originalEntry, UniParcEntryLight newEntry) {
+    private void verifyOriginalAndNewEntry(
+            UniParcEntryLight originalEntry, UniParcEntryLight newEntry) {
         assertEquals(originalEntry.getUniParcId(), newEntry.getUniParcId());
         assertEquals(originalEntry.getCrossReferenceCount(), newEntry.getCrossReferenceCount());
         assertEquals(originalEntry.getCommonTaxons(), newEntry.getCommonTaxons());
         assertEquals(originalEntry.getSequence(), newEntry.getSequence());
         assertEquals(originalEntry.getSequenceFeatures(), newEntry.getSequenceFeatures());
         assertEquals(originalEntry.getOldestCrossRefCreated(), newEntry.getOldestCrossRefCreated());
-        assertEquals(originalEntry.getMostRecentCrossRefUpdated(), newEntry.getMostRecentCrossRefUpdated());
+        assertEquals(
+                originalEntry.getMostRecentCrossRefUpdated(),
+                newEntry.getMostRecentCrossRefUpdated());
         assertEquals(originalEntry.getOrganisms(), newEntry.getOrganisms());
         assertEquals(originalEntry.getProteinNames(), newEntry.getProteinNames());
         assertEquals(originalEntry.getGeneNames(), newEntry.getGeneNames());
         assertEquals(originalEntry.getProteomes(), newEntry.getProteomes());
         assertEquals(originalEntry, newEntry);
     }
-
 }

--- a/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcEntryLightImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniparc/impl/UniParcEntryLightImplTest.java
@@ -1,5 +1,13 @@
 package org.uniprot.core.uniparc.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.ObjectsForTests.sequenceFeatures;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
@@ -10,14 +18,6 @@ import org.uniprot.core.uniparc.SequenceFeature;
 import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
-
-import java.time.LocalDate;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.ObjectsForTests.sequenceFeatures;
 
 class UniParcEntryLightImplTest {
     @Test
@@ -30,28 +30,51 @@ class UniParcEntryLightImplTest {
     void builderFrom_constructorImp_shouldCreate_equalObject() {
         String uniParcId = "UPI0000000001";
         int crossReferenceCount = 30;
-        List<CommonOrganism> commonTaxons = List.of(
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
-                new CommonOrganismBuilder().topLevel("unclassified").commonTaxon("Mus musculus").build());
+        List<CommonOrganism> commonTaxons =
+                List.of(
+                        new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("HIV").build(),
+                        new CommonOrganismBuilder()
+                                .topLevel("unclassified")
+                                .commonTaxon("Mus musculus")
+                                .build());
         String seq = "MVSWGRFICLVVVTMATLSLARPSFSLVED";
         Sequence sequence = new SequenceBuilder(seq).build();
         List<SequenceFeature> sequenceFeatures = sequenceFeatures();
         LocalDate oldestCrossRefCreated = LocalDate.of(2022, 1, 1);
         LocalDate mostRecentCrossRefUpdated = LocalDate.of(2023, 1, 1);
 
-        Organism organism1 = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
-        Organism organism2 = new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
+        Organism organism1 =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism2 =
+                new OrganismBuilder().taxonId(10090).scientificName("Mus musculus").build();
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism1, organism2));
 
         LinkedHashSet<String> proteinNames = new LinkedHashSet<>(List.of("Protein1", "Protein2"));
         LinkedHashSet<String> geneNames = new LinkedHashSet<>(List.of("Gene1", "Gene2"));
-        LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(new ProteomeBuilder().id("UP000005640").component("C1").build(), new ProteomeBuilder().id("UP000002494").component("C2").build()));
-        LinkedHashSet<String> uniProtKBAccessions = new LinkedHashSet<>(List.of("P21802", "P12345"));
+        LinkedHashSet<Proteome> proteomes =
+                new LinkedHashSet<>(
+                        List.of(
+                                new ProteomeBuilder().id("UP000005640").component("C1").build(),
+                                new ProteomeBuilder().id("UP000002494").component("C2").build()));
+        LinkedHashSet<String> uniProtKBAccessions =
+                new LinkedHashSet<>(List.of("P21802", "P12345"));
         Map<String, Object> extraAttributes = Map.of("hasActiveCrossRef", true);
 
-        UniParcEntryLight impl = new UniParcEntryLightImpl(uniParcId, crossReferenceCount, commonTaxons, uniProtKBAccessions,
-                sequence, sequenceFeatures, oldestCrossRefCreated, mostRecentCrossRefUpdated, organisms,
-                proteinNames, geneNames, proteomes, extraAttributes);
+        UniParcEntryLight impl =
+                new UniParcEntryLightImpl(
+                        uniParcId,
+                        crossReferenceCount,
+                        commonTaxons,
+                        uniProtKBAccessions,
+                        sequence,
+                        sequenceFeatures,
+                        oldestCrossRefCreated,
+                        mostRecentCrossRefUpdated,
+                        organisms,
+                        proteinNames,
+                        geneNames,
+                        proteomes,
+                        extraAttributes);
 
         UniParcEntryLight obj = UniParcEntryLightBuilder.from(impl).build();
         assertTrue(impl.equals(obj) && obj.equals(impl));

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/DeletedReasonTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/DeletedReasonTest.java
@@ -1,10 +1,10 @@
 package org.uniprot.core.uniprotkb;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class DeletedReasonTest {
 

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/DiseaseCommentImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/comment/impl/DiseaseCommentImplTest.java
@@ -16,7 +16,8 @@ class DiseaseCommentImplTest {
                     .evidencesSet(createEvidences())
                     .description("some description")
                     .diseaseCrossReference(crossReference(DiseaseDatabase.MIM, "3124"))
-                    .build();;
+                    .build();
+    ;
 
     @Test
     void testDiseaseCommentImpl() {

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceBuilderTest.java
@@ -1,10 +1,7 @@
 package org.uniprot.core.uniprotkb.evidence.impl;
 
-import org.junit.jupiter.api.Test;
-import org.uniprot.core.CrossReference;
-import org.uniprot.core.uniprotkb.evidence.Evidence;
-import org.uniprot.core.uniprotkb.evidence.EvidenceCode;
-import org.uniprot.core.uniprotkb.evidence.EvidenceDatabase;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.uniprotkb.evidence.impl.EvidenceImplTest.getEvidenceCrossRef;
 
 import java.util.List;
 import java.util.UUID;
@@ -12,8 +9,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.uniprotkb.evidence.impl.EvidenceImplTest.getEvidenceCrossRef;
+import org.junit.jupiter.api.Test;
+import org.uniprot.core.CrossReference;
+import org.uniprot.core.uniprotkb.evidence.Evidence;
+import org.uniprot.core.uniprotkb.evidence.EvidenceCode;
+import org.uniprot.core.uniprotkb.evidence.EvidenceDatabase;
 
 public class EvidenceBuilderTest {
     @Test
@@ -32,7 +32,7 @@ public class EvidenceBuilderTest {
     }
 
     @Test
-    void buildWithCrossReference(){
+    void buildWithCrossReference() {
         CrossReference<EvidenceDatabase> xref = getEvidenceCrossRef();
         Evidence obj = new EvidenceBuilder().crossReference(xref).build();
         assertEquals(xref, obj.getEvidenceCrossReference());

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceImplTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/evidence/impl/EvidenceImplTest.java
@@ -75,7 +75,7 @@ class EvidenceImplTest {
         assertEquals(xref, evidence.getEvidenceCrossReference());
     }
 
-    static CrossReference<EvidenceDatabase> getEvidenceCrossRef(){
+    static CrossReference<EvidenceDatabase> getEvidenceCrossRef() {
         List<Property> properties =
                 asList(new Property("key1", "value1"), new Property("key2", "value2"));
         return new CrossReferenceBuilder<EvidenceDatabase>()

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/impl/EntryInactiveReasonBuilderTest.java
@@ -20,9 +20,8 @@ class EntryInactiveReasonBuilderTest {
     @Test
     void canBuildWithDeletedReason() {
         DeletedReason deletedReason = DeletedReason.SWISSPROT_DELETION;
-        EntryInactiveReason reason = new EntryInactiveReasonBuilder()
-                .deletedReason(deletedReason)
-                .build();
+        EntryInactiveReason reason =
+                new EntryInactiveReasonBuilder().deletedReason(deletedReason).build();
         assertNotNull(reason.getDeletedReason());
         assertEquals(deletedReason, reason.getDeletedReason());
     }

--- a/core-domain/src/test/java/org/uniprot/core/uniprotkb/impl/UniProtKBReferenceBuilderTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/uniprotkb/impl/UniProtKBReferenceBuilderTest.java
@@ -18,7 +18,8 @@ class UniProtKBReferenceBuilderTest {
     @Test
     void canSetReferenceNumber() {
         int referenceNumber = 10;
-        UniProtKBReference reference = new UniProtKBReferenceBuilder().referenceNumber(referenceNumber).build();
+        UniProtKBReference reference =
+                new UniProtKBReferenceBuilder().referenceNumber(referenceNumber).build();
         assertEquals(referenceNumber, reference.getReferenceNumber());
         assertTrue(reference.hasReferenceNumber());
     }

--- a/core-domain/src/test/java/org/uniprot/core/unirule/impl/BuilderCommonTest.java
+++ b/core-domain/src/test/java/org/uniprot/core/unirule/impl/BuilderCommonTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.uniprot.core.Builder;
 import org.uniprot.core.unirule.*;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public class BuilderCommonTest {
 
     /**

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/FastaParserUtils.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/FastaParserUtils.java
@@ -5,16 +5,18 @@ import org.uniprot.core.impl.SequenceBuilder;
 import org.uniprot.core.util.Utils;
 
 public class FastaParserUtils {
-    private FastaParserUtils(){}
+    private FastaParserUtils() {}
+
     public static Sequence getSequence(Sequence sequence, String sequenceRange) {
-        if(containsSequenceRange(sequenceRange)) {
+        if (containsSequenceRange(sequenceRange)) {
             String[] rangeTokens = sequenceRange.split("-");
             int start = Integer.parseInt(rangeTokens[0]);
             int end = Integer.parseInt(rangeTokens[1]);
-            String sequenceString = sequence.getValue()
-                    .substring(
-                            Math.min(start - 1, sequence.getLength()),
-                            Math.min(end, sequence.getLength()));
+            String sequenceString =
+                    sequence.getValue()
+                            .substring(
+                                    Math.min(start - 1, sequence.getLength()),
+                                    Math.min(end, sequence.getLength()));
             return new SequenceBuilder(sequenceString).build();
         }
         return sequence;

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/UniRefFastaParser.java
@@ -1,10 +1,10 @@
 package org.uniprot.core.parser.fasta;
 
+import static org.uniprot.core.parser.fasta.FastaUtils.parseSequence;
+
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniref.UniRefEntry;
 import org.uniprot.core.uniref.UniRefEntryLight;
-
-import static org.uniprot.core.parser.fasta.FastaUtils.parseSequence;
 
 /**
  * @author jluo

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParser.java
@@ -1,28 +1,27 @@
 package org.uniprot.core.parser.fasta.uniparc;
 
+import static org.uniprot.core.parser.fasta.FastaParserUtils.getSequence;
+import static org.uniprot.core.parser.fasta.FastaUtils.*;
+import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
+
 import org.uniprot.core.Sequence;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcEntry;
 import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.util.Utils;
 
-import static org.uniprot.core.parser.fasta.FastaUtils.*;
-import static org.uniprot.core.parser.fasta.FastaParserUtils.getSequence;
-import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
-
 /**
  * @author jluo
  * @date: 24 Jun 2019
  */
 public class UniParcFastaParser {
-    private UniParcFastaParser(){}
-
+    private UniParcFastaParser() {}
 
     public static String toFasta(UniParcEntry entry) {
         String status = "active";
-        boolean isActive = entry.getUniParcCrossReferences()
-                .stream()
-                .anyMatch(UniParcCrossReference::isActive);
+        boolean isActive =
+                entry.getUniParcCrossReferences().stream()
+                        .anyMatch(UniParcCrossReference::isActive);
         if (!isActive) {
             status = "inactive";
         }
@@ -30,22 +29,24 @@ public class UniParcFastaParser {
     }
 
     public static String toFasta(UniParcEntryLight entry) {
-       return toFasta(entry, null);
+        return toFasta(entry, null);
     }
 
     public static String toFasta(UniParcEntryLight entry, String sequenceRange) {
         String status = "active";
-        if(entry.getExtraAttributes().containsKey(HAS_ACTIVE_CROSS_REF) &&
-                entry.getExtraAttributes().get(HAS_ACTIVE_CROSS_REF).equals(false)){
+        if (entry.getExtraAttributes().containsKey(HAS_ACTIVE_CROSS_REF)
+                && entry.getExtraAttributes().get(HAS_ACTIVE_CROSS_REF).equals(false)) {
             status = "inactive";
         }
         Sequence sequence = getSequence(entry.getSequence(), sequenceRange);
         return getFastaString(entry.getUniParcId(), status, sequence, sequenceRange);
     }
-    private static String getFastaString(String entry, String status, Sequence sequence, String sequenceRange) {
+
+    private static String getFastaString(
+            String entry, String status, Sequence sequence, String sequenceRange) {
         StringBuilder sb = new StringBuilder();
         sb.append(">").append(entry);
-        if(Utils.notNullNotEmpty(sequenceRange)){
+        if (Utils.notNullNotEmpty(sequenceRange)) {
             sb.append("|").append(sequenceRange);
         }
         sb.append(" ");

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniparc/UniParcProteomeFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniparc/UniParcProteomeFastaParser.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.parser.fasta.uniparc;
 
+import static org.uniprot.core.parser.fasta.FastaUtils.parseSequence;
+import static org.uniprot.core.util.Utils.*;
+
+import java.util.*;
+
 import org.uniprot.core.Property;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
@@ -7,24 +12,23 @@ import org.uniprot.core.uniparc.UniParcEntry;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.util.Utils;
 
-import java.util.*;
-
-import static org.uniprot.core.parser.fasta.FastaUtils.parseSequence;
-import static org.uniprot.core.util.Utils.*;
-
 public class UniParcProteomeFastaParser {
 
-    private static final Set<UniParcDatabase> UNIPROTKB_DATABASES = Set.of(
-            UniParcDatabase.SWISSPROT, UniParcDatabase.TREMBL, UniParcDatabase.SWISSPROT_VARSPLIC);
+    private static final Set<UniParcDatabase> UNIPROTKB_DATABASES =
+            Set.of(
+                    UniParcDatabase.SWISSPROT,
+                    UniParcDatabase.TREMBL,
+                    UniParcDatabase.SWISSPROT_VARSPLIC);
     private static final String DELIMITER = "|";
 
     /**
-     * This method is responsible to convert UniParcEntry into UniParc Proteome FASTA format.
-     * The FASTA HEADER will display cross-references (Xrefs) in the following order of precedence:
-     * 1. Display active UniProtXrefs only.
-     * 2. If no active UniProtXrefs are available, display inactive UniProtXrefs only.
-     * 3. If no UniProtXrefs (active or inactive) are available, display active sources only.
-     * 4. If no UniProtXrefs and no active sources are available, display inactive sources only.
+     * This method is responsible to convert UniParcEntry into UniParc Proteome FASTA format. The
+     * FASTA HEADER will display cross-references (Xrefs) in the following order of precedence: 1.
+     * Display active UniProtXrefs only. 2. If no active UniProtXrefs are available, display
+     * inactive UniProtXrefs only. 3. If no UniProtXrefs (active or inactive) are available, display
+     * active sources only. 4. If no UniProtXrefs and no active sources are available, display
+     * inactive sources only.
+     *
      * @param UniParc Entry
      * @return FASTA format string
      */
@@ -36,31 +40,35 @@ public class UniParcProteomeFastaParser {
         boolean hasUniProtXrefsActive = false;
         boolean hasSourceActive = false;
         String proteomeId = null;
-        for(UniParcCrossReference xref: entry.getUniParcCrossReferences()){
-            if(UNIPROTKB_DATABASES.contains(xref.getDatabase())){
+        for (UniParcCrossReference xref : entry.getUniParcCrossReferences()) {
+            if (UNIPROTKB_DATABASES.contains(xref.getDatabase())) {
                 uniProtXrefs.add(xref);
-                if(proteomeId == null && xref.hasProperties()){
+                if (proteomeId == null && xref.hasProperties()) {
                     proteomeId = getProteomeId(xref.getProperties().get(0));
                 }
-                if(xref.isActive()){
+                if (xref.isActive()) {
                     hasUniProtXrefsActive = true;
                 }
             } else {
                 sourceXrefs.put(xref.getId(), xref);
-                if(Utils.notNullNotEmpty(xref.getProteomes())) {
+                if (Utils.notNullNotEmpty(xref.getProteomes())) {
                     int size = xref.getProteomes().size();
-                    proteomeId = xref.getProteomes().get(size-1).getId();
+                    proteomeId = xref.getProteomes().get(size - 1).getId();
                 }
-                if(xref.isActive()){
+                if (xref.isActive()) {
                     hasSourceActive = true;
                 }
             }
         }
         StringBuilder sb = new StringBuilder();
-        if(!uniProtXrefs.isEmpty()){
-            sb.append(getFastaHeader(uniProtXrefs, hasUniProtXrefsActive, id, proteomeId, sourceXrefs));
+        if (!uniProtXrefs.isEmpty()) {
+            sb.append(
+                    getFastaHeader(
+                            uniProtXrefs, hasUniProtXrefsActive, id, proteomeId, sourceXrefs));
         } else {
-            sb.append(getFastaHeader(sourceXrefs.values(), hasSourceActive, id, proteomeId, sourceXrefs));
+            sb.append(
+                    getFastaHeader(
+                            sourceXrefs.values(), hasSourceActive, id, proteomeId, sourceXrefs));
         }
         sb.append("\n");
         sb.append(parseSequence(entry.getSequence().getValue()));
@@ -70,23 +78,28 @@ public class UniParcProteomeFastaParser {
     private static String getProteomeId(Property property) {
         String result = null;
         String[] sourcePropertyValues = property.getValue().split(",");
-        if(sourcePropertyValues.length == 1){
+        if (sourcePropertyValues.length == 1) {
             String[] propertyValue = sourcePropertyValues[0].split(":");
-            if(propertyValue.length > 2){
+            if (propertyValue.length > 2) {
                 result = propertyValue[2];
             }
         }
         return result;
     }
 
-    private static StringBuilder getFastaHeader(Collection<UniParcCrossReference> xrefs, boolean hasActive, String id, String proteomeId, Map<String, UniParcCrossReference> sourceXrefs) {
+    private static StringBuilder getFastaHeader(
+            Collection<UniParcCrossReference> xrefs,
+            boolean hasActive,
+            String id,
+            String proteomeId,
+            Map<String, UniParcCrossReference> sourceXrefs) {
         Set<String> proteinNames = new LinkedHashSet<>();
         Set<String> geneNames = new LinkedHashSet<>();
         Set<String> accessions = new LinkedHashSet<>();
         Set<String> sourceIds = new LinkedHashSet<>();
         Set<String> components = new LinkedHashSet<>();
         Organism organism = null;
-        for(UniParcCrossReference xref: xrefs) {
+        for (UniParcCrossReference xref : xrefs) {
             if (xref.isActive() == hasActive) {
                 addOrIgnoreNull(xref.getProteinName(), proteinNames);
                 addOrIgnoreNull(xref.getGeneName(), geneNames);
@@ -116,7 +129,7 @@ public class UniParcProteomeFastaParser {
         }
         StringBuilder sb = new StringBuilder();
         sb.append(">").append(id);
-        if(!proteinNames.isEmpty()){
+        if (!proteinNames.isEmpty()) {
             sb.append(" ").append(String.join(DELIMITER, proteinNames));
         }
         if (notNull(organism)) {
@@ -126,16 +139,16 @@ public class UniParcProteomeFastaParser {
             sb.append(" OX=").append(organism.getTaxonId());
         }
 
-        if(!geneNames.isEmpty()){
+        if (!geneNames.isEmpty()) {
             sb.append(" GN=").append(String.join(DELIMITER, geneNames));
         }
-        if(!accessions.isEmpty()){
+        if (!accessions.isEmpty()) {
             sb.append(" AC=").append(String.join(DELIMITER, accessions));
         }
-        if(!sourceIds.isEmpty()){
+        if (!sourceIds.isEmpty()) {
             sb.append(" SS=").append(String.join(DELIMITER, sourceIds));
         }
-        if(Utils.notNullNotEmpty(proteomeId)) {
+        if (Utils.notNullNotEmpty(proteomeId)) {
             sb.append(" PC=").append(proteomeId);
             if (!components.isEmpty()) {
                 sb.append(":").append(String.join(DELIMITER, components));
@@ -151,8 +164,9 @@ public class UniParcProteomeFastaParser {
                 .toList();
     }
 
-    private static String getSourceId(Map<String, UniParcCrossReference> sourceXrefs, String sourceId) {
-        if(sourceXrefs.containsKey(sourceId)){
+    private static String getSourceId(
+            Map<String, UniParcCrossReference> sourceXrefs, String sourceId) {
+        if (sourceXrefs.containsKey(sourceId)) {
             sourceId = sourceXrefs.get(sourceId).getDatabase().getName() + ":" + sourceId;
         }
         return sourceId;

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParser.java
@@ -1,5 +1,9 @@
 package org.uniprot.core.parser.fasta.uniprot;
 
+import static org.uniprot.core.parser.fasta.FastaParserUtils.getSequence;
+
+import java.util.List;
+
 import org.uniprot.core.fasta.UniProtKBFasta;
 import org.uniprot.core.fasta.impl.UniProtKBFastaBuilder;
 import org.uniprot.core.gene.Gene;
@@ -9,10 +13,6 @@ import org.uniprot.core.uniprotkb.description.Name;
 import org.uniprot.core.uniprotkb.description.ProteinDescription;
 import org.uniprot.core.util.Utils;
 
-import java.util.List;
-
-import static org.uniprot.core.parser.fasta.FastaParserUtils.getSequence;
-
 public class UniProtKBFastaParser {
 
     private UniProtKBFastaParser() {}
@@ -20,6 +20,7 @@ public class UniProtKBFastaParser {
     public static UniProtKBFasta toUniProtKBFasta(UniProtKBEntry entry) {
         return toUniProtKBFasta(entry, null);
     }
+
     public static UniProtKBFasta toUniProtKBFasta(UniProtKBEntry entry, String sequenceRange) {
         return new UniProtKBFastaBuilder()
                 .id(entry.getPrimaryAccession().getValue())

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserReader.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserReader.java
@@ -36,7 +36,7 @@ class UniProtKBFastaParserReader {
         int proteinExistenceIndex = line.indexOf(" PE=", spaceIndex);
         int sequenceVersionIndex = line.indexOf(" SV=", proteinExistenceIndex);
         String[] proteinIds;
-        if(spaceIndex > 0) {
+        if (spaceIndex > 0) {
             proteinIds = line.substring(0, spaceIndex).split("\\|");
             builder.uniProtkbId(proteinIds[2]);
             parseProteinName(builder, line);

--- a/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserWriter.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserWriter.java
@@ -1,14 +1,14 @@
 package org.uniprot.core.parser.fasta.uniprot;
 
+import static org.uniprot.core.parser.fasta.FastaUtils.*;
+
+import java.util.Objects;
+
 import org.uniprot.core.fasta.UniProtKBFasta;
 import org.uniprot.core.uniprotkb.ProteinExistence;
 import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 import org.uniprot.core.uniprotkb.description.FlagType;
 import org.uniprot.core.util.Utils;
-
-import java.util.Objects;
-
-import static org.uniprot.core.parser.fasta.FastaUtils.*;
 
 /**
  * @author lgonzales

--- a/core-parser/src/main/java/org/uniprot/core/parser/gff/uniprot/FeatureLabel.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/gff/uniprot/FeatureLabel.java
@@ -1,6 +1,8 @@
 package org.uniprot.core.parser.gff.uniprot;
 
-/** @author gqi */
+/**
+ * @author gqi
+ */
 public enum FeatureLabel {
     /**
      * org.expasy.uniprot.models.Annotation.Type

--- a/core-parser/src/main/java/org/uniprot/core/parser/gff/uniprot/UniProtGffParser.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/gff/uniprot/UniProtGffParser.java
@@ -17,7 +17,9 @@ import org.uniprot.core.uniprotkb.evidence.EvidenceCode;
 import org.uniprot.core.uniprotkb.feature.UniProtKBFeature;
 import org.uniprot.core.uniprotkb.feature.UniprotKBFeatureType;
 
-/** @author gqi */
+/**
+ * @author gqi
+ */
 public class UniProtGffParser {
     private static final String FEATURE_SOURCE = "UniProtKB";
     private static final String EMPTY_COLUMN = ".";

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcCrossReferenceMap.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcCrossReferenceMap.java
@@ -1,15 +1,15 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import org.uniprot.core.parser.tsv.NamedValueMap;
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.util.Utils;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author jluo

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryCrossRefValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryCrossRefValueMapper.java
@@ -1,14 +1,14 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
 import org.uniprot.core.parser.tsv.EntityValueMapper;
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.util.Utils;
-
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.util.*;
 
 /**
  * @author sahmad

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryLightValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryLightValueMapper.java
@@ -1,18 +1,19 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import org.uniprot.core.parser.tsv.EntityValueMapper;
 import org.uniprot.core.uniparc.CommonOrganism;
 import org.uniprot.core.uniparc.UniParcEntryLight;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
-import java.time.LocalDate;
-import java.util.*;
-import java.util.stream.Collectors;
-
 public class UniParcEntryLightValueMapper implements EntityValueMapper<UniParcEntryLight> {
 
     private static final List<String> UNIPARC_FIELDS =
-            List.of("upi",
+            List.of(
+                    "upi",
                     "organism",
                     "organism_id",
                     "gene",
@@ -28,11 +29,12 @@ public class UniParcEntryLightValueMapper implements EntityValueMapper<UniParcEn
     @Override
     public Map<String, String> mapEntity(UniParcEntryLight entry, List<String> fields) {
         Map<String, String> map = new HashMap<>();
-        if(contains(fields)){
+        if (contains(fields)) {
             map.putAll(getSimpleAttributeValues(entry, fields));
         }
         if (UniParcSequenceFeatureMap.contains(fields)) {
-            UniParcSequenceFeatureMap featureMapper = new UniParcSequenceFeatureMap(entry.getSequenceFeatures());
+            UniParcSequenceFeatureMap featureMapper =
+                    new UniParcSequenceFeatureMap(entry.getSequenceFeatures());
             map.putAll(featureMapper.attributeValues());
         }
         if (UniParcSequenceMap.contains(fields)) {
@@ -42,13 +44,12 @@ public class UniParcEntryLightValueMapper implements EntityValueMapper<UniParcEn
         return map;
     }
 
-
-
     private static boolean contains(List<String> fields) {
         return fields.stream().anyMatch(UNIPARC_FIELDS::contains);
     }
 
-    private Map<String, String> getSimpleAttributeValues(UniParcEntryLight entry, List<String> fields) {
+    private Map<String, String> getSimpleAttributeValues(
+            UniParcEntryLight entry, List<String> fields) {
         Map<String, String> map = new HashMap<>();
         for (String field : fields) {
             switch (field) {
@@ -71,16 +72,24 @@ public class UniParcEntryLightValueMapper implements EntityValueMapper<UniParcEn
                                     .collect(Collectors.joining(DELIMITER2)));
                     break;
                 case "gene":
-                    map.put(UNIPARC_FIELDS.get(3),String.join(DELIMITER2, entry.getGeneNames()));
+                    map.put(UNIPARC_FIELDS.get(3), String.join(DELIMITER2, entry.getGeneNames()));
                     break;
                 case "protein":
-                    map.put(UNIPARC_FIELDS.get(4),String.join(DELIMITER2, entry.getProteinNames()));
+                    map.put(
+                            UNIPARC_FIELDS.get(4),
+                            String.join(DELIMITER2, entry.getProteinNames()));
                     break;
                 case "proteome":
-                    map.put(UNIPARC_FIELDS.get(5),entry.getProteomes().stream().map(e -> e.getId()+":"+e.getComponent()).collect(Collectors.joining(DELIMITER2)));
+                    map.put(
+                            UNIPARC_FIELDS.get(5),
+                            entry.getProteomes().stream()
+                                    .map(e -> e.getId() + ":" + e.getComponent())
+                                    .collect(Collectors.joining(DELIMITER2)));
                     break;
                 case "accession":
-                    map.put(UNIPARC_FIELDS.get(6),String.join(DELIMITER2, entry.getUniProtKBAccessions()));
+                    map.put(
+                            UNIPARC_FIELDS.get(6),
+                            String.join(DELIMITER2, entry.getUniProtKBAccessions()));
                     break;
                 case "first_seen":
                     map.put(
@@ -118,10 +127,14 @@ public class UniParcEntryLightValueMapper implements EntityValueMapper<UniParcEn
     }
 
     private String getCommonTaxonString(List<CommonOrganism> commonTaxons) {
-        return commonTaxons.stream().map(CommonOrganism::getCommonTaxon).collect(Collectors.joining("; "));
+        return commonTaxons.stream()
+                .map(CommonOrganism::getCommonTaxon)
+                .collect(Collectors.joining("; "));
     }
 
     private String getCommonTaxonIdString(List<CommonOrganism> commonTaxons) {
-        return commonTaxons.stream().map(commonOrganism -> String.valueOf(commonOrganism.getCommonTaxonId())).collect(Collectors.joining("; "));
+        return commonTaxons.stream()
+                .map(commonOrganism -> String.valueOf(commonOrganism.getCommonTaxonId()))
+                .collect(Collectors.joining("; "));
     }
 }

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryValueMapper.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryValueMapper.java
@@ -16,8 +16,7 @@ import org.uniprot.core.uniprotkb.taxonomy.Organism;
  */
 public class UniParcEntryValueMapper implements EntityValueMapper<UniParcEntry> {
 
-    private static final List<String> UNIPARC_FIELDS =
-            List.of("upi", "first_seen", "last_seen");
+    private static final List<String> UNIPARC_FIELDS = List.of("upi", "first_seen", "last_seen");
 
     @Override
     public Map<String, String> mapEntity(UniParcEntry entry, List<String> fields) {

--- a/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniprot/comment/BPCPMap.java
+++ b/core-parser/src/main/java/org/uniprot/core/parser/tsv/uniprot/comment/BPCPMap.java
@@ -109,7 +109,8 @@ public class BPCPMap implements NamedValueMap {
                 .map(BPCPComment::getTemperatureDependence)
                 .map(
                         temperatureDependence ->
-                                lineBuilder.buildTempLine(temperatureDependence, false, true)
+                                lineBuilder
+                                        .buildTempLine(temperatureDependence, false, true)
                                         .stream()
                                         .collect(Collectors.joining(" ")))
                 .collect(Collectors.joining(" "));

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/FastaUtilsTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/FastaUtilsTest.java
@@ -1,8 +1,8 @@
 package org.uniprot.core.parser.fasta;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 class FastaUtilsTest {
     @Test
@@ -23,8 +23,7 @@ class FastaUtilsTest {
     void parseSequenceTwoLines() {
         String input = getSequence(61);
         String result = FastaUtils.parseSequence(input);
-        String expect = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" +
-                        "A";
+        String expect = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" + "A";
         assertEquals(expect, result);
     }
 
@@ -32,8 +31,9 @@ class FastaUtilsTest {
     void parseSequenceTwoLinesFull() {
         String input = getSequence(120);
         String result = FastaUtils.parseSequence(input);
-        String expect = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" +
-                        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        String expect =
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                        + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         assertEquals(expect, result);
     }
 
@@ -41,13 +41,14 @@ class FastaUtilsTest {
     void parseSequenceThreeLines() {
         String input = getSequence(121);
         String result = FastaUtils.parseSequence(input);
-        String expect = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" +
-                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n" +
-                "A";
+        String expect =
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                        + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+                        + "A";
         assertEquals(expect, result);
     }
 
-    private String getSequence(int length){
+    private String getSequence(int length) {
         String s = "A";
         return s.repeat(length);
     }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParserTest.java
@@ -1,5 +1,14 @@
 package org.uniprot.core.parser.fasta.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.Sequence;
@@ -12,28 +21,23 @@ import org.uniprot.core.uniparc.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
 /**
  * @author jluo
  * @date: 24 Jun 2019
  */
 class UniParcFastaParserTest {
 
-    public static final String EXPECTED_FASTA_RESULT = """
+    public static final String EXPECTED_FASTA_RESULT =
+            """
             >UPI0000083A08 status=active
             MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT
             LLRAIDWFRDNGYFNA""";
-    public static final String EXPECTED_FASTA_RESULT_INACTIVE = """
+    public static final String EXPECTED_FASTA_RESULT_INACTIVE =
+            """
             >UPI0000083A08 status=inactive
             MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT
             LLRAIDWFRDNGYFNA""";
+
     @Test
     void testUniParcEntryToFasta() {
         UniParcEntry entry = create();
@@ -51,15 +55,17 @@ class UniParcFastaParserTest {
     @Test
     void testUniParcEntryLightToFastaInactive() {
         UniParcEntryLight entry = createEntryLight();
-        entry = UniParcEntryLightBuilder.from(entry).extraAttributesAdd(HAS_ACTIVE_CROSS_REF, false).build();
+        entry =
+                UniParcEntryLightBuilder.from(entry)
+                        .extraAttributesAdd(HAS_ACTIVE_CROSS_REF, false)
+                        .build();
         String fasta = UniParcFastaParser.toFasta(entry);
         assertEquals(EXPECTED_FASTA_RESULT_INACTIVE, fasta);
     }
 
     @Test
-    void testUniParcLightFastaSeqRange(){
-        String expectedFasta = ">UPI0000083A08|5-10 status=active\n" +
-                "MARALA";
+    void testUniParcLightFastaSeqRange() {
+        String expectedFasta = ">UPI0000083A08|5-10 status=active\n" + "MARALA";
         UniParcEntryLight entry = createEntryLight();
         String seqRange = "5-10";
         String fasta = UniParcFastaParser.toFasta(entry, seqRange);
@@ -68,10 +74,11 @@ class UniParcFastaParserTest {
     }
 
     @Test
-    void testUniParcLightFastaSeqRangeOutOfRangeShouldReturnTillEnd(){
-        String expectedFasta = ">UPI0000083A08|5-1000000 status=active\n" +
-                "MARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDTLLRA\n" +
-                "IDWFRDNGYFNA";
+    void testUniParcLightFastaSeqRangeOutOfRangeShouldReturnTillEnd() {
+        String expectedFasta =
+                ">UPI0000083A08|5-1000000 status=active\n"
+                        + "MARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDTLLRA\n"
+                        + "IDWFRDNGYFNA";
         UniParcEntryLight entry = createEntryLight();
         String seqRange = "5-1000000";
         String fasta = UniParcFastaParser.toFasta(entry, seqRange);
@@ -83,10 +90,10 @@ class UniParcFastaParserTest {
         Sequence sequence = getSequence();
         List<UniParcCrossReference> xrefs = getXrefs();
         return new UniParcEntryBuilder()
-                        .uniParcId(new UniParcIdBuilder("UPI0000083A08").build())
-                        .uniParcCrossReferencesSet(xrefs)
-                        .sequence(sequence)
-                        .build();
+                .uniParcId(new UniParcIdBuilder("UPI0000083A08").build())
+                .uniParcCrossReferencesSet(xrefs)
+                .sequence(sequence)
+                .build();
     }
 
     private UniParcEntryLight createEntryLight() {
@@ -138,10 +145,13 @@ class UniParcFastaParserTest {
                         .propertiesSet(properties2)
                         .organism(taxonomy2)
                         .proteinName("some pname")
-                        .proteomesAdd(new ProteomeBuilder().id("UP00000564").component("chromosome 1").build())
+                        .proteomesAdd(
+                                new ProteomeBuilder()
+                                        .id("UP00000564")
+                                        .component("chromosome 1")
+                                        .build())
                         .build();
 
         return Arrays.asList(xref, xref2);
     }
-
 }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParserTestUtils.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcFastaParserTestUtils.java
@@ -1,5 +1,8 @@
 package org.uniprot.core.parser.fasta.uniparc;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uniprot.core.Property;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
@@ -13,25 +16,29 @@ import org.uniprot.core.uniparc.impl.UniParcIdBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class UniParcFastaParserTestUtils {
 
     static UniParcEntry create() {
         List<UniParcCrossReference> xrefs = getUniProtXrefs(true);
         Organism organism = getOrganism(9606L, "Homo Sapiens");
-        xrefs.add(getXref(UniParcDatabase.EMBL,"CQR81549", true, organism, "UP000005640", "Chromosome 1"));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.EMBL,
+                        "CQR81549",
+                        true,
+                        organism,
+                        "UP000005640",
+                        "Chromosome 1"));
         return new UniParcEntryBuilder()
-                        .uniParcId(new UniParcIdBuilder("UPI0000083A08").build())
-                        .uniParcCrossReferencesSet(xrefs)
-                        .sequence(getSequence())
-                        .build();
+                .uniParcId(new UniParcIdBuilder("UPI0000083A08").build())
+                .uniParcCrossReferencesSet(xrefs)
+                .sequence(getSequence())
+                .build();
     }
 
     static Sequence getSequence() {
-        String seq = "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT" +
-                     "LLRAIDWFRDNGYFNA";
+        String seq =
+                "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT" + "LLRAIDWFRDNGYFNA";
         return new SequenceBuilder(seq).build();
     }
 
@@ -39,7 +46,19 @@ public class UniParcFastaParserTestUtils {
         List<UniParcCrossReference> result = new ArrayList<>();
         Organism human = getOrganism(9606, "Homo sapiens");
 
-        result.add(getXref(UniParcDatabase.SWISSPROT, "P12345", active, human, null, null, "Protein Name One", "Gene Name One", new Property(UniParcCrossReference.PROPERTY_SOURCES, "ABC01415:UP000005640:Chromosome 1")));
+        result.add(
+                getXref(
+                        UniParcDatabase.SWISSPROT,
+                        "P12345",
+                        active,
+                        human,
+                        null,
+                        null,
+                        "Protein Name One",
+                        "Gene Name One",
+                        new Property(
+                                UniParcCrossReference.PROPERTY_SOURCES,
+                                "ABC01415:UP000005640:Chromosome 1")));
 
         return result;
     }
@@ -48,19 +67,42 @@ public class UniParcFastaParserTestUtils {
         return new OrganismBuilder().taxonId(taxonId).scientificName(name).build();
     }
 
-    static UniParcCrossReference getXref(UniParcDatabase database, String id, boolean active, Organism organism) {
+    static UniParcCrossReference getXref(
+            UniParcDatabase database, String id, boolean active, Organism organism) {
         return getXref(database, id, active, organism, null, null);
     }
 
-    static UniParcCrossReference getXref(UniParcDatabase database, String id, boolean active, Organism organism, String proteomeId, String component) {
-        return getXref(database,id, active, organism, proteomeId, component, null, null,null);
+    static UniParcCrossReference getXref(
+            UniParcDatabase database,
+            String id,
+            boolean active,
+            Organism organism,
+            String proteomeId,
+            String component) {
+        return getXref(database, id, active, organism, proteomeId, component, null, null, null);
     }
 
-    static UniParcCrossReference getXref(UniParcDatabase database, String id, boolean active, Organism organism, String geneName, String proteinName, Property property) {
-        return getXref(database,id, active, organism, null, null, proteinName, geneName, property);
+    static UniParcCrossReference getXref(
+            UniParcDatabase database,
+            String id,
+            boolean active,
+            Organism organism,
+            String geneName,
+            String proteinName,
+            Property property) {
+        return getXref(database, id, active, organism, null, null, proteinName, geneName, property);
     }
 
-    static UniParcCrossReference getXref(UniParcDatabase database, String id, boolean active, Organism organism, String proteomeId, String component, String proteinName, String geneName, Property property) {
+    static UniParcCrossReference getXref(
+            UniParcDatabase database,
+            String id,
+            boolean active,
+            Organism organism,
+            String proteomeId,
+            String component,
+            String proteinName,
+            String geneName,
+            Property property) {
         return new UniParcCrossReferenceBuilder()
                 .database(database)
                 .id(id)

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcProteomeFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniparc/UniParcProteomeFastaParserTest.java
@@ -1,5 +1,11 @@
 package org.uniprot.core.parser.fasta.uniparc;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.core.parser.fasta.uniparc.UniParcFastaParserTestUtils.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.uniparc.UniParcCrossReference;
@@ -9,33 +15,42 @@ import org.uniprot.core.uniparc.impl.UniParcEntryBuilder;
 import org.uniprot.core.uniparc.impl.UniParcIdBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.core.parser.fasta.uniparc.UniParcFastaParserTestUtils.*;
-
 class UniParcProteomeFastaParserTest {
 
-    private static final Property source1 = new Property(UniParcCrossReference.PROPERTY_SOURCES,
-            UniParcDatabase.SWISSPROT.getName() + ":" + "ABC01416:UP000005640:Chromosome 1");
-    private static final UniParcCrossReference xrefSource1 = getXref(UniParcDatabase.EMBL_CON, "ABC01416", true,
-            null, "UP000005640", "Chromosome 1");
-    private static final Property source2 = new Property(UniParcCrossReference.PROPERTY_SOURCES,
-            UniParcDatabase.TREMBL.getName() + ":" + "ABC01417:UP000005640:Chromosome 2");
-    private static final UniParcCrossReference xrefSource2 = getXref(UniParcDatabase.REFSEQ, "ABC01417", true,
-            null, "UP000005640", "Chromosome 2");
+    private static final Property source1 =
+            new Property(
+                    UniParcCrossReference.PROPERTY_SOURCES,
+                    UniParcDatabase.SWISSPROT.getName()
+                            + ":"
+                            + "ABC01416:UP000005640:Chromosome 1");
+    private static final UniParcCrossReference xrefSource1 =
+            getXref(
+                    UniParcDatabase.EMBL_CON,
+                    "ABC01416",
+                    true,
+                    null,
+                    "UP000005640",
+                    "Chromosome 1");
+    private static final Property source2 =
+            new Property(
+                    UniParcCrossReference.PROPERTY_SOURCES,
+                    UniParcDatabase.TREMBL.getName() + ":" + "ABC01417:UP000005640:Chromosome 2");
+    private static final UniParcCrossReference xrefSource2 =
+            getXref(UniParcDatabase.REFSEQ, "ABC01417", true, null, "UP000005640", "Chromosome 2");
     private static final Organism humanOrganism = getOrganism(9606L, "Homo Sapiens");
 
     @Test
     void toFastaWithoutCrossReferencesReturnJustIdAndSequence() {
-        UniParcEntry entry = new UniParcEntryBuilder().uniParcId("UPI0000083A08")
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId("UPI0000083A08")
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
-        String expected = ">UPI0000083A08\n" +
-                "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                "LLRAIDWFRDNGYFNA";
+        String expected =
+                ">UPI0000083A08\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -43,19 +58,29 @@ class UniParcProteomeFastaParserTest {
     void toFastaFullSingleValues() {
         Organism organism = getOrganism(9606L, "Homo Sapiens");
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.SWISSPROT, "P21802", true, organism, null, null,
-                "Protein Name 1", "Gene Name1", source1 ));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.SWISSPROT,
+                        "P21802",
+                        true,
+                        organism,
+                        null,
+                        null,
+                        "Protein Name 1",
+                        "Gene Name1",
+                        source1));
         xrefs.add(xrefSource1);
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 Protein Name 1 OS=Homo Sapiens OX=9606 GN=Gene Name1 AC=P21802 SS=EMBL_CON:ABC01416 PC=UP000005640:Chromosome 1\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 Protein Name 1 OS=Homo Sapiens OX=9606 GN=Gene Name1 AC=P21802 SS=EMBL_CON:ABC01416 PC=UP000005640:Chromosome 1\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -63,20 +88,41 @@ class UniParcProteomeFastaParserTest {
     void toFastaFullMultiValues() {
         Organism organism = getOrganism(9606L, "Homo Sapiens");
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.SWISSPROT, "P21802", true, organism, null, null, "Protein Name 1", "Gene Name1", source1 ));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.SWISSPROT,
+                        "P21802",
+                        true,
+                        organism,
+                        null,
+                        null,
+                        "Protein Name 1",
+                        "Gene Name1",
+                        source1));
         xrefs.add(xrefSource1);
-        xrefs.add(getXref(UniParcDatabase.TREMBL, "P12345", true, organism, null, null, "Protein Name 2", "Gene Name2", source2));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.TREMBL,
+                        "P12345",
+                        true,
+                        organism,
+                        null,
+                        null,
+                        "Protein Name 2",
+                        "Gene Name2",
+                        source2));
         xrefs.add(xrefSource2);
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 Protein Name 1|Protein Name 2 OS=Homo Sapiens OX=9606 GN=Gene Name1|Gene Name2 AC=P21802|P12345 SS=EMBL_CON:ABC01416|RefSeq:ABC01417 PC=UP000005640:Chromosome 1|Chromosome 2\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 Protein Name 1|Protein Name 2 OS=Homo Sapiens OX=9606 GN=Gene Name1|Gene Name2 AC=P21802|P12345 SS=EMBL_CON:ABC01416|RefSeq:ABC01417 PC=UP000005640:Chromosome 1|Chromosome 2\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -84,20 +130,41 @@ class UniParcProteomeFastaParserTest {
     void toFastaFullAccessionActiveOnly() {
         Organism organism = getOrganism(9606L, "Homo Sapiens");
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.SWISSPROT, "P21802", true, organism, null, null, "Protein Name 1", "Gene Name1", source1 ));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.SWISSPROT,
+                        "P21802",
+                        true,
+                        organism,
+                        null,
+                        null,
+                        "Protein Name 1",
+                        "Gene Name1",
+                        source1));
         xrefs.add(xrefSource1);
-        xrefs.add(getXref(UniParcDatabase.TREMBL, "P12345", false, organism, null, null, "Protein Name 2", "Gene Name2", source2));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.TREMBL,
+                        "P12345",
+                        false,
+                        organism,
+                        null,
+                        null,
+                        "Protein Name 2",
+                        "Gene Name2",
+                        source2));
         xrefs.add(xrefSource2);
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 Protein Name 1 OS=Homo Sapiens OX=9606 GN=Gene Name1 AC=P21802 SS=EMBL_CON:ABC01416 PC=UP000005640:Chromosome 1\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 Protein Name 1 OS=Homo Sapiens OX=9606 GN=Gene Name1 AC=P21802 SS=EMBL_CON:ABC01416 PC=UP000005640:Chromosome 1\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -105,17 +172,25 @@ class UniParcProteomeFastaParserTest {
     void toFastaWithoutAccessions() {
         String proteomeId = "UP000005640";
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.EMBL_CON, "XP12345", true, humanOrganism, proteomeId, "C1"));
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.EMBL_CON,
+                        "XP12345",
+                        true,
+                        humanOrganism,
+                        proteomeId,
+                        "C1"));
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640:C1\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640:C1\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -123,17 +198,25 @@ class UniParcProteomeFastaParserTest {
     void toFastaWithoutComponent() {
         String proteomeId = "UP000005640";
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.EMBL_CON, "XP12345", true, humanOrganism, proteomeId, null));
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.EMBL_CON,
+                        "XP12345",
+                        true,
+                        humanOrganism,
+                        proteomeId,
+                        null));
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -142,16 +225,17 @@ class UniParcProteomeFastaParserTest {
         String proteomeId = "UP000005640";
         List<UniParcCrossReference> xrefs = new ArrayList<>();
         xrefs.add(getXref(UniParcDatabase.EMBL_CON, "XP12345", true, null, proteomeId, "C8"));
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 SS=EMBL_CON:XP12345 PC=UP000005640:C8\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 SS=EMBL_CON:XP12345 PC=UP000005640:C8\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 
@@ -159,18 +243,26 @@ class UniParcProteomeFastaParserTest {
     void toFastaActiveOnlySources() {
         String proteomeId = "UP000005640";
         List<UniParcCrossReference> xrefs = new ArrayList<>();
-        xrefs.add(getXref(UniParcDatabase.EMBL_CON, "XP12345", true, humanOrganism, proteomeId, "C5"));
+        xrefs.add(
+                getXref(
+                        UniParcDatabase.EMBL_CON,
+                        "XP12345",
+                        true,
+                        humanOrganism,
+                        proteomeId,
+                        "C5"));
         xrefs.add(getXref(UniParcDatabase.EMBL_CON, "XP54321", false, null, proteomeId, "C3"));
-        UniParcEntry entry = new UniParcEntryBuilder()
-                .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
-                .uniParcCrossReferencesSet(xrefs)
-                .sequence(getSequence())
-                .build();
+        UniParcEntry entry =
+                new UniParcEntryBuilder()
+                        .uniParcId(new UniParcIdBuilder("UPI0000083A09").build())
+                        .uniParcCrossReferencesSet(xrefs)
+                        .sequence(getSequence())
+                        .build();
         String fasta = UniParcProteomeFastaParser.toFasta(entry);
         String expected =
-                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640:C5\n" +
-                        "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n" +
-                        "LLRAIDWFRDNGYFNA";
+                ">UPI0000083A09 OS=Homo Sapiens OX=9606 SS=EMBL_CON:XP12345 PC=UP000005640:C5\n"
+                        + "MSMAMARALATLGRLRYRVSGQLPLLDETAIEVMAGGQFLDGRKAREELGFFSTTALDDT\n"
+                        + "LLRAIDWFRDNGYFNA";
         assertEquals(expected, fasta);
     }
 }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserReaderTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserReaderTest.java
@@ -131,9 +131,7 @@ class UniProtKBFastaParserReaderTest {
 
     @Test
     void parseFastaWithSequenceRange() {
-        String fastaInput =
-                ">sp|P12345|10-20\n"
-                        + "ITFTCPRSDG";
+        String fastaInput = ">sp|P12345|10-20\n" + "ITFTCPRSDG";
         UniProtKBFasta result = UniProtKBFastaParserReader.parse(fastaInput);
         assertNotNull(result);
         assertEquals(UniProtKBEntryType.SWISSPROT, result.getEntryType());

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserTest.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.parser.fasta.uniprot;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.fasta.UniProtKBFasta;
 import org.uniprot.core.fasta.impl.UniProtKBFastaBuilder;
@@ -15,11 +20,6 @@ import org.uniprot.core.uniprotkb.description.impl.ProteinNameBuilder;
 import org.uniprot.core.uniprotkb.description.impl.ProteinSubNameBuilder;
 import org.uniprot.core.uniprotkb.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author lgonzales
@@ -222,8 +222,12 @@ class UniProtKBFastaParserTest {
     }
 
     @Test
-    void testToUniProtKBFasta(){
-        List<Gene> genes = List.of(new GeneBuilder().orfNamesAdd(new ORFNameBuilder().value("ORF 1").build()).build());
+    void testToUniProtKBFasta() {
+        List<Gene> genes =
+                List.of(
+                        new GeneBuilder()
+                                .orfNamesAdd(new ORFNameBuilder().value("ORF 1").build())
+                                .build());
         UniProtKBEntry entry = getEntryWithGene(genes);
         UniProtKBFasta result = UniProtKBFastaParser.toUniProtKBFasta(entry);
         assertNotNull(result);
@@ -241,8 +245,12 @@ class UniProtKBFastaParserTest {
     }
 
     @Test
-    void testToUniProtKBFastaWithSubsequenceRange(){
-        List<Gene> genes = List.of(new GeneBuilder().orfNamesAdd(new ORFNameBuilder().value("ORF 1").build()).build());
+    void testToUniProtKBFastaWithSubsequenceRange() {
+        List<Gene> genes =
+                List.of(
+                        new GeneBuilder()
+                                .orfNamesAdd(new ORFNameBuilder().value("ORF 1").build())
+                                .build());
         UniProtKBEntry entry = getEntryWithGene(genes);
         String sequenceRange = "10-20";
         UniProtKBFasta result = UniProtKBFastaParser.toUniProtKBFasta(entry, sequenceRange);
@@ -256,13 +264,18 @@ class UniProtKBFastaParserTest {
         assertEquals("FRAGMENTS_PRECURSOR", result.getFlagType().name());
         assertEquals(entry.getProteinExistence(), result.getProteinExistence());
         assertEquals(entry.getEntryAudit().getSequenceVersion(), result.getSequenceVersion());
-        assertEquals(entry.getSequence().getValue().substring(9, 20), result.getSequence().getValue());
+        assertEquals(
+                entry.getSequence().getValue().substring(9, 20), result.getSequence().getValue());
         assertEquals(sequenceRange, result.getSequenceRange());
     }
 
     @Test
-    void testToUniProtKBFastaWithSubsequenceOutOfRange(){
-        List<Gene> genes = List.of(new GeneBuilder().orfNamesAdd(new ORFNameBuilder().value("ORF 1").build()).build());
+    void testToUniProtKBFastaWithSubsequenceOutOfRange() {
+        List<Gene> genes =
+                List.of(
+                        new GeneBuilder()
+                                .orfNamesAdd(new ORFNameBuilder().value("ORF 1").build())
+                                .build());
         UniProtKBEntry entry = getEntryWithGene(genes);
         String sequenceRange = "40-50";
         UniProtKBFasta result = UniProtKBFastaParser.toUniProtKBFasta(entry, sequenceRange);
@@ -273,8 +286,12 @@ class UniProtKBFastaParserTest {
     }
 
     @Test
-    void testToUniProtKBFastaWithSubsequenceOutOfRangeEnd(){
-        List<Gene> genes = List.of(new GeneBuilder().orfNamesAdd(new ORFNameBuilder().value("ORF 1").build()).build());
+    void testToUniProtKBFastaWithSubsequenceOutOfRangeEnd() {
+        List<Gene> genes =
+                List.of(
+                        new GeneBuilder()
+                                .orfNamesAdd(new ORFNameBuilder().value("ORF 1").build())
+                                .build());
         UniProtKBEntry entry = getEntryWithGene(genes);
         String sequenceRange = "20-100";
         UniProtKBFasta result = UniProtKBFastaParser.toUniProtKBFasta(entry, sequenceRange);
@@ -310,5 +327,4 @@ class UniProtKBFastaParserTest {
                         .build();
         return entry;
     }
-
 }

--- a/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserWriterTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/fasta/uniprot/UniProtKBFastaParserWriterTest.java
@@ -126,10 +126,7 @@ class UniProtKBFastaParserWriterTest {
                         .id("P21802")
                         .uniProtkbId("P12345_PROT")
                         .entryType(UniProtKBEntryType.SWISSPROT)
-                        .sequence(
-                                new SequenceBuilder(
-                                        "ABCDE")
-                                        .build())
+                        .sequence(new SequenceBuilder("ABCDE").build())
                         .geneName("Gene Name Value")
                         .proteinName("Protein Name Value")
                         .organism(

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcCrossReferenceMapTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcCrossReferenceMapTest.java
@@ -1,17 +1,17 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniparc.impl.ProteomeBuilder;
 import org.uniprot.core.uniparc.impl.UniParcCrossReferenceBuilder;
-
-import java.time.LocalDate;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author jluo
@@ -141,7 +141,11 @@ class UniParcCrossReferenceMapTest {
                         .active(false)
                         .propertiesSet(properties2)
                         .proteinName("some pname2")
-                        .proteomesAdd(new ProteomeBuilder().id("UP00000564").component("chromosome 1").build())
+                        .proteomesAdd(
+                                new ProteomeBuilder()
+                                        .id("UP00000564")
+                                        .component("chromosome 1")
+                                        .build())
                         .build();
 
         return List.of(xref, xref2);

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryCrossRefValueMapperTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryCrossRefValueMapperTest.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
@@ -10,11 +15,6 @@ import org.uniprot.core.uniparc.impl.ProteomeBuilder;
 import org.uniprot.core.uniparc.impl.UniParcCrossReferenceBuilder;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author sahmad
@@ -78,7 +78,8 @@ class UniParcEntryCrossRefValueMapperTest {
                 new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
         List<Property> properties = new ArrayList<>();
         properties.add(new Property("prop1", "pvalue"));
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("proteoemid").component("component").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("proteoemid").component("component").build();
         return new UniParcCrossReferenceBuilder()
                 .versionI(3)
                 .database(UniParcDatabase.SWISSPROT)

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryLightValueMapperTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryLightValueMapperTest.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
@@ -8,17 +13,19 @@ import org.uniprot.core.uniparc.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 class UniParcEntryLightValueMapperTest {
 
     @Test
     void testGetDataOrganism() {
         UniParcEntryLight entry = create();
-        List<String> fields = Arrays.asList("upi", "organism", "organism_id", "proteome", "common_taxons", "common_taxon_ids");
+        List<String> fields =
+                Arrays.asList(
+                        "upi",
+                        "organism",
+                        "organism_id",
+                        "proteome",
+                        "common_taxons",
+                        "common_taxon_ids");
 
         Map<String, String> result = new UniParcEntryLightValueMapper().mapEntity(entry, fields);
 
@@ -34,10 +41,19 @@ class UniParcEntryLightValueMapperTest {
     @Test
     void testGetDataOrganism_withEmptyCommonTaxons() {
         UniParcEntryLight entry = create();
-        UniParcEntryLight entryWithEmptyCommonTaxons = UniParcEntryLightBuilder.from(entry).commonTaxonsSet(List.of()).build();
-        List<String> fields = Arrays.asList("upi", "organism", "organism_id", "proteome", "common_taxons", "common_taxon_ids");
+        UniParcEntryLight entryWithEmptyCommonTaxons =
+                UniParcEntryLightBuilder.from(entry).commonTaxonsSet(List.of()).build();
+        List<String> fields =
+                Arrays.asList(
+                        "upi",
+                        "organism",
+                        "organism_id",
+                        "proteome",
+                        "common_taxons",
+                        "common_taxon_ids");
 
-        Map<String, String> result = new UniParcEntryLightValueMapper().mapEntity(entryWithEmptyCommonTaxons, fields);
+        Map<String, String> result =
+                new UniParcEntryLightValueMapper().mapEntity(entryWithEmptyCommonTaxons, fields);
 
         assertEquals(fields.size(), result.size());
         verify("UPI0000083A08", "upi", result);
@@ -97,8 +113,6 @@ class UniParcEntryLightValueMapperTest {
         verify("sigId2", "PROSITE", result);
     }
 
-
-
     private void verify(String expected, String field, Map<String, String> result) {
         assertEquals(expected, result.get(field));
     }
@@ -108,14 +122,28 @@ class UniParcEntryLightValueMapperTest {
         Sequence sequence = new SequenceBuilder(seq).build();
         List<SequenceFeature> seqFeatures = getSeqFeatures();
 
-        Organism organism1 = new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
+        Organism organism1 =
+                new OrganismBuilder().taxonId(9606).scientificName("Homo sapiens").build();
         Organism organism2 = new OrganismBuilder().taxonId(10090).scientificName("MOUSE").build();
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism1, organism2));
 
         LinkedHashSet<String> proteinNames = new LinkedHashSet<>(List.of("protein1", "protein2"));
         LinkedHashSet<String> geneNames = new LinkedHashSet<>(List.of("gene1", "gene2"));
-        List<CommonOrganism> commonTaxons = List.of(new CommonOrganismBuilder().commonTaxon("Bacteroides").commonTaxonId(12345L).build(),new CommonOrganismBuilder().commonTaxon("Enterococcus").commonTaxonId(9876L).build());
-        LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(new ProteomeBuilder().id("UP000005640").component("C1").build(), new ProteomeBuilder().id("UP000002494").component("C2").build()));
+        List<CommonOrganism> commonTaxons =
+                List.of(
+                        new CommonOrganismBuilder()
+                                .commonTaxon("Bacteroides")
+                                .commonTaxonId(12345L)
+                                .build(),
+                        new CommonOrganismBuilder()
+                                .commonTaxon("Enterococcus")
+                                .commonTaxonId(9876L)
+                                .build());
+        LinkedHashSet<Proteome> proteomes =
+                new LinkedHashSet<>(
+                        List.of(
+                                new ProteomeBuilder().id("UP000005640").component("C1").build(),
+                                new ProteomeBuilder().id("UP000002494").component("C2").build()));
 
         return new UniParcEntryLightBuilder()
                 .uniParcId("UPI0000083A08")

--- a/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryValueMapperTest.java
+++ b/core-parser/src/test/java/org/uniprot/core/parser/tsv/uniparc/UniParcEntryValueMapperTest.java
@@ -1,5 +1,13 @@
 package org.uniprot.core.parser.tsv.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.Sequence;
@@ -8,14 +16,6 @@ import org.uniprot.core.uniparc.*;
 import org.uniprot.core.uniparc.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author jluo
@@ -112,7 +112,10 @@ class UniParcEntryValueMapperTest {
     }
 
     private List<SequenceFeature> getSeqFeatures() {
-        List<SequenceFeatureLocation> locations = Arrays.asList(new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(), new SequenceFeatureLocationBuilder().range(45, 89).build());
+        List<SequenceFeatureLocation> locations =
+                Arrays.asList(
+                        new SequenceFeatureLocationBuilder().range(12, 23).alignment("55M").build(),
+                        new SequenceFeatureLocationBuilder().range(45, 89).build());
         InterProGroup domain = new InterProGroupBuilder().name("name1").id("id1").build();
         SequenceFeature sf =
                 new SequenceFeatureBuilder()
@@ -161,7 +164,11 @@ class UniParcEntryValueMapperTest {
                         .propertiesSet(properties2)
                         .organism(taxonomy2)
                         .proteinName("some pname")
-                        .proteomesAdd(new ProteomeBuilder().id("UP00000564").component("chromosome 1").build())
+                        .proteomesAdd(
+                                new ProteomeBuilder()
+                                        .id("UP00000564")
+                                        .component("chromosome 1")
+                                        .build())
                         .build();
 
         return Arrays.asList(xref, xref2);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/antlr/RememberLastTokenLexer.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/antlr/RememberLastTokenLexer.java
@@ -23,9 +23,9 @@ public abstract class RememberLastTokenLexer extends AbstractUniProtLexer {
 
     /** */
     private static final long serialVersionUID = 1L;
-    
-    public static final String VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER ="<<SPACE_NO_SPACE_PLACEHOLDER>>";
 
+    public static final String VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER =
+            "<<SPACE_NO_SPACE_PLACEHOLDER>>";
 
     private Token lastToken;
     private Token nextToken;

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/DefaultUniProtEntryIterator.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/DefaultUniProtEntryIterator.java
@@ -162,8 +162,8 @@ public class DefaultUniProtEntryIterator implements UniProtEntryIterator {
         this.parsingJobCountDownLatch = new CountDownLatch(threadCount);
 
         for (int i = 0; i < threadCount; i++) {
-            ParsingTask parsingTask =createParsingTask();
-                    
+            ParsingTask parsingTask = createParsingTask();
+
             parsingTask.setName("Parsing Worker No. " + (i + 1));
             this.workers.add(parsingTask);
             parsingTask.start();
@@ -180,8 +180,9 @@ public class DefaultUniProtEntryIterator implements UniProtEntryIterator {
     }
 
     protected ParsingTask createParsingTask() {
-    	return new ParsingTask(ffQueue, entriesQueue, this.parsingJobCountDownLatch);
+        return new ParsingTask(ffQueue, entriesQueue, this.parsingJobCountDownLatch);
     }
+
     public class EntryStringEmitter implements Runnable {
         private final EntryReader entryReader;
 
@@ -267,9 +268,9 @@ public class DefaultUniProtEntryIterator implements UniProtEntryIterator {
             this.countDown = countDown;
             this.parser = createEntryParser();
         }
-        
+
         protected UniProtParser createEntryParser() {
-        	return new DefaultUniProtParser(supportingDataMap, ignoreWrong);
+            return new DefaultUniProtParser(supportingDataMap, ignoreWrong);
         }
 
         void finish() {

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/DefaultUniProtParser.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/DefaultUniProtParser.java
@@ -14,7 +14,8 @@ public class DefaultUniProtParser implements UniProtParser {
     public DefaultUniProtParser(SupportingDataMap supportingDataMap, boolean ignoreWrongDr) {
         this.parser = new DefaultUniprotKBLineParserFactory().createEntryParser();
         this.converter = new EntryObjectConverter(supportingDataMap, ignoreWrongDr);
-    };
+    }
+    ;
 
     @Override
     public UniProtKBEntry parse(String entryff) {

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryModelListener.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryModelListener.java
@@ -11,27 +11,29 @@ import org.uniprot.core.flatfile.parser.impl.ft.FtLineObject;
 import org.uniprot.core.flatfile.parser.impl.gn.GnLineObject;
 import org.uniprot.core.flatfile.parser.impl.kw.KwLineObject;
 
-public class AAEntryModelListener extends UniprotAAParserBaseListener implements ParseTreeObjectExtractor<AAEntryObject> {
+public class AAEntryModelListener extends UniprotAAParserBaseListener
+        implements ParseTreeObjectExtractor<AAEntryObject> {
 
     private AAEntryObject object;
-    private DefaultAAUniProtKBLineParserFactory parserFactory = new DefaultAAUniProtKBLineParserFactory();
+    private DefaultAAUniProtKBLineParserFactory parserFactory =
+            new DefaultAAUniProtKBLineParserFactory();
 
     @Override
     public void enterEntry(UniprotAAParser.EntryContext ctx) {
         object = new AAEntryObject();
     }
-    
+
     @Override
     public AAEntryObject getObject() {
         return this.object;
-    }    
+    }
 
     private boolean enableAc = true;
     private UniprotKBLineParser<AcLineObject> acLineParser = parserFactory.createAcLineParser();
 
     @Override
     public void exitAc(UniprotAAParser.AcContext ctx) {
-        
+
         if (this.enableAc) {
             AcLineObject parse = acLineParser.parse(ctx.getText());
             object.ac = parse;
@@ -43,44 +45,43 @@ public class AAEntryModelListener extends UniprotAAParserBaseListener implements
 
     @Override
     public void exitDe(UniprotAAParser.DeContext ctx) {
-       
+
         if (this.enableDe) {
             DeLineObject parse = deLineParser.parse(ctx.getText());
             object.de = parse;
         }
     }
-    
-    
+
     private boolean enableGn = true;
     private UniprotKBLineParser<GnLineObject> gnLineParser = parserFactory.createGnLineParser();
 
     @Override
     public void exitGn(UniprotAAParser.GnContext ctx) {
-       
+
         if (this.enableGn) {
             GnLineObject parse = gnLineParser.parse(ctx.getText());
             object.gn = parse;
         }
     }
-    
+
     private boolean enableCc = true;
     private UniprotKBLineParser<CcLineObject> ccLineParser = parserFactory.createCcLineParser();
 
     @Override
     public void exitCc(UniprotAAParser.CcContext ctx) {
-        
+
         if (this.enableCc) {
             CcLineObject parse = ccLineParser.parse(ctx.getText());
             object.cc = parse;
         }
     }
-    
+
     private boolean enableKw = true;
     private UniprotKBLineParser<KwLineObject> kwLineParser = parserFactory.createKwLineParser();
 
     @Override
     public void exitKw(UniprotAAParser.KwContext ctx) {
-       
+
         if (this.enableKw) {
             KwLineObject parse = kwLineParser.parse(ctx.getText());
             object.kw = parse;
@@ -92,14 +93,10 @@ public class AAEntryModelListener extends UniprotAAParserBaseListener implements
 
     @Override
     public void exitFt(UniprotAAParser.FtContext ctx) {
-       
+
         if (this.enableFt) {
             FtLineObject parse = ftLineParser.parse(ctx.getText());
             object.ft = parse;
         }
     }
-
-
-
 }
-

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryObject.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryObject.java
@@ -15,5 +15,4 @@ public class AAEntryObject {
     public FtLineObject ft;
     public GnLineObject gn;
     public KwLineObject kw;
-   
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryObjectConverter.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAEntryObjectConverter.java
@@ -13,25 +13,24 @@ import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 
-
 public class AAEntryObjectConverter implements Converter<AAEntryObject, UniProtKBEntry> {
     private static final long serialVersionUID = 1L;
-	private final AcLineConverter acLineConverter = new AcLineConverter();
-    private final CcLineConverter ccLineConverter ;
+    private final AcLineConverter acLineConverter = new AcLineConverter();
+    private final CcLineConverter ccLineConverter;
     private final DeLineConverter deLineConverter = new DeLineConverter();
     private final FtLineConverter ftLineConverter = new FtLineConverter();
     private final GnLineConverter gnLineConverter = new GnLineConverter();
 
     private final KwLineConverter kwLineConverter;
-   // private final UniProtFactory factory = DefaultUniProtFactory.getInstance();
+    // private final UniProtFactory factory = DefaultUniProtFactory.getInstance();
 
-    public  AAEntryObjectConverter(SupportingDataMap supportingDataMap, boolean ignoreWrong) {
-    	ccLineConverter =
+    public AAEntryObjectConverter(SupportingDataMap supportingDataMap, boolean ignoreWrong) {
+        ccLineConverter =
                 new CcLineConverter(
                         supportingDataMap.getDiseaseMap(),
                         supportingDataMap.getSubcellularLocationMap(),
                         ignoreWrong);
-    	 kwLineConverter = new KwLineConverter(supportingDataMap.getKeywordMap(), ignoreWrong);
+        kwLineConverter = new KwLineConverter(supportingDataMap.getKeywordMap(), ignoreWrong);
     }
 
     @Override
@@ -41,23 +40,21 @@ public class AAEntryObjectConverter implements Converter<AAEntryObject, UniProtK
         UniProtKBAcLineObject acLineObj = acLineConverter.convert(f.ac);
         UniProtKBEntryBuilder activeEntryBuilder =
                 new UniProtKBEntryBuilder(
-                                acLineObj.getPrimaryAccession().getValue(),"", UniProtKBEntryType.AA);
+                        acLineObj.getPrimaryAccession().getValue(), "", UniProtKBEntryType.AA);
 
-        if (f.cc != null){
+        if (f.cc != null) {
             activeEntryBuilder.commentsSet(ccLineConverter.convert(f.cc));
         }
         if (f.de != null) {
             activeEntryBuilder.proteinDescription(deLineConverter.convert(f.de));
         }
-       
 
         if (f.ft != null) {
             activeEntryBuilder.featuresSet(ftLineConverter.convert(f.ft));
         }
-        if (f.gn != null){
+        if (f.gn != null) {
             activeEntryBuilder.genesSet(gnLineConverter.convert(f.gn));
         }
-
 
         if (f.kw != null) {
             activeEntryBuilder.keywordsSet(kwLineConverter.convert(f.kw));
@@ -66,15 +63,11 @@ public class AAEntryObjectConverter implements Converter<AAEntryObject, UniProtK
         return activeEntryBuilder.build();
     }
 
-
-
     private void clear() {
         ccLineConverter.clear();
         deLineConverter.clear();
         ftLineConverter.clear();
         gnLineConverter.clear();
         kwLineConverter.clear();
-       
     }
-
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAGrammarFactory.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAGrammarFactory.java
@@ -23,12 +23,15 @@ import org.uniprot.core.flatfile.antlr.KwLineParser;
 import org.uniprot.core.flatfile.antlr.UniprotAALexer;
 import org.uniprot.core.flatfile.antlr.UniprotAAParser;
 
-
-
-
-public interface AAGrammarFactory<L extends Lexer, P extends Parser>  {
+public interface AAGrammarFactory<L extends Lexer, P extends Parser> {
     enum GrammarFactoryEnum {
-        UNIPROT_AA, AC, KW, GN, DE, FT, CC;
+        UNIPROT_AA,
+        AC,
+        KW,
+        GN,
+        DE,
+        FT,
+        CC;
 
         private AAGrammarFactory factory;
 
@@ -38,56 +41,57 @@ public interface AAGrammarFactory<L extends Lexer, P extends Parser>  {
                 @Override
                 public Lexer createLexer(CharStream in) {
                     switch (GrammarFactoryEnum.this) {
-                    case UNIPROT_AA:
-                        return wrapLexer(new UniprotAALexer(in), UniprotAALexer._ATN);
-                    case AC:
-                        return wrapLexer(new AcLineLexer(in), AcLineLexer._ATN);
-                                     
-                    case KW:
-                        return wrapLexer(new KwLineLexer(in), KwLineLexer._ATN);
-                                       
-                    case GN:
-                        return wrapLexer(new GnLineLexer(in), GnLineLexer._ATN);
+                        case UNIPROT_AA:
+                            return wrapLexer(new UniprotAALexer(in), UniprotAALexer._ATN);
+                        case AC:
+                            return wrapLexer(new AcLineLexer(in), AcLineLexer._ATN);
 
-                    case DE:
-                        return wrapLexer(new DeLineLexer(in), DeLineLexer._ATN);
-                    
-                    case FT:
-                        return wrapLexer(new FtLineLexer(in), FtLineLexer._ATN);
-                   
-                    case CC:
-                        return wrapLexer(new CcLineLexer(in), CcLineLexer._ATN);
-                   
-                    default:
-                        throw new RuntimeException("Lexer is not defined for: " + GrammarFactoryEnum.this);
+                        case KW:
+                            return wrapLexer(new KwLineLexer(in), KwLineLexer._ATN);
+
+                        case GN:
+                            return wrapLexer(new GnLineLexer(in), GnLineLexer._ATN);
+
+                        case DE:
+                            return wrapLexer(new DeLineLexer(in), DeLineLexer._ATN);
+
+                        case FT:
+                            return wrapLexer(new FtLineLexer(in), FtLineLexer._ATN);
+
+                        case CC:
+                            return wrapLexer(new CcLineLexer(in), CcLineLexer._ATN);
+
+                        default:
+                            throw new RuntimeException(
+                                    "Lexer is not defined for: " + GrammarFactoryEnum.this);
                     }
-
                 }
 
                 @Override
                 public Parser createParser(CommonTokenStream tokens) {
                     switch (GrammarFactoryEnum.this) {
-                    case UNIPROT_AA:
-                        return new UniprotAAParser(tokens);
-                    case AC:
-                        return new AcLineParser(tokens);
-                    case KW:
-                        return new KwLineParser(tokens);
-                   
-                    case GN:
-                        return new GnLineParser(tokens);                   
-                    
-                    case DE:
-                        return new DeLineParser(tokens);
-                    
-                    case FT:
-                        return new FtLineParser(tokens);
-                    
-                    case CC:
-                        return new CcLineParser(tokens);
-                    
-                    default:
-                        throw new RuntimeException("Parser is not defined for: " + GrammarFactoryEnum.this);
+                        case UNIPROT_AA:
+                            return new UniprotAAParser(tokens);
+                        case AC:
+                            return new AcLineParser(tokens);
+                        case KW:
+                            return new KwLineParser(tokens);
+
+                        case GN:
+                            return new GnLineParser(tokens);
+
+                        case DE:
+                            return new DeLineParser(tokens);
+
+                        case FT:
+                            return new FtLineParser(tokens);
+
+                        case CC:
+                            return new CcLineParser(tokens);
+
+                        default:
+                            throw new RuntimeException(
+                                    "Parser is not defined for: " + GrammarFactoryEnum.this);
                     }
                 }
             };
@@ -102,8 +106,8 @@ public interface AAGrammarFactory<L extends Lexer, P extends Parser>  {
 
         public static Lexer wrapLexer(Lexer lexer, ATN atn) {
             DFA[] dfAfromATN = createDFAfromATN(atn);
-            LexerATNSimulator lexerATNSimulator = new LexerATNSimulator(lexer, atn, dfAfromATN,
-                    new PredictionContextCache());
+            LexerATNSimulator lexerATNSimulator =
+                    new LexerATNSimulator(lexer, atn, dfAfromATN, new PredictionContextCache());
             lexer.setInterpreter(lexerATNSimulator);
             return lexer;
         }
@@ -120,5 +124,4 @@ public interface AAGrammarFactory<L extends Lexer, P extends Parser>  {
     public L createLexer(CharStream in);
 
     public P createParser(CommonTokenStream tokens);
-
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtEntryIterator.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtEntryIterator.java
@@ -8,12 +8,9 @@ import org.uniprot.core.flatfile.parser.impl.DefaultUniProtEntryIterator;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 
 /**
- *
  * @author jluo
  * @date: 30 Jan 2026
- *
-*/
-
+ */
 public class AAUniProtEntryIterator extends DefaultUniProtEntryIterator {
     public AAUniProtEntryIterator() {
         super();
@@ -24,22 +21,24 @@ public class AAUniProtEntryIterator extends DefaultUniProtEntryIterator {
         super(numberOfThreads, entryQueuesize, ffQueueSize);
         setIgnoreWrong(true);
     }
+
     @Override
     protected ParsingTask createParsingTask() {
-    	return new AAParsingTask(ffQueue, entriesQueue, this.parsingJobCountDownLatch);
+        return new AAParsingTask(ffQueue, entriesQueue, this.parsingJobCountDownLatch);
     }
-    
-    public class AAParsingTask extends DefaultUniProtEntryIterator.ParsingTask{
 
-		public AAParsingTask(BlockingQueue<String> ffQueue, BlockingQueue<UniProtKBEntry> queue, CountDownLatch countDown) {
-			super(ffQueue, queue, countDown);
-		}
-    	
-		@Override
-		protected UniProtParser createEntryParser() {
-        	return new AAUniProtParser(supportingDataMap, ignoreWrong);
+    public class AAParsingTask extends DefaultUniProtEntryIterator.ParsingTask {
+
+        public AAParsingTask(
+                BlockingQueue<String> ffQueue,
+                BlockingQueue<UniProtKBEntry> queue,
+                CountDownLatch countDown) {
+            super(ffQueue, queue, countDown);
         }
 
+        @Override
+        protected UniProtParser createEntryParser() {
+            return new AAUniProtParser(supportingDataMap, ignoreWrong);
+        }
     }
 }
-

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtKBLineParser.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtKBLineParser.java
@@ -22,9 +22,8 @@ import org.uniprot.core.flatfile.parser.impl.cc.CcLineErrorListener;
 import org.uniprot.core.flatfile.parser.impl.entry.EntryErrorListener;
 import org.uniprot.core.flatfile.parser.impl.ft.FtLineErrorListener;
 
-
-
-public class AAUniProtKBLineParser <T, L extends Lexer, P extends Parser> implements UniprotKBLineParser<T> {
+public class AAUniProtKBLineParser<T, L extends Lexer, P extends Parser>
+        implements UniprotKBLineParser<T> {
 
     private final P parser;
 
@@ -32,7 +31,8 @@ public class AAUniProtKBLineParser <T, L extends Lexer, P extends Parser> implem
 
     private L lexer;
 
-    protected AAUniProtKBLineParser(AAGrammarFactory<L, P> factory, ParseTreeObjectExtractor<T> listener) {
+    protected AAUniProtKBLineParser(
+            AAGrammarFactory<L, P> factory, ParseTreeObjectExtractor<T> listener) {
         this.listener = listener;
 
         this.parser = this.createParserFromInput(new ANTLRInputStream(), factory);
@@ -93,39 +93,42 @@ public class AAUniProtKBLineParser <T, L extends Lexer, P extends Parser> implem
         if (parser instanceof CcLineParser lineParser) {
             lineParser.cc_lines();
         } else {
-            throw new RuntimeException("Parser's type : " + parser.getClass()
-                    + " is not recognized or not supported for No header parse.");
+            throw new RuntimeException(
+                    "Parser's type : "
+                            + parser.getClass()
+                            + " is not recognized or not supported for No header parse.");
         }
         return listener.getObject();
     }
+
     protected T processWithParser(P parser, String originString) {
 
-       
         try {
             if (parser instanceof AcLineParser lineParser) {
                 lineParser.ac_ac();
             } else if (parser instanceof CcLineParser lineParser) {
                 lineParser.cc_cc();
             } else if (parser instanceof DeLineParser lineParser) {
-                lineParser.de_de();            
+                lineParser.de_de();
             } else if (parser instanceof FtLineParser lineParser) {
                 lineParser.ft_ft();
             } else if (parser instanceof GnLineParser lineParser) {
                 lineParser.gn_gn();
-           
+
             } else if (parser instanceof KwLineParser lineParser) {
                 lineParser.kw_kw();
-          
+
             } else if (parser instanceof UniprotAAParser uniprotParser) {
                 uniprotParser.entry();
             } else {
-                throw new RuntimeException("Parser's type : " + parser.getClass() + " is not recognized.");
+                throw new RuntimeException(
+                        "Parser's type : " + parser.getClass() + " is not recognized.");
             }
         } catch (NullPointerException e) {
-            throw new RuntimeException("Unexpected Error, Checking the format of string: " + originString, e);
+            throw new RuntimeException(
+                    "Unexpected Error, Checking the format of string: " + originString, e);
         }
-            
+
         return listener.getObject();
     }
-
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtKBLineParserFactory.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtKBLineParserFactory.java
@@ -18,10 +18,8 @@ public interface AAUniProtKBLineParserFactory {
     UniprotKBLineParser<KwLineObject> createKwLineParser();
 
     UniprotKBLineParser<FtLineObject> createFtLineParser();
- 
+
     UniprotKBLineParser<CcLineObject> createCcLineParser();
 
     UniprotKBLineParser<AAEntryObject> createEntryParser();
-
-   
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtParser.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtParser.java
@@ -6,16 +6,13 @@ import org.uniprot.core.flatfile.parser.UniprotKBLineParser;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 
 /**
- *
  * @author jluo
  * @date: 30 Jan 2026
- *
-*/
-
+ */
 public class AAUniProtParser implements UniProtParser {
 
-	private static final long serialVersionUID = 1L;
-	private final UniprotKBLineParser<AAEntryObject> parser;
+    private static final long serialVersionUID = 1L;
+    private final UniprotKBLineParser<AAEntryObject> parser;
     private final AAEntryObjectConverter converter;
 
     public AAUniProtParser(SupportingDataMap supportingDataMap, boolean ignoreWrong) {
@@ -29,4 +26,3 @@ public class AAUniProtParser implements UniProtParser {
         return converter.convert(parse);
     }
 }
-

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/DefaultAAUniProtKBLineParserFactory.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/aaentry/DefaultAAUniProtKBLineParserFactory.java
@@ -43,13 +43,11 @@ public class DefaultAAUniProtKBLineParserFactory implements AAUniProtKBLineParse
                 AAGrammarFactory.GrammarFactoryEnum.AC.getFactory(), new AcLineModelListener());
     }
 
-
     @Override
     public UniprotKBLineParser<DeLineObject> createDeLineParser() {
         return new AAUniProtKBLineParser<DeLineObject, DeLineLexer, DeLineParser>(
                 AAGrammarFactory.GrammarFactoryEnum.DE.getFactory(), new DeLineModelListener());
     }
-
 
     @Override
     public UniprotKBLineParser<GnLineObject> createGnLineParser() {
@@ -57,16 +55,11 @@ public class DefaultAAUniProtKBLineParserFactory implements AAUniProtKBLineParse
                 AAGrammarFactory.GrammarFactoryEnum.GN.getFactory(), new GnLineModelListener());
     }
 
-
-
     @Override
     public UniprotKBLineParser<KwLineObject> createKwLineParser() {
         return new AAUniProtKBLineParser<KwLineObject, KwLineLexer, KwLineParser>(
                 AAGrammarFactory.GrammarFactoryEnum.KW.getFactory(), new KwLineModelListener());
     }
-
-
-
 
     @Override
     public UniprotKBLineParser<FtLineObject> createFtLineParser() {
@@ -74,13 +67,9 @@ public class DefaultAAUniProtKBLineParserFactory implements AAUniProtKBLineParse
                 AAGrammarFactory.GrammarFactoryEnum.FT.getFactory(), new FtLineModelListener());
     }
 
-
     @Override
     public UniprotKBLineParser<CcLineObject> createCcLineParser() {
         return new AAUniProtKBLineParser<CcLineObject, CcLineLexer, CcLineParser>(
                 AAGrammarFactory.GrammarFactoryEnum.CC.getFactory(), new CcLineModelListener());
     }
-
-
 }
-

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCInteractionCommentLineBuilder.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCInteractionCommentLineBuilder.java
@@ -7,7 +7,9 @@ import org.uniprot.core.uniprotkb.comment.Interactant;
 import org.uniprot.core.uniprotkb.comment.Interaction;
 import org.uniprot.core.uniprotkb.comment.InteractionComment;
 
-/** @author jieluo */
+/**
+ * @author jieluo
+ */
 public class CCInteractionCommentLineBuilder extends CCLineBuilderAbstr<InteractionComment> {
 
     @Override

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCLineBuilderFactory.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/cc/CCLineBuilderFactory.java
@@ -27,7 +27,8 @@ public class CCLineBuilderFactory {
         commentBuilders.put(CommentType.WEBRESOURCE, new CCWebResourceCommentLineBuilder());
         commentBuilders.put(CommentType.COFACTOR, new CCCofactorCommentLineBuilder());
         commentBuilders.put(CommentType.CATALYTIC_ACTIVITY, new CatalyticActivityCCLineBuilder());
-    };
+    }
+    ;
 
     private static final FFLineBuilder<FreeTextComment> defaultBuilder =
             new CCFreeTextCommentLineBuilder();

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/entry/EntryObjectConverter.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/entry/EntryObjectConverter.java
@@ -190,5 +190,4 @@ public class EntryObjectConverter implements Converter<EntryObject, UniProtKBEnt
         refObjConverter.clear();
         drLineConverter.clear();
     }
-
 }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/entry/ReferenceObjectConverter.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/entry/ReferenceObjectConverter.java
@@ -38,7 +38,7 @@ public class ReferenceObjectConverter extends EvidenceCollector
                 builder = rlLineConverter.convert(f.rl);
         int referenceNumber = 0;
         if (f.rn != null) {
-           referenceNumber = f.rn.number;
+            referenceNumber = f.rn.number;
         }
         if (f.ra != null) {
             List<Author> authors = raLineConverter.convert(f.ra);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FTLineBuilderHelper.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FTLineBuilderHelper.java
@@ -209,8 +209,10 @@ public class FTLineBuilderHelper {
             }
             String joiner = getJoiner(featureWithAlternativeSequence);
             sb.append(
-                    featureWithAlternativeSequence.getAlternativeSequence()
-                            .getAlternativeSequences().stream()
+                    featureWithAlternativeSequence
+                            .getAlternativeSequence()
+                            .getAlternativeSequences()
+                            .stream()
                             .collect(Collectors.joining(joiner)));
         } else {
             sb.append(MISSING);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FeatureLineBuilderFactory.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FeatureLineBuilderFactory.java
@@ -18,7 +18,8 @@ public class FeatureLineBuilderFactory {
         featureBuilders.put(UniprotKBFeatureType.VARIANT, new VariantFeatureLineBuilder());
         featureBuilders.put(UniprotKBFeatureType.VAR_SEQ, new VarSeqFeatureBuilder());
         featureBuilders.put(UniprotKBFeatureType.BINDING, new BindingFeatureLineBuilder());
-    };
+    }
+    ;
 
     private static final FFLineBuilder<UniProtKBFeature> defaultBuilder =
             new SimpleFeatureLineBuilder();

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FtLineModelListener.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/ft/FtLineModelListener.java
@@ -68,37 +68,46 @@ public class FtLineModelListener extends FtLineParserBaseListener
             ft.setFtText(updateAltSeqText(result));
         }
     }
-    
+
     private String replaceVarSeqSpaceNoSpace(String text1) {
-        if(Strings.isNullOrEmpty(text1)){
+        if (Strings.isNullOrEmpty(text1)) {
             return text1;
         }
         String newText = text1;
-        while(newText.contains(RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER)) {
-           String restText = newText.substring(newText.indexOf(RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER)
-                   +RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER.length() );
-           String token = restText;
-           int indexSpace = restText.indexOf(" ");
-           int indexLess = restText.indexOf("<");
-           if(indexSpace>0) {
-               if(indexLess>0) {
-                   if(indexLess<indexSpace) {
-                       token =restText.substring(0, restText.indexOf("<"));
-                   }else {
-                       token =restText.substring(0, restText.indexOf(" "));
-                   }
-               }else {
-                   token =restText.substring(0, restText.indexOf(" "));
-               }
-           } else  if(indexLess>0) {
-               token =restText.substring(0, restText.indexOf("<"));
-           }
-       
-          if(RememberLastTokenLexer.isSequenceLetter(token)) {
-              newText = newText.replaceFirst(RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER, "");
-          }else {
-              newText = newText.replaceFirst(RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER, " ");
-          }
+        while (newText.contains(RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER)) {
+            String restText =
+                    newText.substring(
+                            newText.indexOf(
+                                            RememberLastTokenLexer
+                                                    .VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER)
+                                    + RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER
+                                            .length());
+            String token = restText;
+            int indexSpace = restText.indexOf(" ");
+            int indexLess = restText.indexOf("<");
+            if (indexSpace > 0) {
+                if (indexLess > 0) {
+                    if (indexLess < indexSpace) {
+                        token = restText.substring(0, restText.indexOf("<"));
+                    } else {
+                        token = restText.substring(0, restText.indexOf(" "));
+                    }
+                } else {
+                    token = restText.substring(0, restText.indexOf(" "));
+                }
+            } else if (indexLess > 0) {
+                token = restText.substring(0, restText.indexOf("<"));
+            }
+
+            if (RememberLastTokenLexer.isSequenceLetter(token)) {
+                newText =
+                        newText.replaceFirst(
+                                RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER, "");
+            } else {
+                newText =
+                        newText.replaceFirst(
+                                RememberLastTokenLexer.VAR_SEQ_SPACE_NO_SPACE_PLACEHOLDER, " ");
+            }
         }
         return newText;
     }

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/os/OSLineBuilder.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/parser/impl/os/OSLineBuilder.java
@@ -13,8 +13,8 @@ import org.uniprot.core.flatfile.writer.impl.FFLineWrapper;
 import org.uniprot.core.flatfile.writer.impl.FFLines;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 
-public class OSLineBuilder extends FFLineBuilderAbstr<Organism>
-        implements FFLineBuilder<Organism> {;
+public class OSLineBuilder extends FFLineBuilderAbstr<Organism> implements FFLineBuilder<Organism> {
+    ;
 
     public OSLineBuilder() {
         super(LineType.OS);

--- a/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/UniProtFlatfileWriter.java
+++ b/ff-parser/src/main/java/org/uniprot/core/flatfile/writer/impl/UniProtFlatfileWriter.java
@@ -25,8 +25,8 @@ import org.uniprot.core.flatfile.writer.FlatfileWriter;
 import org.uniprot.core.flatfile.writer.LineType;
 import org.uniprot.core.uniprotkb.*;
 import org.uniprot.core.uniprotkb.comment.Comment;
-import org.uniprot.core.uniprotkb.comment.SequenceCautionComment;
 import org.uniprot.core.uniprotkb.comment.CommentType;
+import org.uniprot.core.uniprotkb.comment.SequenceCautionComment;
 
 import com.google.common.base.Strings;
 
@@ -248,16 +248,14 @@ public class UniProtFlatfileWriter implements FlatfileWriter<UniProtKBEntry> {
         for (CommentType commentType : CommentType.values()) {
             List<Comment> comments = entry.getCommentsByType(commentType);
             if (!comments.isEmpty()) {
-            	if(commentType ==CommentType.SEQUENCE_CAUTION) {
-            		List<List<Comment>> seqCoumentsList = splitSequenceComments(comments);
-            		for(List<Comment> seqComments: seqCoumentsList) {
-            			ccLines.add(buildComment(seqComments, showEvidence));
-            		}            		
-            	}else {
-            		ccLines.add(buildComment(comments, showEvidence));
-            	}
-            	
-         
+                if (commentType == CommentType.SEQUENCE_CAUTION) {
+                    List<List<Comment>> seqCoumentsList = splitSequenceComments(comments);
+                    for (List<Comment> seqComments : seqCoumentsList) {
+                        ccLines.add(buildComment(seqComments, showEvidence));
+                    }
+                } else {
+                    ccLines.add(buildComment(comments, showEvidence));
+                }
             }
         }
         return ccLines;
@@ -266,48 +264,45 @@ public class UniProtFlatfileWriter implements FlatfileWriter<UniProtKBEntry> {
     private static List<List<Comment>> splitSequenceComments(List<Comment> comments) {
         List<List<Comment>> splittedComments = new ArrayList<>();
         Comment currentComment = null;
-        List<Comment> curComments= new ArrayList<>();
-        for(Comment comment: comments) {
-            if(currentComment ==null) {
-                currentComment =comment;
+        List<Comment> curComments = new ArrayList<>();
+        for (Comment comment : comments) {
+            if (currentComment == null) {
+                currentComment = comment;
                 curComments = new ArrayList<>();
                 curComments.add(comment);
-            }else {
-            	String curMolecule = ((SequenceCautionComment)currentComment).getMolecule();
-            	String molecule =((SequenceCautionComment)comment).getMolecule();
-                if(Strings.isNullOrEmpty(curMolecule)){
-                  if(Strings.isNullOrEmpty(molecule))  {
-                      curComments.add(comment);
-                  }else {
-                      splittedComments.add(curComments);
-                      currentComment =comment;
-                      curComments = new ArrayList<>();
-                      curComments.add(comment); 
-                      
-                  }
-                }else if(curMolecule.equals(molecule)) {
+            } else {
+                String curMolecule = ((SequenceCautionComment) currentComment).getMolecule();
+                String molecule = ((SequenceCautionComment) comment).getMolecule();
+                if (Strings.isNullOrEmpty(curMolecule)) {
+                    if (Strings.isNullOrEmpty(molecule)) {
+                        curComments.add(comment);
+                    } else {
+                        splittedComments.add(curComments);
+                        currentComment = comment;
+                        curComments = new ArrayList<>();
+                        curComments.add(comment);
+                    }
+                } else if (curMolecule.equals(molecule)) {
                     curComments.add(comment);
-                }else {
+                } else {
                     splittedComments.add(curComments);
-                    currentComment =comment;
+                    currentComment = comment;
                     curComments = new ArrayList<>();
-                    curComments.add(comment);  
+                    curComments.add(comment);
                 }
             }
         }
-        if(!curComments.isEmpty()) {
+        if (!curComments.isEmpty()) {
             splittedComments.add(curComments);
         }
         return splittedComments;
     }
-    
+
     private static FFLine buildComment(List<Comment> comments, boolean showEvidence) {
-        if (showEvidence)
-            return ccLineBuilder.buildWithEvidence(comments);
-        else
-            return ccLineBuilder.build(comments);
+        if (showEvidence) return ccLineBuilder.buildWithEvidence(comments);
+        else return ccLineBuilder.build(comments);
     }
-    
+
     private static FFLine buildDRLines(UniProtKBEntry entry, boolean showEvidence) {
         FFLine drLines = FFLines.create();
         drLines.add(drLineBuilder.build(entry.getUniProtKBCrossReferences()));

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/antlr/FtLineParserTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/antlr/FtLineParserTest.java
@@ -34,13 +34,12 @@ class FtLineParserTest {
                 "PRO_0000232680");
     }
 
-    
     @Test
     void testChainWithThreeSingleQuote() {
         String ftLines =
                 "FT   CHAIN           1..468\n"
                         + "FT                   /note=\"Anthocyanidin 3-O-glucoside 2'''-O-\n"
-                		+"FT                   xylosyltransferase\"\n"
+                        + "FT                   xylosyltransferase\"\n"
                         + "FT                   /id=\"PRO_0000409107\"\n";
         UniprotKBLineParser<FtLineObject> parser =
                 new DefaultUniprotKBLineParserFactory().createFtLineParser();
@@ -55,7 +54,6 @@ class FtLineParserTest {
                 "PRO_0000409107");
     }
 
-    
     @Test
     void testHelix() {
         String ftLines = "FT   HELIX           33..83\n";
@@ -167,7 +165,7 @@ class FtLineParserTest {
     @Test
     void testVarSeq2() {
         String ftLines =
-                          "FT   VAR_SEQ         1\n"
+                "FT   VAR_SEQ         1\n"
                         + "FT                   /note=\"M -> MTDRQTDTAPSPSAHLLAGGLPTVDAAASREEPKPA\n"
                         + "FT                   SPSRRGSASRAGPGRASETM (in isoform L-VEGF-1)\"\n"
                         + "FT                   /evidence=\"ECO:0000305\"\n"
@@ -194,70 +192,68 @@ class FtLineParserTest {
                 feature.getAlternativeSequence().getAlternativeSequences().get(0));
         assertEquals("in isoform L-VEGF-1", feature.getDescription().getValue());
     }
-    
-    
+
     @Test
     void testVarSeqNotSeqBreak() {
-    	 String ftLines =
-    			   "FT   VAR_SEQ         24\n"
-                 + "FT                   /note=\"R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform D\n"
-                 + "FT                   and isoform E)\"\n"
-                 + "FT                   /evidence=\"ECO:0000303|PubMed:11528118,\n"
-                 + "FT                   ECO:0000303|PubMed:15489334, ECO:0000305|PubMed:11528118\"\n"
-                 + "FT                   /id=\"VSP_058785\"\n";
+        String ftLines =
+                "FT   VAR_SEQ         24\n"
+                        + "FT                   /note=\"R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform D\n"
+                        + "FT                   and isoform E)\"\n"
+                        + "FT                   /evidence=\"ECO:0000303|PubMed:11528118,\n"
+                        + "FT                   ECO:0000303|PubMed:15489334, ECO:0000305|PubMed:11528118\"\n"
+                        + "FT                   /id=\"VSP_058785\"\n";
 
-         UniprotKBLineParser<FtLineObject> parser =
-                 new DefaultUniprotKBLineParserFactory().createFtLineParser();
-         FtLineObject obj = parser.parse(ftLines);
-         assertEquals(1, obj.getFts().size());
-         System.out.println(obj.getFts().get(0).getFtText());
-         String desc =
-                 "R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform D and isoform E)";
-         
-         FtLineConverter converter = new FtLineConverter();
-         List<UniProtKBFeature> features = converter.convert(obj);
-         assertEquals(1, features.size());
-         UniProtKBFeature feature = features.get(0);
-         assertEquals("R", feature.getAlternativeSequence().getOriginalSequence());
+        UniprotKBLineParser<FtLineObject> parser =
+                new DefaultUniprotKBLineParserFactory().createFtLineParser();
+        FtLineObject obj = parser.parse(ftLines);
+        assertEquals(1, obj.getFts().size());
+        System.out.println(obj.getFts().get(0).getFtText());
+        String desc = "R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform D and isoform E)";
 
-         assertEquals(
-                 "RDSLKLHPSQNFHRAGLLE",
-                 feature.getAlternativeSequence().getAlternativeSequences().get(0));
-         assertEquals("in isoform B, isoform D and isoform E", feature.getDescription().getValue());
+        FtLineConverter converter = new FtLineConverter();
+        List<UniProtKBFeature> features = converter.convert(obj);
+        assertEquals(1, features.size());
+        UniProtKBFeature feature = features.get(0);
+        assertEquals("R", feature.getAlternativeSequence().getOriginalSequence());
+
+        assertEquals(
+                "RDSLKLHPSQNFHRAGLLE",
+                feature.getAlternativeSequence().getAlternativeSequences().get(0));
+        assertEquals("in isoform B, isoform D and isoform E", feature.getDescription().getValue());
     }
 
     @Test
     void testVarSeqNotSeqBreak2() {
-    	 String ftLines =
-    			   "FT   VAR_SEQ         24\n"
-                 + "FT                   /note=\"R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform\n"
-                 + "FT                   D and isoform E)\"\n"
-                 + "FT                   /evidence=\"ECO:0000303|PubMed:11528118,\n"
-                 + "FT                   ECO:0000303|PubMed:15489334, ECO:0000305|PubMed:11528118\"\n"
-                 + "FT                   /id=\"VSP_058785\"\n";
+        String ftLines =
+                "FT   VAR_SEQ         24\n"
+                        + "FT                   /note=\"R -> RDSLKLHPSQNFHRAGLLE (in isoform B, isoform\n"
+                        + "FT                   D and isoform E)\"\n"
+                        + "FT                   /evidence=\"ECO:0000303|PubMed:11528118,\n"
+                        + "FT                   ECO:0000303|PubMed:15489334, ECO:0000305|PubMed:11528118\"\n"
+                        + "FT                   /id=\"VSP_058785\"\n";
 
-         UniprotKBLineParser<FtLineObject> parser =
-                 new DefaultUniprotKBLineParserFactory().createFtLineParser();
-         FtLineObject obj = parser.parse(ftLines);
-         assertEquals(1, obj.getFts().size());
-       
-         // verify(obj.getFts().get(0), FTType.VAR_SEQ, "1", "31",  desc, "VSP_043645");
-         FtLineConverter converter = new FtLineConverter();
-         List<UniProtKBFeature> features = converter.convert(obj);
-         assertEquals(1, features.size());
-         UniProtKBFeature feature = features.get(0);
-         assertEquals("R", feature.getAlternativeSequence().getOriginalSequence());
+        UniprotKBLineParser<FtLineObject> parser =
+                new DefaultUniprotKBLineParserFactory().createFtLineParser();
+        FtLineObject obj = parser.parse(ftLines);
+        assertEquals(1, obj.getFts().size());
 
-         assertEquals(
-                 "RDSLKLHPSQNFHRAGLLE",
-                 feature.getAlternativeSequence().getAlternativeSequences().get(0));
-         assertEquals("in isoform B, isoform D and isoform E", feature.getDescription().getValue());
+        // verify(obj.getFts().get(0), FTType.VAR_SEQ, "1", "31",  desc, "VSP_043645");
+        FtLineConverter converter = new FtLineConverter();
+        List<UniProtKBFeature> features = converter.convert(obj);
+        assertEquals(1, features.size());
+        UniProtKBFeature feature = features.get(0);
+        assertEquals("R", feature.getAlternativeSequence().getOriginalSequence());
+
+        assertEquals(
+                "RDSLKLHPSQNFHRAGLLE",
+                feature.getAlternativeSequence().getAlternativeSequences().get(0));
+        assertEquals("in isoform B, isoform D and isoform E", feature.getDescription().getValue());
     }
-    
-    
+
     @Test
     void testVarSeqMultiLineNoBreak() {
-        String ftLine ="""
+        String ftLine =
+                """
                 FT   VAR_SEQ         1..166
                 FT                   /note="MRREFCWDAYSKAAGSRASSPLPRQDRDSFCHQMSFCLTELHLWSLKNTLHI
                 FT                   QNSRCVLSKWKNKYVCQLLFGSGVLVSLSLSGPQLEKVVIDRSLVGKLISDTI -> MF
@@ -267,29 +263,30 @@ class FtLineParserTest {
                 FT                   /evidence="ECO:0000303|PubMed:15489334, ECO:0000303|Ref.1"
                 FT                   /id="VSP_032408"
                 """;
-        
+
         UniprotKBLineParser<FtLineObject> parser =
                 new DefaultUniprotKBLineParserFactory().createFtLineParser();
         FtLineObject obj = parser.parse(ftLine);
         assertEquals(1, obj.getFts().size());
-        String expected ="MRREFCWDAYSKAAGSRASSPLPRQDRDSFCHQMSFCLTELHLWSLKNTLHIQNSRCVLSKWKNKYVCQLLFGSGVLVSLSLSGPQLEKVVIDRSLVGKLISDTI"
-        		+ " -> MFSSLHSSRDYPWTLKNRRPEKLRDSLKELEELQKLAESR (in isoform B, isoform D, isoform E,"
-        		+ " isoform F, isoform G, isofrom I, isoform L and isoform M)";
+        String expected =
+                "MRREFCWDAYSKAAGSRASSPLPRQDRDSFCHQMSFCLTELHLWSLKNTLHIQNSRCVLSKWKNKYVCQLLFGSGVLVSLSLSGPQLEKVVIDRSLVGKLISDTI"
+                        + " -> MFSSLHSSRDYPWTLKNRRPEKLRDSLKELEELQKLAESR (in isoform B, isoform D, isoform E,"
+                        + " isoform F, isoform G, isofrom I, isoform L and isoform M)";
 
         assertEquals(expected, obj.getFts().get(0).getFtText());
         FtLineConverter converter = new FtLineConverter();
         List<UniProtKBFeature> features = converter.convert(obj);
         assertEquals(1, features.size());
         UniProtKBFeature feature = features.get(0);
-        String origSeq =  "MRREFCWDAYSKAAGSRASSPLPRQDRDSFCHQMSFCLTELHLWSLKNTLHI"
-                + "QNSRCVLSKWKNKYVCQLLFGSGVLVSLSLSGPQLEKVVIDRSLVGKLISDTI";
-        String altSeq ="MFSSLHSSRDYPWTLKNRRPEKLRDSLKELEELQKLAESR";
+        String origSeq =
+                "MRREFCWDAYSKAAGSRASSPLPRQDRDSFCHQMSFCLTELHLWSLKNTLHI"
+                        + "QNSRCVLSKWKNKYVCQLLFGSGVLVSLSLSGPQLEKVVIDRSLVGKLISDTI";
+        String altSeq = "MFSSLHSSRDYPWTLKNRRPEKLRDSLKELEELQKLAESR";
         assertEquals(origSeq, feature.getAlternativeSequence().getOriginalSequence());
+        assertEquals(altSeq, feature.getAlternativeSequence().getAlternativeSequences().get(0));
         assertEquals(
-        		altSeq,
-                feature.getAlternativeSequence().getAlternativeSequences().get(0));
-        assertEquals("in isoform B, isoform D, isoform E, isoform F, isoform G, isofrom I, isoform L and isoform M", feature.getDescription().getValue());
-     
+                "in isoform B, isoform D, isoform E, isoform F, isoform G, isofrom I, isoform L and isoform M",
+                feature.getDescription().getValue());
     }
 
     @Test

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtEntryIteratorTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtEntryIteratorTest.java
@@ -10,40 +10,35 @@ import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 
 /**
- *
  * @author jluo
  * @date: 30 Jan 2026
- *
-*/
-
+ */
 class AAUniProtEntryIteratorTest {
 
-	 private  AAUniProtEntryIterator entryIterator;
+    private AAUniProtEntryIterator entryIterator;
 
-	    @BeforeEach
-	    void setUp() {
-	        entryIterator = new  AAUniProtEntryIterator();
-	    }
-	    
-	@Test
-	void test() {
-		 String filename = "src/test/resources/aaentry/aadat.txt";
-         entryIterator.setInput(filename, "", "", "", "");
-         List<String> expected = List.of(
-        		 "A0ABM6UB92",
-        		 "A0ABM6UD37",
-        		 "A0ABM6UN56",
-        		 "A0A009HMB5",
-        		 "A0A009HMZ2",
-        		 "A0A009HN62"	 
-        		 );
-         List<String> result = new ArrayList<>();
-         while (entryIterator.hasNext()) {
-        	 UniProtKBEntry entry = entryIterator.next();
-        	 result.add(entry.getPrimaryAccession().getValue());
-         }
-         assertEquals(expected, result);
-	}
+    @BeforeEach
+    void setUp() {
+        entryIterator = new AAUniProtEntryIterator();
+    }
 
+    @Test
+    void test() {
+        String filename = "src/test/resources/aaentry/aadat.txt";
+        entryIterator.setInput(filename, "", "", "", "");
+        List<String> expected =
+                List.of(
+                        "A0ABM6UB92",
+                        "A0ABM6UD37",
+                        "A0ABM6UN56",
+                        "A0A009HMB5",
+                        "A0A009HMZ2",
+                        "A0A009HN62");
+        List<String> result = new ArrayList<>();
+        while (entryIterator.hasNext()) {
+            UniProtKBEntry entry = entryIterator.next();
+            result.add(entry.getPrimaryAccession().getValue());
+        }
+        assertEquals(expected, result);
+    }
 }
-

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtLineParserTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtLineParserTest.java
@@ -23,14 +23,10 @@ import org.uniprot.core.flatfile.parser.impl.gn.GnLineObject.GnName;
 import org.uniprot.core.flatfile.parser.impl.gn.GnLineObject.GnNameType;
 import org.uniprot.core.flatfile.parser.impl.kw.KwLineObject;
 
-
-
-
 class AAUniProtLineParserTest {
-    private static AAUniProtKBLineParserFactory parserFactory = new DefaultAAUniProtKBLineParserFactory();
+    private static AAUniProtKBLineParserFactory parserFactory =
+            new DefaultAAUniProtKBLineParserFactory();
 
-
-    
     @Test
     public void testACUniParcIdFormat() {
         UniprotKBLineParser<AcLineObject> acParser = parserFactory.createAcLineParser();
@@ -38,32 +34,32 @@ class AAUniProtLineParserTest {
         AcLineObject object = acParser.parse(acLine);
         assertEquals("UPI0013A7CF90", object.primaryAcc);
         assertEquals(0, object.secondaryAcc.size());
-
     }
+
     @Test
     public void testACUniParcIdWithTaxIdFormat() {
-    	UniprotKBLineParser<AcLineObject> acParser = parserFactory.createAcLineParser();
+        UniprotKBLineParser<AcLineObject> acParser = parserFactory.createAcLineParser();
         String acLine = "AC   UPI0013A7CF90-1392245;\n";
         AcLineObject object = acParser.parse(acLine);
         assertEquals("UPI0013A7CF90-1392245", object.primaryAcc);
         assertEquals(0, object.secondaryAcc.size());
     }
-    
-   
-    
+
     @Test
     void testCC() {
-        String ccLine ="""
+        String ccLine =
+                """
 CC   -!- FUNCTION: Catalyzes the conversion of acetate into acetyl-CoA (AcCoA),
 CC       an essential intermediate at the junction of anabolic and catabolic
-CC       product AcCoA. {ECO:0000256|HAMAP-Rule:MF_01123}.                
+CC       product AcCoA. {ECO:0000256|HAMAP-Rule:MF_01123}.
                         """;
         UniprotKBLineParser<CcLineObject> ccParser = parserFactory.createCcLineParser();
-        
+
         CcLineObject obj = ccParser.parse(ccLine);
 
-        String val = "Catalyzes the conversion of acetate into acetyl-CoA (AcCoA), an essential intermediate at the junction of anabolic and catabolic product AcCoA";
-      
+        String val =
+                "Catalyzes the conversion of acetate into acetyl-CoA (AcCoA), an essential intermediate at the junction of anabolic and catabolic product AcCoA";
+
         assertEquals(1, obj.getCcs().size());
         CC cc = obj.getCcs().get(0);
         assertEquals(CC.CCTopicEnum.FUNCTION, cc.getTopic());
@@ -77,30 +73,33 @@ CC       product AcCoA. {ECO:0000256|HAMAP-Rule:MF_01123}.
 
     @Test
     void testDE() {
-        String deLine = """
+        String deLine =
+                """
         DE   RecName: Full=Angiotensin-converting enzyme {ECO:0000256|RuleBase:RU361144};
-        DE            EC=3.4.-.- {ECO:0000256|RuleBase:RU361144};                
+        DE            EC=3.4.-.- {ECO:0000256|RuleBase:RU361144};
                         """;
         UniprotKBLineParser<DeLineObject> deParser = parserFactory.createDeLineParser();
-        
+
         DeLineObject object = deParser.parse(deLine);
-        DeLineObject.Name recName =object.getRecName();
+        DeLineObject.Name recName = object.getRecName();
         assertNotNull(recName);
         assertEquals("Angiotensin-converting enzyme", recName.getFullName());
-        checkEvidence(recName.getFullName(), object.getEvidenceInfo(), "ECO:0000256|RuleBase:RU361144");
+        checkEvidence(
+                recName.getFullName(), object.getEvidenceInfo(), "ECO:0000256|RuleBase:RU361144");
         assertEquals(1, recName.getEcs().size());
         assertEquals("3.4.-.-", recName.getEcs().get(0));
         DeLineObject.ECEvidence ecEvidence = new DeLineObject.ECEvidence();
-        ecEvidence.setEcValue( recName.getEcs().get(0));
-        ecEvidence.setNameECBelong(recName); 
+        ecEvidence.setEcValue(recName.getEcs().get(0));
+        ecEvidence.setNameECBelong(recName);
 
         checkEvidence(ecEvidence, object.getEvidenceInfo(), "ECO:0000256|RuleBase:RU361144");
     }
-    
+
     @Test
     void testGN() {
-        String gnLine ="""
-        GN   Name=acsA {ECO:0000256|HAMAP-Rule:MF_01123};                
+        String gnLine =
+                """
+        GN   Name=acsA {ECO:0000256|HAMAP-Rule:MF_01123};
                         """;
         UniprotKBLineParser<GnLineObject> parser = parserFactory.createGnLineParser();
         GnLineObject obj = parser.parse(gnLine);
@@ -109,37 +108,50 @@ CC       product AcCoA. {ECO:0000256|HAMAP-Rule:MF_01123}.
         GnName gnName = obj.gnObjects.get(0).names.get(0);
         assertEquals(GnNameType.GENAME, gnName.type);
         assertEquals(List.of("acsA"), gnName.names);
-        assertEquals(List.of("ECO:0000256|HAMAP-Rule:MF_01123"),
+        assertEquals(
+                List.of("ECO:0000256|HAMAP-Rule:MF_01123"),
                 gnName.getEvidenceInfo().getEvidences().get("acsA"));
-        
     }
-    
+
     @Test
     void testFT() {
-        String ftLines ="""
+        String ftLines =
+                """
 FT   CHAIN           18..805
 FT                   /note="Angiotensin-converting enzyme"
 FT                   /evidence="ECO:0000256|SAM:SignalP"
 FT                   /id="PRO_5035841938"
 FT   TRANSMEM        741..765
 FT                   /note="Helical"
-FT                   /evidence="ECO:0000256|SAM:Phobius"                        
+FT                   /evidence="ECO:0000256|SAM:Phobius"
                         """;
         UniprotKBLineParser<FtLineObject> parser = parserFactory.createFtLineParser();
         FtLineObject obj = parser.parse(ftLines);
         assertEquals(2, obj.getFts().size());
-        verifyFt(obj, obj.getFts().get(0), FtLineObject.FTType.CHAIN, "18", "805",
-                "Angiotensin-converting enzyme", "PRO_5035841938", 
+        verifyFt(
+                obj,
+                obj.getFts().get(0),
+                FtLineObject.FTType.CHAIN,
+                "18",
+                "805",
+                "Angiotensin-converting enzyme",
+                "PRO_5035841938",
                 List.of("ECO:0000256|SAM:SignalP"));
-        verifyFt(obj, obj.getFts().get(1), FtLineObject.FTType.TRANSMEM, "741", "765",
-                "Helical", null, 
+        verifyFt(
+                obj,
+                obj.getFts().get(1),
+                FtLineObject.FTType.TRANSMEM,
+                "741",
+                "765",
+                "Helical",
+                null,
                 List.of("ECO:0000256|SAM:Phobius"));
-        
     }
-    
+
     @Test
     void testAAEntry() {
-        String aaEntryLines = """
+        String aaEntryLines =
+                """
 AC   UPI000000000B-1032;
 DE   RecName: Full=Angiotensin-converting enzyme {ECO:0000256|RuleBase:RU361144};
 DE            EC=3.4.-.- {ECO:0000256|RuleBase:RU361144};
@@ -276,10 +288,10 @@ FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
 FT   COMPBIAS        789..805
 FT                   /note="Polar residues"
 FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
-//                        
+//
                         """;
         UniprotKBLineParser<AAEntryObject> entryParser = parserFactory.createEntryParser();
-     //   aaEntryLines = aaEntryLines.substring(0, aaEntryLines.length()-1);
+        //   aaEntryLines = aaEntryLines.substring(0, aaEntryLines.length()-1);
         AAEntryObject entry = entryParser.parse(aaEntryLines);
         assertNotNull(entry);
         assertEquals("UPI000000000B-1032", entry.ac.primaryAcc);
@@ -290,10 +302,15 @@ FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
         KwLineObject kw = entry.kw;
         assertEquals(18, kw.keywords.size());
     }
-    
-    void verifyFt(FtLineObject obj,
-            FtLineObject.FT ft, FtLineObject.FTType type, String start, String end,
-            String text, String ftid,
+
+    void verifyFt(
+            FtLineObject obj,
+            FtLineObject.FT ft,
+            FtLineObject.FTType type,
+            String start,
+            String end,
+            String text,
+            String ftid,
             List<String> evidences) {
         assertEquals(type, ft.getType());
         assertEquals(start, ft.getLocationStart());
@@ -305,13 +322,12 @@ FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
     }
 
     private void checkEvidence(Object obj, EvidenceInfo evInfo, String ev) {
-        if ((ev == null) || (ev.isEmpty()))
-            checkEvidences(obj, evInfo, null);
+        if ((ev == null) || (ev.isEmpty())) checkEvidences(obj, evInfo, null);
         List<String> evs = new ArrayList<>();
         evs.add(ev);
         checkEvidences(obj, evInfo, evs);
     }
-    
+
     private void checkEvidences(Object obj, EvidenceInfo evInfo, List<String> evs) {
 
         List<String> evidences = evInfo.getEvidences().get(obj);
@@ -326,5 +342,4 @@ FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
             assertEquals(evs.get(i), evidences.get(i));
         }
     }
-
 }

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtParserTest.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/impl/aaentry/AAUniProtParserTest.java
@@ -17,21 +17,20 @@ import org.uniprot.core.uniprotkb.description.ProteinDescription;
 import org.uniprot.core.uniprotkb.evidence.EvidencedValue;
 import org.uniprot.core.uniprotkb.feature.UniProtKBFeature;
 import org.uniprot.core.uniprotkb.feature.UniprotKBFeatureType;
+
 /**
- *
  * @author jluo
  * @date: 30 Jan 2026
- *
-*/
-
+ */
 class AAUniProtParserTest {
 
-	@Test
-	void testParse() {
-		SupportingDataMap supportingDataMap =new SupportingDataMapImpl();
-		AAUniProtParser parser = new AAUniProtParser(supportingDataMap, true);
-		
-        String aaEntryLines = """
+    @Test
+    void testParse() {
+        SupportingDataMap supportingDataMap = new SupportingDataMapImpl();
+        AAUniProtParser parser = new AAUniProtParser(supportingDataMap, true);
+
+        String aaEntryLines =
+                """
 AC   UPI000000000B-1032;
 DE   RecName: Full=Angiotensin-converting enzyme {ECO:0000256|RuleBase:RU361144};
 DE            EC=3.4.-.- {ECO:0000256|RuleBase:RU361144};
@@ -168,37 +167,34 @@ FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
 FT   COMPBIAS        789..805
 FT                   /note="Polar residues"
 FT                   /evidence="ECO:0000256|SAM:MobiDB-lite"
-//                        
+//
                         """;
-		UniProtKBEntry entry =parser.parse(aaEntryLines);
-		assertNotNull(entry);
-		assertEquals("UPI000000000B-1032", entry.getPrimaryAccession().getValue());
-		
-		ProteinDescription pd = entry.getProteinDescription();
-		assertEquals("Angiotensin-converting enzyme", pd.getRecommendedName()
-				.getFullName().getValue());
-		assertFalse(pd.hasAlternativeNames());
-		assertEquals(15, entry.getComments().size());
-		List<CatalyticActivityComment> caComments =
-				entry.getCommentsByType(CommentType.CATALYTIC_ACTIVITY);
-		
-		assertEquals(9, caComments.size());
-		List<FreeTextComment> coComments =
-				entry.getCommentsByType(CommentType.CAUTION);
-		assertEquals(1, coComments.size());
-		FreeTextComment ctComment = coComments.get(0);
-		assertEquals(1, ctComment.getTexts().size());
-		EvidencedValue ev = ctComment.getTexts().get(0);
-		
-		String expectedEv ="Lacks conserved residue(s) required for the propagation of feature annotation {ECO:0000256|PROSITE-ProRule:PRU01355}";
-		assertEquals(expectedEv, ev.toString());
-		assertEquals(5, entry.getFeatures().size());
-		 List<UniProtKBFeature> domainFts =entry.getFeaturesByType(UniprotKBFeatureType.DOMAIN);
-		assertEquals(1, domainFts.size());
-		
-		assertEquals(18, entry.getKeywords().size());
-	     
-	}
+        UniProtKBEntry entry = parser.parse(aaEntryLines);
+        assertNotNull(entry);
+        assertEquals("UPI000000000B-1032", entry.getPrimaryAccession().getValue());
 
+        ProteinDescription pd = entry.getProteinDescription();
+        assertEquals(
+                "Angiotensin-converting enzyme", pd.getRecommendedName().getFullName().getValue());
+        assertFalse(pd.hasAlternativeNames());
+        assertEquals(15, entry.getComments().size());
+        List<CatalyticActivityComment> caComments =
+                entry.getCommentsByType(CommentType.CATALYTIC_ACTIVITY);
+
+        assertEquals(9, caComments.size());
+        List<FreeTextComment> coComments = entry.getCommentsByType(CommentType.CAUTION);
+        assertEquals(1, coComments.size());
+        FreeTextComment ctComment = coComments.get(0);
+        assertEquals(1, ctComment.getTexts().size());
+        EvidencedValue ev = ctComment.getTexts().get(0);
+
+        String expectedEv =
+                "Lacks conserved residue(s) required for the propagation of feature annotation {ECO:0000256|PROSITE-ProRule:PRU01355}";
+        assertEquals(expectedEv, ev.toString());
+        assertEquals(5, entry.getFeatures().size());
+        List<UniProtKBFeature> domainFts = entry.getFeaturesByType(UniprotKBFeatureType.DOMAIN);
+        assertEquals(1, domainFts.size());
+
+        assertEquals(18, entry.getKeywords().size());
+    }
 }
-

--- a/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/integration/FlatfileRoundTripIT.java
+++ b/ff-parser/src/test/java/org/uniprot/core/flatfile/parser/integration/FlatfileRoundTripIT.java
@@ -83,7 +83,6 @@ class FlatfileRoundTripIT {
         "/entryIT/P09230.txl, false",
         "/entryIT/P0CH48.txl, false",
         "/entryIT/P09919.txl, false",
-       
         "/entryIT/Q9FK72.txl, false",
         "/entryIT/Q00731.txl, false",
         "/entryIT/P54757.txl, false",

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/JsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/JsonConfig.java
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.bohnman.squiggly.filter.SquigglyPropertyFilter;
 import com.github.bohnman.squiggly.filter.SquigglyPropertyFilterMixin;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public abstract class JsonConfig {
 
     public abstract ObjectMapper getSimpleObjectMapper();

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/JsonUtils.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/JsonUtils.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class JsonUtils {
 
     public static String getJsonString(Object obj, boolean isPretty) {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/keyword/KeywordJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/keyword/KeywordJsonConfig.java
@@ -15,7 +15,9 @@ import org.uniprot.core.json.parser.keyword.serializer.KeywordCategorySerializer
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class KeywordJsonConfig extends JsonConfig {
     private static KeywordJsonConfig INSTANCE;
 

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/AuthorSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/AuthorSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class AuthorSerializer extends StdSerializer<AuthorImpl> {
 
     public AuthorSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/JournalSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/JournalSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class JournalSerializer extends StdSerializer<JournalImpl> {
 
     public JournalSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/LocatorSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/LocatorSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LocatorSerializer extends StdSerializer<ElectronicArticleImpl.LocatorImpl> {
 
     public LocatorSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/PublicationDateSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/serializer/PublicationDateSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class PublicationDateSerializer extends StdSerializer<PublicationDateImpl> {
 
     public PublicationDateSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcCrossRefJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcCrossRefJsonConfig.java
@@ -2,7 +2,6 @@ package org.uniprot.core.json.parser.uniparc;
 
 import java.time.LocalDate;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.uniprot.core.CrossReference;
 import org.uniprot.core.Database;
 import org.uniprot.core.impl.CrossReferenceImpl;
@@ -19,10 +18,11 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.evidence.impl.EvidenceImpl;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismImpl;
+import org.uniprot.core.util.Pair;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.uniprot.core.util.Pair;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * @author jluo
@@ -69,7 +69,6 @@ public class UniParcCrossRefJsonConfig extends JsonConfig {
         mod.addAbstractTypeMapping(Proteome.class, ProteomeImpl.class);
         mod.addAbstractTypeMapping(Database.class, DefaultDatabase.class);
         mod.addAbstractTypeMapping(Pair.class, UniParcCrossReferencePair.class);
-
 
         objMapper.registerModule(mod);
         return objMapper;

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcEntryLightJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcEntryLightJsonConfig.java
@@ -1,7 +1,7 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.LocalDate;
+
 import org.uniprot.core.CrossReference;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.CrossReferenceImpl;
@@ -16,7 +16,8 @@ import org.uniprot.core.uniprotkb.evidence.impl.EvidenceImpl;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismImpl;
 
-import java.time.LocalDate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class UniParcEntryLightJsonConfig extends JsonConfig {
     private static UniParcEntryLightJsonConfig instance;
@@ -55,7 +56,8 @@ public class UniParcEntryLightJsonConfig extends JsonConfig {
         mod.addAbstractTypeMapping(UniParcEntryLight.class, UniParcEntryLightImpl.class);
         mod.addAbstractTypeMapping(InterProGroup.class, InterProGroupImpl.class);
         mod.addAbstractTypeMapping(SequenceFeature.class, SequenceFeatureImpl.class);
-        mod.addAbstractTypeMapping(SequenceFeatureLocation.class, SequenceFeatureLocationImpl.class);
+        mod.addAbstractTypeMapping(
+                SequenceFeatureLocation.class, SequenceFeatureLocationImpl.class);
         mod.addAbstractTypeMapping(CrossReference.class, CrossReferenceImpl.class);
         mod.addAbstractTypeMapping(Sequence.class, SequenceImpl.class);
         mod.addAbstractTypeMapping(CommonOrganism.class, CommonOrganismImpl.class);

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniparc/UniParcJsonConfig.java
@@ -1,7 +1,7 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.LocalDate;
+
 import org.uniprot.core.CrossReference;
 import org.uniprot.core.Database;
 import org.uniprot.core.Sequence;
@@ -20,7 +20,8 @@ import org.uniprot.core.uniprotkb.evidence.impl.EvidenceImpl;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismImpl;
 
-import java.time.LocalDate;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 /**
  * @author jluo
@@ -63,7 +64,8 @@ public class UniParcJsonConfig extends JsonConfig {
         mod.addAbstractTypeMapping(UniParcEntry.class, UniParcEntryImpl.class);
         mod.addAbstractTypeMapping(InterProGroup.class, InterProGroupImpl.class);
         mod.addAbstractTypeMapping(SequenceFeature.class, SequenceFeatureImpl.class);
-        mod.addAbstractTypeMapping(SequenceFeatureLocation.class, SequenceFeatureLocationImpl.class);
+        mod.addAbstractTypeMapping(
+                SequenceFeatureLocation.class, SequenceFeatureLocationImpl.class);
         mod.addAbstractTypeMapping(Organism.class, OrganismImpl.class);
         mod.addAbstractTypeMapping(Evidence.class, EvidenceImpl.class);
         mod.addAbstractTypeMapping(UniParcCrossReference.class, UniParcCrossReferenceImpl.class);

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/UniprotKBJsonConfig.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/UniprotKBJsonConfig.java
@@ -52,7 +52,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniprotKBJsonConfig extends JsonConfig {
 
     private static UniprotKBJsonConfig INSTANCE;

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/ECNumberSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/ECNumberSerializer.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ECNumberSerializer extends StdSerializer<ECNumberImpl> {
 
     public ECNumberSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FeatureDescriptionSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FeatureDescriptionSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class FeatureDescriptionSerializer extends StdSerializer<FeatureDescriptionImpl> {
 
     public FeatureDescriptionSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FeatureIdSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FeatureIdSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class FeatureIdSerializer extends StdSerializer<FeatureIdImpl> {
 
     public FeatureIdSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FlagSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/FlagSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class FlagSerializer extends StdSerializer<FlagImpl> {
 
     public FlagSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/IsoformIdImplSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/IsoformIdImplSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class IsoformIdImplSerializer extends StdSerializer<APIsoformImpl.IsoformIdImpl> {
 
     public IsoformIdImplSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtDatabaseSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtDatabaseSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtDatabaseSerializer extends StdSerializer<UniProtKBDatabase> {
 
     public UniProtDatabaseSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtIdSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtIdSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtIdSerializer extends StdSerializer<UniProtKBIdImpl> {
 
     public UniProtIdSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtKBAccessionSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/uniprot/serializer/UniProtKBAccessionSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtKBAccessionSerializer extends StdSerializer<UniProtKBAccessionImpl> {
 
     public UniProtKBAccessionSerializer() {

--- a/json-parser/src/main/java/org/uniprot/core/json/parser/unirule/UniRuleIdImplSerializer.java
+++ b/json-parser/src/main/java/org/uniprot/core/json/parser/unirule/UniRuleIdImplSerializer.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
-/** @author sahmad */
+/**
+ * @author sahmad
+ */
 public class UniRuleIdImplSerializer extends StdSerializer<UniRuleIdImpl> {
 
     public UniRuleIdImplSerializer() {

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordEntryTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordEntryTest.java
@@ -13,7 +13,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class KeywordEntryTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordGeneOntologyTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordGeneOntologyTest.java
@@ -6,7 +6,9 @@ import org.uniprot.core.cv.go.impl.GeneOntologyEntryBuilder;
 import org.uniprot.core.cv.go.impl.GoTermBuilder;
 import org.uniprot.core.json.parser.ValidateJson;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class KeywordGeneOntologyTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/keyword/KeywordTest.java
@@ -5,7 +5,9 @@ import org.uniprot.core.cv.keyword.KeywordId;
 import org.uniprot.core.cv.keyword.impl.KeywordIdBuilder;
 import org.uniprot.core.json.parser.ValidateJson;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class KeywordTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureEntryTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureEntryTest.java
@@ -7,7 +7,9 @@ import org.uniprot.core.json.parser.uniprot.citation.LiteratureTest;
 import org.uniprot.core.literature.LiteratureEntry;
 import org.uniprot.core.literature.impl.LiteratureEntryBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class LiteratureEntryTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureMappedReferenceTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureMappedReferenceTest.java
@@ -5,7 +5,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 import org.uniprot.core.literature.LiteratureMappedReference;
 import org.uniprot.core.literature.impl.LiteratureMappedReferenceBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class LiteratureMappedReferenceTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureStatisticsTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/literature/LiteratureStatisticsTest.java
@@ -5,7 +5,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 import org.uniprot.core.literature.LiteratureStatistics;
 import org.uniprot.core.literature.impl.LiteratureStatisticsBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class LiteratureStatisticsTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/proteome/ProteomeTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/proteome/ProteomeTest.java
@@ -172,8 +172,12 @@ public class ProteomeTest {
                         .synonymsAdd("Escherichia coli K-12")
                         .build();
         ProteomeId relatedProteomeId = new ProteomeIdBuilder("UP000005641").build();
-        RelatedProteome relatedProteome = new RelatedProteomeBuilder().proteomeId(relatedProteomeId)
-                .similarity(1F).taxonomy(taxonomy).build();
+        RelatedProteome relatedProteome =
+                new RelatedProteomeBuilder()
+                        .proteomeId(relatedProteomeId)
+                        .similarity(1F)
+                        .taxonomy(taxonomy)
+                        .build();
 
         return new ProteomeEntryBuilder()
                 .proteomeId(proteomeId)

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/publication/MappedPublicationsJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/publication/MappedPublicationsJsonConfigTest.java
@@ -24,7 +24,9 @@ import org.uniprot.core.uniprotkb.impl.UniProtKBAccessionBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/** @author sahmad Created 18/12/2020 */
+/**
+ * @author sahmad Created 18/12/2020
+ */
 class MappedPublicationsJsonConfigTest {
     @Test
     void testSimpleMappedPublications() {
@@ -111,7 +113,7 @@ class MappedPublicationsJsonConfigTest {
                 .proteinOrGene(protOrGene)
                 .function(function)
                 .disease(disease)
-                .submissionDate(LocalDate.of(2024,9,16));
+                .submissionDate(LocalDate.of(2024, 9, 16));
         CommunityMappedReferenceBuilder builder = new CommunityMappedReferenceBuilder();
         builder.communityAnnotation(communityAnnotationBuilder.build());
         builder.uniProtKBAccession(accession).source(mappedSource);

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/taxonomy/TaxonomyInactiveReasonTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/taxonomy/TaxonomyInactiveReasonTest.java
@@ -6,7 +6,9 @@ import org.uniprot.core.taxonomy.TaxonomyInactiveReason;
 import org.uniprot.core.taxonomy.TaxonomyInactiveReasonType;
 import org.uniprot.core.taxonomy.impl.TaxonomyInactiveReasonBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class TaxonomyInactiveReasonTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/SequenceFeatureTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/SequenceFeatureTest.java
@@ -9,9 +9,9 @@ import org.uniprot.core.uniparc.SequenceFeature;
 import org.uniprot.core.uniparc.SignatureDbType;
 import org.uniprot.core.uniparc.impl.InterProGroupBuilder;
 import org.uniprot.core.uniparc.impl.SequenceFeatureBuilder;
+import org.uniprot.core.uniparc.impl.SequenceFeatureLocationBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.uniprot.core.uniparc.impl.SequenceFeatureLocationBuilder;
 
 /**
  * @author jluo
@@ -40,11 +40,31 @@ class SequenceFeatureTest {
         SequenceFeatureBuilder builder = new SequenceFeatureBuilder();
         builder.signatureDbType(SignatureDbType.PFAM)
                 .signatureDbId("PF00626")
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(81, 163).alignment("81M").build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(202, 267).alignment("202M").build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(330, 398).alignment("81M").build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(586, 653).alignment("586M").build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(692, 766).alignment("81M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(81, 163)
+                                .alignment("81M")
+                                .build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(202, 267)
+                                .alignment("202M")
+                                .build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(330, 398)
+                                .alignment("81M")
+                                .build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(586, 653)
+                                .alignment("586M")
+                                .build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(692, 766)
+                                .alignment("81M")
+                                .build())
                 .interproGroup(
                         new InterProGroupBuilder()
                                 .id("IPR007123")

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcCrossRefJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcCrossRefJsonConfigTest.java
@@ -1,6 +1,10 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.uniprot.core.json.parser.uniparc.UniParcEntryTest.getCompleteUniParcEntry;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.json.parser.ValidateJson;
 import org.uniprot.core.uniparc.UniParcCrossReference;
@@ -8,16 +12,16 @@ import org.uniprot.core.uniparc.UniParcEntry;
 import org.uniprot.core.uniparc.impl.UniParcCrossReferencePair;
 import org.uniprot.core.util.Pair;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.uniprot.core.json.parser.uniparc.UniParcEntryTest.getCompleteUniParcEntry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 class UniParcCrossRefJsonConfigTest {
     @Test
     void test() {
         UniParcEntry completeUniParcEntry = getCompleteUniParcEntry();
-        Pair<String, List<UniParcCrossReference>> entry = new UniParcCrossReferencePair(completeUniParcEntry.getUniParcId().getValue(), completeUniParcEntry.getUniParcCrossReferences());
+        Pair<String, List<UniParcCrossReference>> entry =
+                new UniParcCrossReferencePair(
+                        completeUniParcEntry.getUniParcId().getValue(),
+                        completeUniParcEntry.getUniParcCrossReferences());
         ValidateJson.verifyJsonRoundTripParser(
                 UniParcCrossRefJsonConfig.getInstance().getFullObjectMapper(), entry);
         ValidateJson.verifyEmptyFields(entry);

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcDbCrossReferenceTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcDbCrossReferenceTest.java
@@ -1,6 +1,11 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.json.parser.ValidateJson;
@@ -14,11 +19,7 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.fail;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author jluo
@@ -37,7 +38,8 @@ class UniParcDbCrossReferenceTest {
                         .synonymsAdd("syn name")
                         .evidencesSet(evidences)
                         .build();
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("UPI").component("ComponentValue").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("UPI").component("ComponentValue").build();
 
         UniParcCrossReferenceBuilder builder = new UniParcCrossReferenceBuilder();
         builder.database(UniParcDatabase.TREMBL)

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcEntryLightJsonConfigTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcEntryLightJsonConfigTest.java
@@ -1,6 +1,12 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.uniprot.core.json.parser.uniparc.UniParcEntryTest.getSeqFeature;
+import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
+
+import java.time.LocalDate;
+import java.util.*;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
@@ -14,13 +20,7 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.uniprot.core.json.parser.uniparc.UniParcEntryTest.getSeqFeature;
-import static org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder.HAS_ACTIVE_CROSS_REF;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 class UniParcEntryLightJsonConfigTest {
 
@@ -46,36 +46,58 @@ class UniParcEntryLightJsonConfigTest {
 
         int crossReferenceCount = 19;
 
-        List<CommonOrganism> commonTaxons = List.of(
-                new CommonOrganismBuilder().topLevel("cellular organisms").commonTaxon("Homo sapiens").commonTaxonId(1234L).build(),
-                new CommonOrganismBuilder().topLevel("Viruses").commonTaxon("Mus musculus").commonTaxonId(9876l).build()
-        );
+        List<CommonOrganism> commonTaxons =
+                List.of(
+                        new CommonOrganismBuilder()
+                                .topLevel("cellular organisms")
+                                .commonTaxon("Homo sapiens")
+                                .commonTaxonId(1234L)
+                                .build(),
+                        new CommonOrganismBuilder()
+                                .topLevel("Viruses")
+                                .commonTaxon("Mus musculus")
+                                .commonTaxonId(9876l)
+                                .build());
 
-        LinkedHashSet<String> uniProtKBAccessions = new LinkedHashSet<>(List.of("P12345", "Q67890"));
+        LinkedHashSet<String> uniProtKBAccessions =
+                new LinkedHashSet<>(List.of("P12345", "Q67890"));
 
         String sequenceStr = "MVSWGRFICLVVVTMATLSLARPSFSLVED";
         Sequence sequence = new SequenceBuilder(sequenceStr).build();
 
         List<SequenceFeature> sequenceFeatures = new ArrayList<>();
-        Arrays.stream(SignatureDbType.values()).forEach(signatureType -> sequenceFeatures.add(getSeqFeature(signatureType)));
+        Arrays.stream(SignatureDbType.values())
+                .forEach(signatureType -> sequenceFeatures.add(getSeqFeature(signatureType)));
 
         LocalDate oldestCrossRefCreated = LocalDate.of(2020, 1, 1);
         LocalDate mostRecentCrossRefUpdated = LocalDate.of(2023, 6, 19);
 
         List<Evidence> evidences = CreateUtils.createEvidenceList("ECO:0000269|PubMed:11389730");
-        Organism organism = new OrganismBuilder()
-                .taxonId(123L)
-                .scientificName("ScientificName")
-                .lineagesAdd("Lineage 1")
-                .commonName("common Name")
-                .synonymsAdd("syn name")
-                .evidencesSet(evidences)
-                .build();
+        Organism organism =
+                new OrganismBuilder()
+                        .taxonId(123L)
+                        .scientificName("ScientificName")
+                        .lineagesAdd("Lineage 1")
+                        .commonName("common Name")
+                        .synonymsAdd("syn name")
+                        .evidencesSet(evidences)
+                        .build();
 
         LinkedHashSet<Organism> organisms = new LinkedHashSet<>(List.of(organism));
-        LinkedHashSet<String> proteinNames = new LinkedHashSet<>(List.of("Protein Alpha", "Protein Beta"));
+        LinkedHashSet<String> proteinNames =
+                new LinkedHashSet<>(List.of("Protein Alpha", "Protein Beta"));
         LinkedHashSet<String> geneNames = new LinkedHashSet<>(List.of("Gene1", "Gene2"));
-        LinkedHashSet<Proteome> proteomes = new LinkedHashSet<>(List.of(new ProteomeBuilder().id("UP000005640").component("Chromosome 1").build(), new ProteomeBuilder().id("UP000000589").component("Chromosome 2").build()));
+        LinkedHashSet<Proteome> proteomes =
+                new LinkedHashSet<>(
+                        List.of(
+                                new ProteomeBuilder()
+                                        .id("UP000005640")
+                                        .component("Chromosome 1")
+                                        .build(),
+                                new ProteomeBuilder()
+                                        .id("UP000000589")
+                                        .component("Chromosome 2")
+                                        .build()));
 
         // Use the builder to create a complete UniParcEntryLight
         return new UniParcEntryLightBuilder()

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcEntryTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniparc/UniParcEntryTest.java
@@ -1,6 +1,12 @@
 package org.uniprot.core.json.parser.uniparc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Property;
 import org.uniprot.core.Sequence;
@@ -13,12 +19,7 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.fail;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author jluo
@@ -69,7 +70,8 @@ public class UniParcEntryTest {
                         .synonymsAdd("syn name")
                         .evidencesSet(evidences)
                         .build();
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("UPI").component( "ComponentValue").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("UPI").component("ComponentValue").build();
         builder.uniParcId("UPI0000083A08")
                 .sequence(uniSeq)
                 .sequenceFeaturesSet(sfs)
@@ -118,7 +120,11 @@ public class UniParcEntryTest {
         return new SequenceFeatureBuilder()
                 .signatureDbType(signatureType)
                 .signatureDbId("id-" + signatureType)
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(81, 163).alignment("48M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(81, 163)
+                                .alignment("48M")
+                                .build())
                 .interproGroup(
                         new InterProGroupBuilder()
                                 .id("IPR007123")

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/CreateUtils.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/CreateUtils.java
@@ -9,7 +9,9 @@ import org.uniprot.core.uniprotkb.evidence.EvidencedValue;
 import org.uniprot.core.uniprotkb.evidence.impl.EvidenceBuilder;
 import org.uniprot.core.uniprotkb.evidence.impl.EvidencedValueBuilder;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class CreateUtils {
 
     public static List<Evidence> createEvidenceList(String evidenceStr) {

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/EntryAuditTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/EntryAuditTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.uniprotkb.impl.EntryAuditBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class EntryAuditTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/FeatureTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/FeatureTest.java
@@ -25,7 +25,9 @@ import org.uniprot.core.uniprotkb.feature.impl.UniProtKBFeatureBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class FeatureTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/GeneLocationTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/GeneLocationTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.uniprotkb.impl.GeneLocationBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class GeneLocationTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/GeneTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/GeneTest.java
@@ -13,7 +13,9 @@ import org.uniprot.core.uniprotkb.impl.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class GeneTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/InternalSectionTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/InternalSectionTest.java
@@ -19,7 +19,9 @@ import org.uniprot.core.uniprotkb.impl.SourceLineBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class InternalSectionTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/KeywordTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/KeywordTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.uniprotkb.impl.KeywordBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class KeywordTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/OrganimsTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/OrganimsTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class OrganimsTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/ProteinDescriptionTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/ProteinDescriptionTest.java
@@ -13,7 +13,9 @@ import org.uniprot.core.uniprotkb.description.impl.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ProteinDescriptionTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/SequenceTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/SequenceTest.java
@@ -10,7 +10,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class SequenceTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBAccessionTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBAccessionTest.java
@@ -9,7 +9,9 @@ import org.uniprot.core.uniprotkb.impl.UniProtKBAccessionBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtKBAccessionTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBCrossReferenceTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBCrossReferenceTest.java
@@ -13,7 +13,9 @@ import org.uniprot.cv.xdb.UniProtKBDatabaseImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtKBCrossReferenceTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBEntryIT.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBEntryIT.java
@@ -31,7 +31,9 @@ import org.uniprot.cv.xdb.UniProtDatabaseTypes;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtKBEntryIT {
 
     private static final Logger logger = LoggerFactory.getLogger(UniProtKBEntryIT.class);

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBIdTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBIdTest.java
@@ -9,7 +9,9 @@ import org.uniprot.core.uniprotkb.impl.UniProtKBIdBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class UniProtKBIdTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBReferenceTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniProtKBReferenceTest.java
@@ -19,7 +19,9 @@ import org.uniprot.core.uniprotkb.impl.UniProtKBReferenceBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UniProtKBReferenceTest {
 
     @Test
@@ -61,7 +63,8 @@ public class UniProtKBReferenceTest {
     public static List<UniProtKBReference> getUniProtReferences() {
         List<UniProtKBReference> uniProtKBReferences = new ArrayList<>();
         uniProtKBReferences.add(getUniProtReference(1, BookTest.getBook()));
-        uniProtKBReferences.add(getUniProtReference(2, ElectronicArticleTest.getElectronicArticle()));
+        uniProtKBReferences.add(
+                getUniProtReference(2, ElectronicArticleTest.getElectronicArticle()));
         uniProtKBReferences.add(getUniProtReference(3, JournalArticleTest.getJournalArticle()));
         uniProtKBReferences.add(getUniProtReference(4, PatentTest.getPatent()));
         uniProtKBReferences.add(getUniProtReference(5, SubmissionTest.getSubmission()));

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniprotKBEntryEnumTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/UniprotKBEntryEnumTest.java
@@ -9,7 +9,9 @@ import org.uniprot.core.uniprotkb.UniProtKBEntryType;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class UniprotKBEntryEnumTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/BookTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/BookTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class BookTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/CitationUtil.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/CitationUtil.java
@@ -14,7 +14,9 @@ import org.uniprot.core.impl.CrossReferenceBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 class CitationUtil {
 
     static void validateCitation(JsonNode jsonNode) {

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/ElectronicArticleTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/ElectronicArticleTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ElectronicArticleTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/JournalArticleTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/JournalArticleTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class JournalArticleTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/PatentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/PatentTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class PatentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/SubmissionTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/SubmissionTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class SubmissionTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/ThesisTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/ThesisTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class ThesisTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/UnpublishedTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/citation/UnpublishedTest.java
@@ -11,7 +11,9 @@ import org.uniprot.core.json.parser.ValidateJson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class UnpublishedTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/AlternativeProductsCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/AlternativeProductsCommentTest.java
@@ -20,7 +20,9 @@ import org.uniprot.core.uniprotkb.evidence.impl.EvidencedValueBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class AlternativeProductsCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/BPCPCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/BPCPCommentTest.java
@@ -14,7 +14,9 @@ import org.uniprot.core.uniprotkb.evidence.EvidencedValue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class BPCPCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/CatalyticActivityCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/CatalyticActivityCommentTest.java
@@ -20,7 +20,9 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class CatalyticActivityCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/CofactorCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/CofactorCommentTest.java
@@ -23,7 +23,9 @@ import org.uniprot.core.uniprotkb.evidence.EvidencedValue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class CofactorCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/DiseaseCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/DiseaseCommentTest.java
@@ -18,7 +18,9 @@ import org.uniprot.core.uniprotkb.comment.impl.NoteBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class DiseaseCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/FreeTextCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/FreeTextCommentTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.uniprotkb.comment.impl.FreeTextCommentBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class FreeTextCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/InteractionCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/InteractionCommentTest.java
@@ -18,7 +18,9 @@ import org.uniprot.core.uniprotkb.comment.impl.InteractionCommentBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class InteractionCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/MassSpectrometryCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/MassSpectrometryCommentTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.uniprotkb.comment.impl.MassSpectrometryCommentBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class MassSpectrometryCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/RnaEditingCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/RnaEditingCommentTest.java
@@ -16,7 +16,9 @@ import org.uniprot.core.uniprotkb.comment.impl.RnaEditingPositionBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class RnaEditingCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/SequenceCautionCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/SequenceCautionCommentTest.java
@@ -12,7 +12,9 @@ import org.uniprot.core.uniprotkb.comment.impl.SequenceCautionCommentBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class SequenceCautionCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/SubcellularLocationCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/SubcellularLocationCommentTest.java
@@ -20,7 +20,9 @@ import org.uniprot.core.uniprotkb.evidence.Evidence;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class SubcellularLocationCommentTest {
 
     @Test

--- a/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/WebResourceCommentTest.java
+++ b/json-parser/src/test/java/org/uniprot/core/json/parser/uniprot/comment/WebResourceCommentTest.java
@@ -9,7 +9,9 @@ import org.uniprot.core.uniprotkb.comment.impl.WebResourceCommentBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-/** @author lgonzales */
+/**
+ * @author lgonzales
+ */
 public class WebResourceCommentTest {
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,15 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<distributionManagement>
 		<repository>
 			<id>uniprot-artifactory-deploy-release</id>

--- a/xml-parser/src/main/java/org/uniprot/core/xml/CrossReferenceConverterUtils.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/CrossReferenceConverterUtils.java
@@ -1,6 +1,7 @@
 package org.uniprot.core.xml;
 
-import com.google.common.base.Strings;
+import java.util.Optional;
+
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.impl.ProteomeBuilder;
@@ -10,7 +11,7 @@ import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.cv.taxonomy.TaxonomicNode;
 import org.uniprot.cv.taxonomy.TaxonomyRepo;
 
-import java.util.Optional;
+import com.google.common.base.Strings;
 
 public class CrossReferenceConverterUtils {
     public static final String PROPERTY_GENE_NAME = "gene_name";
@@ -22,9 +23,13 @@ public class CrossReferenceConverterUtils {
     public static final String PROPERTY_UNIPROTKB_ACCESSION = "UniProtKB_accession";
     public static final String PROPERTY_SOURCES = UniParcCrossReference.PROPERTY_SOURCES;
 
-    private CrossReferenceConverterUtils(){}
+    private CrossReferenceConverterUtils() {}
 
-    public static void populateUniParcCrossReferenceBuilder(String propertyType, String propertyValue, UniParcCrossReferenceBuilder builder, TaxonomyRepo taxonomyRepo) {
+    public static void populateUniParcCrossReferenceBuilder(
+            String propertyType,
+            String propertyValue,
+            UniParcCrossReferenceBuilder builder,
+            TaxonomyRepo taxonomyRepo) {
         switch (propertyType) {
             case PROPERTY_GENE_NAME:
                 builder.geneName(propertyValue);
@@ -42,7 +47,8 @@ public class CrossReferenceConverterUtils {
                 builder.proteomesAdd(getProteomeIdComponent(propertyValue));
                 break;
             case PROPERTY_NCBI_TAXONOMY_ID:
-                builder.organism(CrossReferenceConverterUtils.convertTaxonomy(propertyValue, taxonomyRepo));
+                builder.organism(
+                        CrossReferenceConverterUtils.convertTaxonomy(propertyValue, taxonomyRepo));
                 break;
             case PROPERTY_UNIPROTKB_ACCESSION:
                 builder.propertiesAdd(PROPERTY_UNIPROTKB_ACCESSION, propertyValue);
@@ -52,10 +58,7 @@ public class CrossReferenceConverterUtils {
                 break;
             default:
                 throw new XmlReaderException(
-                        "Unable to read xml property: "
-                                + propertyType
-                                + "value: "
-                                + propertyValue);
+                        "Unable to read xml property: " + propertyType + "value: " + propertyValue);
         }
     }
 
@@ -76,7 +79,8 @@ public class CrossReferenceConverterUtils {
         return builder.build();
     }
 
-    private static Optional<TaxonomicNode> getTaxonomyNode(String taxId, TaxonomyRepo taxonomyRepo) {
+    private static Optional<TaxonomicNode> getTaxonomyNode(
+            String taxId, TaxonomyRepo taxonomyRepo) {
         if (taxonomyRepo == null) {
             return Optional.empty();
         } else return taxonomyRepo.retrieveNodeUsingTaxID(Integer.parseInt(taxId));
@@ -87,6 +91,9 @@ public class CrossReferenceConverterUtils {
         if (proteomeIdComponentValues.length < 2) {
             throw new XmlReaderException("Unable to parse proteomeId component: " + propertyValue);
         }
-        return new ProteomeBuilder().id(proteomeIdComponentValues[0]).component(proteomeIdComponentValues[1]).build();
+        return new ProteomeBuilder()
+                .id(proteomeIdComponentValues[0])
+                .component(proteomeIdComponentValues[1])
+                .build();
     }
 }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/dbreference/UniParcCrossReferenceConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/dbreference/UniParcCrossReferenceConverter.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.xml.dbreference;
 
+import static org.uniprot.core.xml.CrossReferenceConverterUtils.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
@@ -12,11 +17,6 @@ import org.uniprot.core.xml.jaxb.dbreference.ObjectFactory;
 import org.uniprot.core.xml.jaxb.dbreference.PropertyType;
 import org.uniprot.core.xml.uniprot.XmlConverterHelper;
 import org.uniprot.cv.taxonomy.TaxonomyRepo;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.uniprot.core.xml.CrossReferenceConverterUtils.*;
 
 public class UniParcCrossReferenceConverter
         implements Converter<DbReference, UniParcCrossReference> {
@@ -43,7 +43,8 @@ public class UniParcCrossReferenceConverter
                 .lastUpdated(XmlConverterHelper.dateFromXml(xmlObj.getLast()));
 
         for (PropertyType property : xmlObj.getProperty()) {
-            CrossReferenceConverterUtils.populateUniParcCrossReferenceBuilder(property.getType(), property.getValue(), builder, taxonomyRepo);
+            CrossReferenceConverterUtils.populateUniParcCrossReferenceBuilder(
+                    property.getType(), property.getValue(), builder, taxonomyRepo);
         }
         if (xmlObj.getVersion() != null) builder.version(xmlObj.getVersion());
         return builder.build();
@@ -77,7 +78,6 @@ public class UniParcCrossReferenceConverter
             for (Proteome proteomeIdComponent : uniObj.getProteomes()) {
                 properties.add(createProperty(PROPERTY_PROTEOMEID_COMPONENT, proteomeIdComponent));
             }
-
         }
 
         if (Utils.notNull(uniObj.getOrganism())) {

--- a/xml-parser/src/main/java/org/uniprot/core/xml/proteome/ProteomeConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/proteome/ProteomeConverter.java
@@ -65,11 +65,12 @@ public class ProteomeConverter implements Converter<Proteome, ProteomeEntry> {
         Integer proteinCount = xmlObj.getProteinCount();
         List<RelatedProteome> reladedProteomes = new ArrayList<>();
 
-        if(xmlObj.getRelatedTo() != null) {
-            reladedProteomes = xmlObj.getRelatedTo().getRelatedReferenceProteome().stream()
-                    .map(relatedReferenceProteomeConverter::fromXml).toList();
+        if (xmlObj.getRelatedTo() != null) {
+            reladedProteomes =
+                    xmlObj.getRelatedTo().getRelatedReferenceProteome().stream()
+                            .map(relatedReferenceProteomeConverter::fromXml)
+                            .toList();
         }
-
 
         builder.proteomeId(proteomeId(xmlObj.getUpid()))
                 .proteomeType(getProteomeType(xmlObj.getProteomeStatus()))
@@ -171,21 +172,21 @@ public class ProteomeConverter implements Converter<Proteome, ProteomeEntry> {
             convertExclusionReasons(uniObj, xmlObj);
         }
 
-        if(notNull(uniObj.getPanproteomeTaxon())){
+        if (notNull(uniObj.getPanproteomeTaxon())) {
             xmlObj.setPanproteomeTaxon(uniObj.getPanproteomeTaxon().getTaxonId());
-
         }
 
-        if(notNullNotEmpty(uniObj.getRelatedProteomes())){
+        if (notNullNotEmpty(uniObj.getRelatedProteomes())) {
             convertRelatedProteomes(uniObj, xmlObj);
         }
         return xmlObj;
     }
 
     private void convertRelatedProteomes(ProteomeEntry uniObj, Proteome xmlObj) {
-        List<RelatedReferenceProteome> rrps = uniObj.getRelatedProteomes().stream()
-                .map(relatedReferenceProteomeConverter::toXml)
-                .toList();
+        List<RelatedReferenceProteome> rrps =
+                uniObj.getRelatedProteomes().stream()
+                        .map(relatedReferenceProteomeConverter::toXml)
+                        .toList();
         RelatedToType relatedToType = xmlFactory.createRelatedToType();
         relatedToType.getRelatedReferenceProteome().addAll(rrps);
         xmlObj.setRelatedTo(relatedToType);

--- a/xml-parser/src/main/java/org/uniprot/core/xml/proteome/RelatedReferenceProteomeConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/proteome/RelatedReferenceProteomeConverter.java
@@ -9,7 +9,8 @@ import org.uniprot.core.xml.Converter;
 import org.uniprot.core.xml.jaxb.proteome.ObjectFactory;
 import org.uniprot.core.xml.jaxb.proteome.RelatedReferenceProteome;
 
-public class RelatedReferenceProteomeConverter implements Converter<RelatedReferenceProteome, RelatedProteome> {
+public class RelatedReferenceProteomeConverter
+        implements Converter<RelatedReferenceProteome, RelatedProteome> {
 
     private ObjectFactory objectFactory;
 
@@ -20,6 +21,7 @@ public class RelatedReferenceProteomeConverter implements Converter<RelatedRefer
     public RelatedReferenceProteomeConverter(ObjectFactory objectFactory) {
         this.objectFactory = objectFactory;
     }
+
     @Override
     public RelatedProteome fromXml(RelatedReferenceProteome xmlObj) {
         RelatedProteomeBuilder builder = new RelatedProteomeBuilder();

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/SequenceFeatureConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/SequenceFeatureConverter.java
@@ -37,13 +37,13 @@ public class SequenceFeatureConverter implements Converter<SeqFeatureType, Seque
     @Override
     public SequenceFeature fromXml(SeqFeatureType xmlObj) {
         SequenceFeatureBuilder builder = new SequenceFeatureBuilder();
-                builder.signatureDbType(SignatureDbType.typeOf(xmlObj.getDatabase()))
+        builder.signatureDbType(SignatureDbType.typeOf(xmlObj.getDatabase()))
                 .signatureDbId(xmlObj.getId())
                 .locationsSet(
                         xmlObj.getLcn().stream()
                                 .map(locationConverter::fromXml)
                                 .collect(Collectors.toList()));
-        if(xmlObj.getIpr() != null){
+        if (xmlObj.getIpr() != null) {
             builder.interproGroup(interproGroupConverter.fromXml(xmlObj.getIpr()));
         }
 
@@ -55,7 +55,7 @@ public class SequenceFeatureConverter implements Converter<SeqFeatureType, Seque
         SeqFeatureType xmlObj = xmlFactory.createSeqFeatureType();
         xmlObj.setDatabase(uniObj.getSignatureDbType().getDisplayName());
         xmlObj.setId(uniObj.getSignatureDbId());
-        if(uniObj.getInterProDomain() != null) {
+        if (uniObj.getInterProDomain() != null) {
             xmlObj.setIpr(interproGroupConverter.toXml(uniObj.getInterProDomain()));
         }
 

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/UniParcDBCrossReferenceConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/UniParcDBCrossReferenceConverter.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.xml.uniparc;
 
+import static org.uniprot.core.xml.CrossReferenceConverterUtils.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.uniprot.core.uniparc.Proteome;
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
@@ -12,11 +17,6 @@ import org.uniprot.core.xml.jaxb.uniparc.ObjectFactory;
 import org.uniprot.core.xml.jaxb.uniparc.PropertyType;
 import org.uniprot.core.xml.uniprot.XmlConverterHelper;
 import org.uniprot.cv.taxonomy.TaxonomyRepo;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.uniprot.core.xml.CrossReferenceConverterUtils.*;
 
 /**
  * @author jluo
@@ -47,7 +47,8 @@ public class UniParcDBCrossReferenceConverter
                 .lastUpdated(XmlConverterHelper.dateFromXml(xmlObj.getLast()));
 
         for (PropertyType property : xmlObj.getProperty()) {
-            CrossReferenceConverterUtils.populateUniParcCrossReferenceBuilder(property.getType(), property.getValue(), builder, taxonomyRepo);
+            CrossReferenceConverterUtils.populateUniParcCrossReferenceBuilder(
+                    property.getType(), property.getValue(), builder, taxonomyRepo);
         }
         if (xmlObj.getVersion() != null) builder.version(xmlObj.getVersion());
         return builder.build();
@@ -81,7 +82,6 @@ public class UniParcDBCrossReferenceConverter
             for (Proteome proteomeIdComponent : uniObj.getProteomes()) {
                 properties.add(createProperty(PROPERTY_PROTEOMEID_COMPONENT, proteomeIdComponent));
             }
-
         }
 
         if (Utils.notNull(uniObj.getOrganism())) {
@@ -98,7 +98,6 @@ public class UniParcDBCrossReferenceConverter
 
         return xmlObj;
     }
-
 
     private PropertyType createProperty(String key, String value) {
         PropertyType xmlObj = xmlFactory.createPropertyType();

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/UniParcEntryLightConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniparc/UniParcEntryLightConverter.java
@@ -12,7 +12,7 @@ public class UniParcEntryLightConverter implements Converter<Entry, UniParcEntry
     private final SequenceFeatureConverter seqFeatureConverter;
     private final SequenceConverter sequenceConverter;
 
-    public UniParcEntryLightConverter(){
+    public UniParcEntryLightConverter() {
         this(new ObjectFactory());
     }
 

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/EvidenceConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/EvidenceConverter.java
@@ -33,7 +33,10 @@ public class EvidenceConverter implements Converter<EvidenceType, Evidence> {
         EvidenceBuilder evidenceBuilder = new EvidenceBuilder().evidenceCode(evCode);
         if (xmlObj.getSource() != null) {
             CrossReference<EvidenceDatabase> xref = xrefConverter.fromXml(xmlObj.getSource());
-            evidenceBuilder.databaseId(xref.getId()).databaseName(xref.getDatabase().getName()).crossReference(xref);
+            evidenceBuilder
+                    .databaseId(xref.getId())
+                    .databaseName(xref.getDatabase().getName())
+                    .crossReference(xref);
         }
 
         return evidenceBuilder.build();
@@ -68,10 +71,14 @@ public class EvidenceConverter implements Converter<EvidenceType, Evidence> {
         @Override
         public CrossReference<EvidenceDatabase> fromXml(SourceType xmlObj) {
             if (xmlObj.getDbReference() != null) {
-                List<Property> properties = xmlObj.getDbReference().getProperty()
-                        .stream()
-                        .map(propertyType -> new Property(propertyType.getType(), propertyType.getValue()))
-                        .toList();
+                List<Property> properties =
+                        xmlObj.getDbReference().getProperty().stream()
+                                .map(
+                                        propertyType ->
+                                                new Property(
+                                                        propertyType.getType(),
+                                                        propertyType.getValue()))
+                                .toList();
                 return new CrossReferenceBuilder<EvidenceDatabase>()
                         .database(new EvidenceDatabase(xmlObj.getDbReference().getType()))
                         .id(xmlObj.getDbReference().getId())
@@ -98,7 +105,7 @@ public class EvidenceConverter implements Converter<EvidenceType, Evidence> {
                 DbReferenceType dbRef = xmlUniprotFactory.createDbReferenceType();
                 dbRef.setType(uniObj.getDatabase().getName());
                 dbRef.setId(uniObj.getId());
-                if(uniObj.getProperties() != null && !uniObj.getProperties().isEmpty()) {
+                if (uniObj.getProperties() != null && !uniObj.getProperties().isEmpty()) {
                     List<Property> properties = uniObj.getProperties();
                     for (Property property : properties) {
                         PropertyType propertyType = xmlUniprotFactory.createPropertyType();

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/GoogleUniProtEntryConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/GoogleUniProtEntryConverter.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.xml.uniprot;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.uniprot.core.uniprotkb.UniProtKBEntry;
 import org.uniprot.core.uniprotkb.description.ProteinDescription;
 import org.uniprot.core.uniprotkb.evidence.Evidence;
@@ -7,30 +12,23 @@ import org.uniprot.core.uniprotkb.impl.UniProtKBEntryBuilder;
 import org.uniprot.core.xml.jaxb.uniprot.DbReferenceType;
 import org.uniprot.core.xml.jaxb.uniprot.Entry;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-
 public class GoogleUniProtEntryConverter extends UniProtEntryConverter {
     private static final Set<String> EXCLUDED_XREF_TYPES = Set.of("EC", "Pfam");
-
 
     public GoogleUniProtEntryConverter() {
         super();
     }
 
     /*
-    Predicted values by ProtNLM2:
-    1. Protein name
-    2. EC
-    3. comment - Function
-    4. comment - Catalytic activity/Rhea
-    5. comment - Subcellular location
-    6. Keywords
-    7. GO
- */
+       Predicted values by ProtNLM2:
+       1. Protein name
+       2. EC
+       3. comment - Function
+       4. comment - Catalytic activity/Rhea
+       5. comment - Subcellular location
+       6. Keywords
+       7. GO
+    */
     @Override
     public UniProtKBEntry fromXml(Entry xmlEntry) {
         Map<Evidence, Integer> evidenceIdMap = fromXmlForEvidences(xmlEntry);
@@ -39,9 +37,7 @@ public class GoogleUniProtEntryConverter extends UniProtEntryConverter {
         ProteinDescription proteinDescription = fromXml(xmlEntry.getProtein());
         activeEntryBuilder.proteinDescription(fromXml(proteinDescription, xmlEntry.getSequence()));
         activeEntryBuilder.referencesSet(
-                xmlEntry.getReference().stream()
-                        .map(this::fromXml)
-                        .collect(Collectors.toList()));
+                xmlEntry.getReference().stream().map(this::fromXml).collect(Collectors.toList()));
         activeEntryBuilder.commentsSet(fromXmlForComments(xmlEntry));
         activeEntryBuilder.uniProtCrossReferencesSet(
                 xmlEntry.getDbReference().stream()
@@ -50,9 +46,7 @@ public class GoogleUniProtEntryConverter extends UniProtEntryConverter {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList()));
         activeEntryBuilder.keywordsSet(
-                xmlEntry.getKeyword().stream()
-                        .map(this::fromXml)
-                        .collect(Collectors.toList()));
+                xmlEntry.getKeyword().stream().map(this::fromXml).collect(Collectors.toList()));
         return activeEntryBuilder.build();
     }
 

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/UniProtCrossReferenceConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/UniProtCrossReferenceConverter.java
@@ -30,7 +30,8 @@ public class UniProtCrossReferenceConverter
         this(evRefMapper, new ObjectFactory());
     }
 
-    public UniProtCrossReferenceConverter(EvidenceIndexMapper evRefMapper, ObjectFactory xmlUniprotFactory) {
+    public UniProtCrossReferenceConverter(
+            EvidenceIndexMapper evRefMapper, ObjectFactory xmlUniprotFactory) {
         this.xmlUniprotFactory = xmlUniprotFactory;
         this.evRefMapper = evRefMapper;
     }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/UniProtEntryConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/UniProtEntryConverter.java
@@ -142,11 +142,11 @@ public class UniProtEntryConverter implements Converter<Entry, UniProtKBEntry> {
         evRefMapper.reset(evidenceIdMap);
     }
 
-    protected ProteinDescription fromXml(ProteinType proteinType){
+    protected ProteinDescription fromXml(ProteinType proteinType) {
         return descriptionConverter.fromXml(proteinType);
     }
 
-    ProteinDescription fromXml(ProteinDescription modelObject, SequenceType xmlObject){
+    ProteinDescription fromXml(ProteinDescription modelObject, SequenceType xmlObject) {
         return flagUpdater.fromXml(modelObject, xmlObject);
     }
 

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMap.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMap.java
@@ -12,5 +12,6 @@ import java.io.Serializable;
 public interface SubcellLocationNameMap extends Serializable {
 
     String getLocationName(String name);
+
     String getName(String name);
 }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMapImpl.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellLocationNameMapImpl.java
@@ -70,12 +70,13 @@ public class SubcellLocationNameMapImpl implements SubcellLocationNameMap {
     private String getLowercaseContent(SubcellularLocationEntry entry) {
         return entry.getContent().toLowerCase();
     }
+
     private String getLowercaseName(SubcellularLocationEntry entry) {
         return entry.getName().toLowerCase();
     }
 
-	@Override
-	public String getName(String name) {
-		return subcellularLocationNameMap.get(name.toLowerCase());
-	}
+    @Override
+    public String getName(String name) {
+        return subcellularLocationNameMap.get(name.toLowerCase());
+    }
 }

--- a/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
+++ b/xml-parser/src/main/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverter.java
@@ -148,15 +148,14 @@ public class SubcellularLocationConverter
         return typeLocation;
     }
 
-    
     private String capitalizeFirstLetter(String value) {
-        if(Character.isUpperCase(value.charAt(0))) {
+        if (Character.isUpperCase(value.charAt(0))) {
             return value;
         }
-        String loc = subcellLocationNameMap.getName(value); 
-        return loc==null?Utils.upperFirstChar(value):loc;      
+        String loc = subcellLocationNameMap.getName(value);
+        return loc == null ? Utils.upperFirstChar(value) : loc;
     }
-    
+
     private EvidencedStringType buildLocation(SubcellularLocationValue locationValue) {
         if ((locationValue != null) && (!locationValue.getValue().isEmpty())) {
             return buildLocation(locationValue.getValue(), locationValue);

--- a/xml-parser/src/main/resources/xsd/proteome.xsd
+++ b/xml-parser/src/main/resources/xsd/proteome.xsd
@@ -25,9 +25,11 @@
 				<xs:element name="taxonomy" type="xs:long" />
 				<xs:element name="modified" type="xs:date" />
 				<xs:element name="proteomeStatus" type="xs:string" />
-				<xs:element name="panproteomeTaxon" type="xs:long" minOccurs="0"/>
+				<xs:element name="panproteomeTaxon" type="xs:long"
+					minOccurs="0" />
 				<xs:element name="strain" type="xs:string" minOccurs="0" />
-				<xs:element name="relatedTo" type="relatedToType" minOccurs="0"/>
+				<xs:element name="relatedTo" type="relatedToType"
+					minOccurs="0" />
 				<xs:element name="isolate" type="xs:string" minOccurs="0" />
 				<xs:element name="genomeAssembly"
 					type="genomeAssemblyType" minOccurs="0" />
@@ -76,9 +78,7 @@
 	<xs:complexType name="relatedToType">
 		<xs:sequence>
 			<xs:element name="relatedReferenceProteome"
-						type="relatedReferenceProteome"
-						minOccurs="0"
-						maxOccurs="unbounded"/>
+				type="relatedReferenceProteome" minOccurs="0" maxOccurs="unbounded" />
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="relatedReferenceProteome">
@@ -87,9 +87,10 @@
 				Describes related proteome
 			</xs:documentation>
 		</xs:annotation>
-		<xs:attribute name="upid" type="xs:string" use="required"/>
-		<xs:attribute name="similarity" type="xs:string" use="required"/>
-		<xs:attribute name="taxon" type="xs:long" use="required"/>
+		<xs:attribute name="upid" type="xs:string" use="required" />
+		<xs:attribute name="similarity" type="xs:string"
+			use="required" />
+		<xs:attribute name="taxon" type="xs:long" use="required" />
 	</xs:complexType>
 
 	<xs:complexType name="componentType">

--- a/xml-parser/src/main/resources/xsd/uniparc-dbreference.xsd
+++ b/xml-parser/src/main/resources/xsd/uniparc-dbreference.xsd
@@ -1,39 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           elementFormDefault="qualified"
-           targetNamespace="http://uniprot.org/dbReference"
-           xmlns="http://uniprot.org/dbReference">
-    <xs:element name="dbReferences">
-        <xs:complexType>
-            <xs:annotation>
-                <xs:documentation>Describes a collection of dbReference entries.</xs:documentation>
-            </xs:annotation>
-            <xs:sequence>
-                <xs:element ref="dbReference" minOccurs="0" maxOccurs="unbounded" />
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="dbReference">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="property" type="propertyType"
-                            minOccurs="0" maxOccurs="unbounded" />
-            </xs:sequence>
-            <xs:attribute name="type" type="xs:string" use="required" />
-            <xs:attribute name="id" type="xs:string" use="required" />
-            <xs:attribute name="version_i" type="xs:int"
-                          use="required" />
-            <xs:attribute name="active" type="xs:string"
-                          use="required" />
-            <xs:attribute name="version" type="xs:int" />
-            <xs:attribute name="created" type="xs:date" />
-            <xs:attribute name="last" type="xs:date" />
-        </xs:complexType>
-    </xs:element>
+	elementFormDefault="qualified"
+	targetNamespace="http://uniprot.org/dbReference"
+	xmlns="http://uniprot.org/dbReference">
+	<xs:element name="dbReferences">
+		<xs:complexType>
+			<xs:annotation>
+				<xs:documentation>Describes a collection of dbReference entries.</xs:documentation>
+			</xs:annotation>
+			<xs:sequence>
+				<xs:element ref="dbReference" minOccurs="0"
+					maxOccurs="unbounded" />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="dbReference">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="property" type="propertyType"
+					minOccurs="0" maxOccurs="unbounded" />
+			</xs:sequence>
+			<xs:attribute name="type" type="xs:string"
+				use="required" />
+			<xs:attribute name="id" type="xs:string" use="required" />
+			<xs:attribute name="version_i" type="xs:int"
+				use="required" />
+			<xs:attribute name="active" type="xs:string"
+				use="required" />
+			<xs:attribute name="version" type="xs:int" />
+			<xs:attribute name="created" type="xs:date" />
+			<xs:attribute name="last" type="xs:date" />
+		</xs:complexType>
+	</xs:element>
 
-    <xs:complexType name="propertyType">
-        <xs:attribute name="type" type="xs:string" use="required" />
-        <xs:attribute name="value" type="xs:string"
-                      use="required" />
-    </xs:complexType>
+	<xs:complexType name="propertyType">
+		<xs:attribute name="type" type="xs:string" use="required" />
+		<xs:attribute name="value" type="xs:string"
+			use="required" />
+	</xs:complexType>
 </xs:schema>

--- a/xml-parser/src/main/resources/xsd/uniparc.xsd
+++ b/xml-parser/src/main/resources/xsd/uniparc.xsd
@@ -82,7 +82,8 @@
 	<xs:complexType name="locationType">
 		<xs:attribute name="start" type="xs:int" use="required" />
 		<xs:attribute name="end" type="xs:int" use="required" />
-		<xs:attribute name="alignment" type="xs:string" use="optional"/>
+		<xs:attribute name="alignment" type="xs:string"
+			use="optional" />
 	</xs:complexType>
 
 

--- a/xml-parser/src/test/java/org/uniprot/core/xml/dbreference/UniParcCrossReferenceConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/dbreference/UniParcCrossReferenceConverterTest.java
@@ -1,8 +1,12 @@
 package org.uniprot.core.xml.dbreference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.uniprot.core.xml.CrossReferenceConverterUtils.PROPERTY_UNIPROTKB_ACCESSION;
+
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.Proteome;
-
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniparc.impl.ProteomeBuilder;
@@ -11,18 +15,13 @@ import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.xml.jaxb.dbreference.DbReference;
 
-import java.time.LocalDate;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.uniprot.core.xml.CrossReferenceConverterUtils.PROPERTY_UNIPROTKB_ACCESSION;
-
-
 class UniParcCrossReferenceConverterTest {
     @Test
     void testComplete() {
         Organism taxonomy = new OrganismBuilder().taxonId(7227).build();
         UniParcCrossReferenceBuilder builder = new UniParcCrossReferenceBuilder();
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("proteomeValue").component("ComponentValue").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("proteomeValue").component("ComponentValue").build();
         builder.database(UniParcDatabase.TREMBL)
                 .id("A0A0C4DHG2-PB")
                 .versionI(1)
@@ -43,6 +42,5 @@ class UniParcCrossReferenceConverterTest {
         DbReference xmlObj = converter.toXml(xref);
         UniParcCrossReference converted = converter.fromXml(xmlObj);
         assertEquals(xref, converted);
-
     }
 }

--- a/xml-parser/src/test/java/org/uniprot/core/xml/proteome/ProteomeConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/proteome/ProteomeConverterTest.java
@@ -20,7 +20,6 @@ import org.uniprot.core.uniprotkb.taxonomy.Taxonomy;
 import org.uniprot.core.uniprotkb.taxonomy.impl.TaxonomyBuilder;
 import org.uniprot.core.xml.jaxb.proteome.Proteome;
 
-
 class ProteomeConverterTest {
 
     @Test
@@ -147,14 +146,22 @@ class ProteomeConverterTest {
         ProteomeId proteomeId1 = new ProteomeIdBuilder(id1).build();
         float similarity1 = 0.5f;
         Taxonomy taxon1 = new TaxonomyBuilder().taxonId(9600).build();
-        RelatedProteome relatedProteome1 = new RelatedProteomeBuilder().proteomeId(proteomeId1)
-                .similarity(similarity1).taxonomy(taxon1).build();
+        RelatedProteome relatedProteome1 =
+                new RelatedProteomeBuilder()
+                        .proteomeId(proteomeId1)
+                        .similarity(similarity1)
+                        .taxonomy(taxon1)
+                        .build();
         Taxonomy taxon2 = new TaxonomyBuilder().taxonId(9601).build();
         float similarity2 = 0.6f;
         String id2 = "UP1234567880";
         ProteomeId proteomeId2 = new ProteomeIdBuilder(id2).build();
-        RelatedProteome relatedProteome2 = new RelatedProteomeBuilder().proteomeId(proteomeId2)
-                .similarity(similarity2).taxonomy(taxon2).build();
+        RelatedProteome relatedProteome2 =
+                new RelatedProteomeBuilder()
+                        .proteomeId(proteomeId2)
+                        .similarity(similarity2)
+                        .taxonomy(taxon2)
+                        .build();
         List<RelatedProteome> relatedProteomes = new ArrayList<>();
         relatedProteomes.add(relatedProteome1);
         relatedProteomes.add(relatedProteome2);

--- a/xml-parser/src/test/java/org/uniprot/core/xml/proteome/ProteomeXMLTestHelper.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/proteome/ProteomeXMLTestHelper.java
@@ -1,10 +1,11 @@
 package org.uniprot.core.xml.proteome;
 
+import java.io.StringWriter;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.namespace.QName;
-import java.io.StringWriter;
 
 public class ProteomeXMLTestHelper {
 

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/SequenceFeatureConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/SequenceFeatureConverterTest.java
@@ -40,7 +40,11 @@ class SequenceFeatureConverterTest {
         SequenceFeatureBuilder builder = new SequenceFeatureBuilder();
         builder.signatureDbType(SignatureDbType.PANTHER)
                 .signatureDbId("PTHR11977")
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(49, 790).alignment("55M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(49, 790)
+                                .alignment("55M")
+                                .build())
                 .interproGroup(
                         new InterProGroupBuilder().id("IPR007122").name("Villin/Gelsolin").build());
         verify(builder.build());
@@ -70,9 +74,17 @@ class SequenceFeatureConverterTest {
         builder.signatureDbType(SignatureDbType.PFAM)
                 .signatureDbId("PF00626")
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(81, 163).build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(202, 267).alignment("21M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(202, 267)
+                                .alignment("21M")
+                                .build())
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(330, 398).build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(586, 653).alignment("55M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(586, 653)
+                                .alignment("55M")
+                                .build())
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(692, 766).build())
                 .interproGroup(
                         new InterProGroupBuilder()

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcDBCrossReferenceConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcDBCrossReferenceConverterTest.java
@@ -1,8 +1,13 @@
 package org.uniprot.core.xml.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.uniprot.core.xml.CrossReferenceConverterUtils.PROPERTY_UNIPROTKB_ACCESSION;
+
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.uniparc.Proteome;
-
 import org.uniprot.core.uniparc.UniParcCrossReference;
 import org.uniprot.core.uniparc.UniParcDatabase;
 import org.uniprot.core.uniparc.impl.ProteomeBuilder;
@@ -12,12 +17,6 @@ import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.xml.XmlReaderException;
 import org.uniprot.core.xml.jaxb.uniparc.DbReferenceType;
 import org.uniprot.core.xml.jaxb.uniparc.PropertyType;
-
-import java.time.LocalDate;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.uniprot.core.xml.CrossReferenceConverterUtils.PROPERTY_UNIPROTKB_ACCESSION;
 
 /**
  * @author jluo
@@ -74,7 +73,8 @@ class UniParcDBCrossReferenceConverterTest {
         //		</dbReference>
 
         Organism taxonomy = new OrganismBuilder().taxonId(7227).build();
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("proteomeValue").component("ComponentValue").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("proteomeValue").component("ComponentValue").build();
 
         UniParcCrossReferenceBuilder builder = new UniParcCrossReferenceBuilder();
         builder.database(UniParcDatabase.TREMBL)

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcEntryConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcEntryConverterTest.java
@@ -1,5 +1,11 @@
 package org.uniprot.core.xml.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
@@ -8,12 +14,6 @@ import org.uniprot.core.uniparc.impl.*;
 import org.uniprot.core.uniprotkb.taxonomy.Organism;
 import org.uniprot.core.uniprotkb.taxonomy.impl.OrganismBuilder;
 import org.uniprot.core.xml.jaxb.uniparc.Entry;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author jluo
@@ -56,9 +56,17 @@ class UniParcEntryConverterTest {
                 .signatureDbType(SignatureDbType.PFAM)
                 .signatureDbId("PF00626")
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(81, 163).build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(202, 267).alignment("22M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(202, 267)
+                                .alignment("22M")
+                                .build())
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(330, 398).build())
-                .locationsAdd(new SequenceFeatureLocationBuilder().range(586, 653).alignment("57M").build())
+                .locationsAdd(
+                        new SequenceFeatureLocationBuilder()
+                                .range(586, 653)
+                                .alignment("57M")
+                                .build())
                 .locationsAdd(new SequenceFeatureLocationBuilder().range(692, 766).build());
         sfs.add(sfBuilder.build());
         sfs.add(sfBuilder2.build());
@@ -92,7 +100,8 @@ class UniParcEntryConverterTest {
         builder.uniParcCrossReferencesAdd(xrefBuilder.build());
 
         Organism taxonomy2 = new OrganismBuilder().taxonId(7227).build();
-        Proteome proteomeIdComponent = new ProteomeBuilder().id("UP00000564").component( "chromosome 1").build();
+        Proteome proteomeIdComponent =
+                new ProteomeBuilder().id("UP00000564").component("chromosome 1").build();
 
         // id="NC_004354_874_0" version_i="5" active="Y" created="2007-04-27" last="2007-04-27">
         UniParcCrossReferenceBuilder xrefBuilder2 = new UniParcCrossReferenceBuilder();

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcEntryLightConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniparc/UniParcEntryLightConverterTest.java
@@ -1,5 +1,10 @@
 package org.uniprot.core.xml.uniparc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.Sequence;
 import org.uniprot.core.impl.SequenceBuilder;
@@ -12,11 +17,6 @@ import org.uniprot.core.uniparc.impl.SequenceFeatureBuilder;
 import org.uniprot.core.uniparc.impl.SequenceFeatureLocationBuilder;
 import org.uniprot.core.uniparc.impl.UniParcEntryLightBuilder;
 import org.uniprot.core.xml.jaxb.uniparc.Entry;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class UniParcEntryLightConverterTest {
 
@@ -65,13 +65,12 @@ class UniParcEntryLightConverterTest {
                                 .build());
         sfs.add(sfBuilder.build());
         sfs.add(sfBuilder2.build());
-        builder.uniParcId("UPI0000083A08")
-                .sequence(sequence)
-                .sequenceFeaturesSet(sfs);
+        builder.uniParcId("UPI0000083A08").sequence(sequence).sequenceFeaturesSet(sfs);
         return builder.build();
     }
 
-    private SequenceFeatureLocation createSequenceFeatureLocationObject(int start, int end, String alignment){
+    private SequenceFeatureLocation createSequenceFeatureLocationObject(
+            int start, int end, String alignment) {
         SequenceFeatureLocationBuilder builder = new SequenceFeatureLocationBuilder();
         builder.range(start, end);
         builder.alignment(alignment);

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/EvidenceConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/EvidenceConverterTest.java
@@ -1,5 +1,11 @@
 package org.uniprot.core.xml.uniprot;
 
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.uniprot.cv.evidence.EvidenceHelper.parseEvidenceLine;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.CrossReference;
 import org.uniprot.core.Property;
@@ -9,12 +15,6 @@ import org.uniprot.core.uniprotkb.evidence.EvidenceCode;
 import org.uniprot.core.uniprotkb.evidence.EvidenceDatabase;
 import org.uniprot.core.uniprotkb.evidence.impl.EvidenceBuilder;
 import org.uniprot.core.xml.jaxb.uniprot.EvidenceType;
-
-import java.util.List;
-
-import static java.util.Arrays.asList;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.uniprot.cv.evidence.EvidenceHelper.parseEvidenceLine;
 
 class EvidenceConverterTest {
     private final EvidenceConverter converter = new EvidenceConverter();
@@ -313,28 +313,33 @@ class EvidenceConverterTest {
     }
 
     @Test
-    void testEvidenceToAndFromXMLWithProperties(){
-            List<Property> properties =
-                    asList(new Property("key1", "value1"), new Property("key2", "value2"));
-            CrossReference<EvidenceDatabase> xref =
-                    new CrossReferenceBuilder<EvidenceDatabase>()
-                            .database(new EvidenceDatabase("EMBL"))
-                            .id("DB123414")
-                            .propertiesSet(properties)
-                            .build();
-            Evidence evidence = new EvidenceBuilder().evidenceCode(EvidenceCode.ECO_0000245).crossReference(xref).build();
+    void testEvidenceToAndFromXMLWithProperties() {
+        List<Property> properties =
+                asList(new Property("key1", "value1"), new Property("key2", "value2"));
+        CrossReference<EvidenceDatabase> xref =
+                new CrossReferenceBuilder<EvidenceDatabase>()
+                        .database(new EvidenceDatabase("EMBL"))
+                        .id("DB123414")
+                        .propertiesSet(properties)
+                        .build();
+        Evidence evidence =
+                new EvidenceBuilder()
+                        .evidenceCode(EvidenceCode.ECO_0000245)
+                        .crossReference(xref)
+                        .build();
         EvidenceType xmlObj = converter.toXml(evidence);
         assertNotNull(xmlObj);
         Evidence converted = converter.fromXml(xmlObj);
         assertEquals(evidence, converted);
-        assertEquals("<evidence type=\"ECO:0000245\" key=\"1\" xmlns=\"http://uniprot.org/uniprot\">\n" +
-                        "    <source>\n" +
-                        "        <dbReference type=\"EMBL\" id=\"DB123414\">\n" +
-                        "            <property type=\"key1\" value=\"value1\"/>\n" +
-                        "            <property type=\"key2\" value=\"value2\"/>\n" +
-                        "        </dbReference>\n" +
-                        "    </source>\n" +
-                        "</evidence>",
+        assertEquals(
+                "<evidence type=\"ECO:0000245\" key=\"1\" xmlns=\"http://uniprot.org/uniprot\">\n"
+                        + "    <source>\n"
+                        + "        <dbReference type=\"EMBL\" id=\"DB123414\">\n"
+                        + "            <property type=\"key1\" value=\"value1\"/>\n"
+                        + "            <property type=\"key2\" value=\"value2\"/>\n"
+                        + "        </dbReference>\n"
+                        + "    </source>\n"
+                        + "</evidence>",
                 UniProtXmlTestHelper.toXmlString(xmlObj, EvidenceType.class, "evidence"));
     }
 

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/GoogleUniProtEntryConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/GoogleUniProtEntryConverterTest.java
@@ -1,5 +1,14 @@
 package org.uniprot.core.xml.uniprot;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.InputStream;
+import java.util.List;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
 import org.junit.jupiter.api.Test;
 import org.uniprot.core.CrossReference;
 import org.uniprot.core.citation.Citation;
@@ -17,14 +26,6 @@ import org.uniprot.core.uniprotkb.evidence.EvidenceDatabase;
 import org.uniprot.core.uniprotkb.evidence.EvidencedValue;
 import org.uniprot.core.uniprotkb.xdb.UniProtKBCrossReference;
 import org.uniprot.core.xml.jaxb.uniprot.Uniprot;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import java.io.InputStream;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class GoogleUniProtEntryConverterTest {
     @Test
@@ -47,7 +48,9 @@ class GoogleUniProtEntryConverterTest {
         assertNotNull(uniProtEntry);
         assertEquals("A0A6A5BR32", uniProtEntry.getPrimaryAccession().getValue());
         assertEquals("PLACEHOLDER", uniProtEntry.getUniProtkbId().getValue());
-        assertEquals("Uncharacterized protein", uniProtEntry.getProteinDescription().getRecommendedName().getFullName().getValue());
+        assertEquals(
+                "Uncharacterized protein",
+                uniProtEntry.getProteinDescription().getRecommendedName().getFullName().getValue());
         // reference
         assertEquals(1, uniProtEntry.getReferences().size());
         UniProtKBReference reference = uniProtEntry.getReferences().get(0);
@@ -142,7 +145,8 @@ class GoogleUniProtEntryConverterTest {
         assertNotNull(nameEvidence);
         assertEquals(1, nameEvidence.size());
         assertEquals(EvidenceCode.ECO_0008006, nameEvidence.get(0).getEvidenceCode());
-        CrossReference<EvidenceDatabase> nameEvidenceXref = nameEvidence.get(0).getEvidenceCrossReference();
+        CrossReference<EvidenceDatabase> nameEvidenceXref =
+                nameEvidence.get(0).getEvidenceCrossReference();
         assertNotNull(nameEvidenceXref);
         assertEquals("Google", nameEvidenceXref.getDatabase().getName());
         assertEquals("ProtNLM2", nameEvidenceXref.getId());
@@ -174,43 +178,52 @@ class GoogleUniProtEntryConverterTest {
         assertEquals(1, similarityComment.getTexts().size());
         EvidencedValue similarityCommentText = similarityComment.getTexts().get(0);
         assertNotNull(similarityCommentText);
-        assertEquals("Belongs to the ZIP transporter (TC 2.A.5) family", similarityCommentText.getValue());
+        assertEquals(
+                "Belongs to the ZIP transporter (TC 2.A.5) family",
+                similarityCommentText.getValue());
         assertEquals(1, similarityCommentText.getEvidences().size());
         Evidence similarityCommentTextEvidence = similarityCommentText.getEvidences().get(0);
         assertNotNull(similarityCommentTextEvidence);
         assertEquals(EvidenceCode.ECO_0008006, similarityCommentTextEvidence.getEvidenceCode());
-        CrossReference<EvidenceDatabase> similarityCommentTextEvidenceXref = similarityCommentTextEvidence.getEvidenceCrossReference();
+        CrossReference<EvidenceDatabase> similarityCommentTextEvidenceXref =
+                similarityCommentTextEvidence.getEvidenceCrossReference();
         assertNotNull(similarityCommentTextEvidenceXref);
         assertEquals("Google", similarityCommentTextEvidenceXref.getDatabase().getName());
         assertEquals("ProtNLM2", similarityCommentTextEvidenceXref.getId());
         assertEquals(3, similarityCommentTextEvidenceXref.getProperties().size());
         // comment function
-        FreeTextComment functionComment = (FreeTextComment) comments.get(1); // assuming this is the second comment
+        FreeTextComment functionComment =
+                (FreeTextComment) comments.get(1); // assuming this is the second comment
         assertNotNull(functionComment);
         assertEquals(CommentType.FUNCTION, functionComment.getCommentType());
         assertEquals(1, functionComment.getTexts().size());
 
         EvidencedValue functionCommentText = functionComment.getTexts().get(0);
         assertNotNull(functionCommentText);
-        assertEquals("Shows cytolytic activity on many different cells by forming pore in lipid membranes. In vivo, increases heart rate or kills the animal by cardiac arrest. In addition, it binds to heparin with high affinity, interacts with Kv channel-interacting protein 1 (KCNIP1) in a calcium-independent manner, and binds to integrin alpha-V/beta-3 (ITGAV/ITGB3) with moderate affinity", functionCommentText.getValue());
+        assertEquals(
+                "Shows cytolytic activity on many different cells by forming pore in lipid membranes. In vivo, increases heart rate or kills the animal by cardiac arrest. In addition, it binds to heparin with high affinity, interacts with Kv channel-interacting protein 1 (KCNIP1) in a calcium-independent manner, and binds to integrin alpha-V/beta-3 (ITGAV/ITGB3) with moderate affinity",
+                functionCommentText.getValue());
 
         assertEquals(1, functionCommentText.getEvidences().size());
         Evidence functionCommentTextEvidence = functionCommentText.getEvidences().get(0);
         assertNotNull(functionCommentTextEvidence);
         assertEquals(EvidenceCode.ECO_0008006, functionCommentTextEvidence.getEvidenceCode());
 
-        CrossReference<EvidenceDatabase> functionCommentTextEvidenceXref = functionCommentTextEvidence.getEvidenceCrossReference();
+        CrossReference<EvidenceDatabase> functionCommentTextEvidenceXref =
+                functionCommentTextEvidence.getEvidenceCrossReference();
         assertNotNull(functionCommentTextEvidenceXref);
         assertEquals("Google", functionCommentTextEvidenceXref.getDatabase().getName());
         assertEquals("ProtNLM2", functionCommentTextEvidenceXref.getId());
         assertEquals(3, functionCommentTextEvidenceXref.getProperties().size());
         // comment subcellular location
-        SubcellularLocationComment subcellularComment = (SubcellularLocationComment) comments.get(2);
+        SubcellularLocationComment subcellularComment =
+                (SubcellularLocationComment) comments.get(2);
         assertNotNull(subcellularComment);
         assertEquals(CommentType.SUBCELLULAR_LOCATION, subcellularComment.getCommentType());
         assertEquals(1, subcellularComment.getSubcellularLocations().size());
 
-        SubcellularLocation subcellularLocation = subcellularComment.getSubcellularLocations().get(0);
+        SubcellularLocation subcellularLocation =
+                subcellularComment.getSubcellularLocations().get(0);
         assertNotNull(subcellularLocation);
 
         EvidencedValue location = subcellularLocation.getLocation();
@@ -222,11 +235,11 @@ class GoogleUniProtEntryConverterTest {
         assertNotNull(locationEvidence);
         assertEquals(EvidenceCode.ECO_0008006, locationEvidence.getEvidenceCode());
 
-        CrossReference<EvidenceDatabase> locationEvidenceXref = locationEvidence.getEvidenceCrossReference();
+        CrossReference<EvidenceDatabase> locationEvidenceXref =
+                locationEvidence.getEvidenceCrossReference();
         assertNotNull(locationEvidenceXref);
         assertEquals("Google", locationEvidenceXref.getDatabase().getName());
         assertEquals("ProtNLM2", locationEvidenceXref.getId());
         assertEquals(3, locationEvidenceXref.getProperties().size());
-
     }
 }

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/UniProtKBCrossReferenceConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/UniProtKBCrossReferenceConverterTest.java
@@ -22,7 +22,9 @@ import org.uniprot.cv.xdb.UniProtKBDatabaseImpl;
 import com.google.common.base.Strings;
 
 public class UniProtKBCrossReferenceConverterTest extends AbstractConverterTest {
-    private final UniProtCrossReferenceConverter converter = new UniProtCrossReferenceConverter(new EvidenceIndexMapper(EvidenceHelper.createEvidences()));
+    private final UniProtCrossReferenceConverter converter =
+            new UniProtCrossReferenceConverter(
+                    new EvidenceIndexMapper(EvidenceHelper.createEvidences()));
 
     @Test
     void testEmbl3Attributes() {

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/citation/ReferenceConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/citation/ReferenceConverterTest.java
@@ -37,8 +37,8 @@ class ReferenceConverterTest {
         refComments.add(createReferenceComment(ReferenceCommentType.STRAIN, "S1", evidences));
         refComments.add(createReferenceComment(ReferenceCommentType.TISSUE, "S11", evidences));
         UniProtKBReference uniReference =
-                createUniProtReference(2,
-                        submission, referencePositions, refComments, Collections.emptyList());
+                createUniProtReference(
+                        2, submission, referencePositions, refComments, Collections.emptyList());
         ReferenceConverter converter = new ReferenceConverter(new EvidenceIndexMapper());
         ReferenceType xmlReference = converter.toXml(uniReference);
         System.out.println(

--- a/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverterTest.java
+++ b/xml-parser/src/test/java/org/uniprot/core/xml/uniprot/comment/SubcellularLocationConverterTest.java
@@ -57,34 +57,33 @@ public class SubcellularLocationConverterTest extends AbstractConverterTest {
         SubcellularLocation converted = converter.fromXml(xmlsubcelLocation);
         assertEquals(subcelLocation, converted);
     }
-    
+
     @Test
     void testLocationWithLowercase() {
-    	 SubcellularLocationValue location =
-                 create(
-                         "Golgi apparatus, trans-Golgi network membrane",
-                         List.of(
-                                 "ECO:0000256|PIRNR:PIRNR037393"));
-        
-         SubcellularLocation subcelLocation =
-                 new SubcellularLocationBuilder()
-                         .location(location)
-                         .build();
-         SubcellularLocationConverter converter =
-                 new SubcellularLocationConverter(
-                         new EvidenceIndexMapper(), new SubcellLocationNameMapImpl());
-         SubcellularLocationType xmlsubcelLocation = converter.toXml(subcelLocation);
-         String xml =UniProtXmlTestHelper.toXmlString(
-                 xmlsubcelLocation, SubcellularLocationType.class, "subcellularLocation");
-         String expectedXml ="""
+        SubcellularLocationValue location =
+                create(
+                        "Golgi apparatus, trans-Golgi network membrane",
+                        List.of("ECO:0000256|PIRNR:PIRNR037393"));
+
+        SubcellularLocation subcelLocation =
+                new SubcellularLocationBuilder().location(location).build();
+        SubcellularLocationConverter converter =
+                new SubcellularLocationConverter(
+                        new EvidenceIndexMapper(), new SubcellLocationNameMapImpl());
+        SubcellularLocationType xmlsubcelLocation = converter.toXml(subcelLocation);
+        String xml =
+                UniProtXmlTestHelper.toXmlString(
+                        xmlsubcelLocation, SubcellularLocationType.class, "subcellularLocation");
+        String expectedXml =
+                """
 <subcellularLocation xmlns="http://uniprot.org/uniprot">
     <location evidence="1">Golgi apparatus</location>
     <location evidence="1">trans-Golgi network membrane</location>
 </subcellularLocation>\
          		""";
-        assertEquals(expectedXml, xml ) ;		 
-         SubcellularLocation converted = converter.fromXml(xmlsubcelLocation);
-         assertEquals(subcelLocation, converted);
+        assertEquals(expectedXml, xml);
+        SubcellularLocation converted = converter.fromXml(xmlsubcelLocation);
+        assertEquals(subcelLocation, converted);
     }
 
     private SubcellularLocationValue create(String val, List<String> evidences) {


### PR DESCRIPTION
Without this some logs are directed to no-op logger in tests and it is harder to see if the test is stuck or still running. Example - OnZeroCountSleeperTest

Before

```
[INFO] Running org.uniprot.core.util.concurrency.OnZeroCountSleeperTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

After

```
[INFO] Running org.uniprot.core.util.concurrency.OnZeroCountSleeperTest
[Thread-5] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 4
[Thread-2] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 1
[main] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeper - Waiting 5000 ms for counter (currently 5), to reach 0
[Thread-3] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 2
[Thread-4] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 3
[Thread-6] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 5
[Thread-8] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 4
[main] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeper - Waiting 5000 ms for counter (currently 4), to reach 0
[Thread-7] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 3
[Thread-9] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 2

```

This PR also updated the workflow to use Java 17 instead of 11. The checks fail to run with current setup. Note that once the workflow was fixed, it created an automatic formatting commit with `spotless`. https://github.com/ebi-uniprot/uniprot-core/pull/318/changes/a6aeae219109f41de2716a2ea6353cca7fb1ed76

Please let me know if we are no longer using it.
