### PR TITLE
fix: Add missing slf4j static logger binder for tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,15 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<distributionManagement>
 		<repository>
 			<id>uniprot-artifactory-deploy-release</id>


### PR DESCRIPTION
Without this some logs are directed to no-op logger in tests and it is harder to see if the test is stuck or still running. Example - OnZeroCountSleeperTest

Before

```
[INFO] Running org.uniprot.core.util.concurrency.OnZeroCountSleeperTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

After

```
[INFO] Running org.uniprot.core.util.concurrency.OnZeroCountSleeperTest
[Thread-5] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 4
[Thread-2] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 1
[main] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeper - Waiting 5000 ms for counter (currently 5), to reach 0
[Thread-3] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 2
[Thread-4] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 3
[Thread-6] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - incremented, so that count = 5
[Thread-8] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 4
[main] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeper - Waiting 5000 ms for counter (currently 4), to reach 0
[Thread-7] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 3
[Thread-9] INFO org.uniprot.core.util.concurrency.OnZeroCountSleeperTest - decremented, so that count = 2

```

Note: The workflow fails as it is using Java 11. But if it is fixed, it will commit a big formatting change with `spotless`. Hence not fixing it.
